### PR TITLE
[stable/falco] certs configuration and service for Falco gRPC server

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -3,6 +3,13 @@
 This file documents all notable changes to Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.5
+
+### Minor Changes
+
+* Add headless service for gRPC server
+* Allow gRPC certificates configuration by using `--set-file`
+
 ## v1.1.4
 
 ### Minor Changes

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.1.4
+version: 1.1.5
 appVersion: 0.20.0
 description: Falco
 keywords:

--- a/stable/falco/README.md
+++ b/stable/falco/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `falco.httpOutput.enabled`                      | Enable http output for security notifications                                                                      | `false`                                                                                                                                   |
 | `falco.httpOutput.url`                          | Url to notify using the http output when a notification arrives                                                    | `http://some.url`                                                                                                                         |
 | `falco.grpc.enabled`                            | Enable the Falco gRPC server                                                          | `false`  
-| `falco.grpc.listenPort`                        | Port where Falco gRPC server listen to connections server                        | `5060` 
+| `falco.grpc.listenPort`                        | Port where Falco gRPC server listen to connections                        | `5060` 
 | `falco.grpc.threadiness`                        | Number of threads (and context) the gRPC server will use                              | `8` 
 | `falco.grpc.privateKey`                         | Key file path for the Falco gRPC server                                               | `/etc/falco/certs/server.key` 
 | `falco.grpc.certChain`                          | Cert file path for the Falco gRPC server                                              | `/etc/falco/certs/server.crt` 
@@ -267,3 +267,21 @@ This means that the apiserver cannot recognize the `auditregistration.k8s.io`
 resource, which means that the dynamic auditing feature hasn't been enabled
 properly. You need to enable it or ensure that your using a Kubernetes version
 greater than v1.13.
+
+## Enabling gRPC service
+
+The Falco gRPC server and the Falco gRPC Outputs APIs are not enabled by default.
+
+The gRPC server can only be used with mutual authentication between the clients and the server using TLS certificates. How to generate the certificates is [documented here](https://falco.org/docs/grpc/#generate-valid-ca).
+
+To install Falco with gRPC enabled, you have to:
+
+```
+$ helm install --name my-release \
+  --set falco.grpc.enabled=true \
+  --set falco.grpcOutput.enabled=true \
+  --set-file certs.server.key=/path/to/server.key \
+  --set-file certs.server.crt=/path/to/certs/server.crt \
+  --set-file certs.ca.crt=/path/to/ca.crt \
+   stable/falco
+```

--- a/stable/falco/README.md
+++ b/stable/falco/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `falco.httpOutput.enabled`                      | Enable http output for security notifications                                                                      | `false`                                                                                                                                   |
 | `falco.httpOutput.url`                          | Url to notify using the http output when a notification arrives                                                    | `http://some.url`                                                                                                                         |
 | `falco.grpc.enabled`                            | Enable the Falco gRPC server                                                          | `false`  
-| `falco.grpc.bindAddress`                        | Configure the address to bind and expose the Falco gRPC server                        | `0.0.0.0:5060` 
+| `falco.grpc.listenPort`                        | Port where Falco gRPC server listen to connections server                        | `5060` 
 | `falco.grpc.threadiness`                        | Number of threads (and context) the gRPC server will use                              | `8` 
 | `falco.grpc.privateKey`                         | Key file path for the Falco gRPC server                                               | `/etc/falco/certs/server.key` 
 | `falco.grpc.certChain`                          | Cert file path for the Falco gRPC server                                              | `/etc/falco/certs/server.crt` 

--- a/stable/falco/templates/configmap.yaml
+++ b/stable/falco/templates/configmap.yaml
@@ -185,7 +185,7 @@ data:
 
     grpc:
       enabled: {{ .Values.falco.grpc.enabled }}
-      bind_address: {{ .Values.falco.grpc.bindAddress }}
+      bind_address: "0.0.0.0:{{ .Values.falco.grpc.listenPort }}"
       threadiness: {{ .Values.falco.grpc.threadiness }}
       private_key: {{ .Values.falco.grpc.privateKey }}
       cert_chain: {{ .Values.falco.grpc.certChain }}

--- a/stable/falco/templates/daemonset.yaml
+++ b/stable/falco/templates/daemonset.yaml
@@ -128,6 +128,11 @@ spec:
               name: shared-pipe
               readOnly: false
             {{- end }}
+            {{- if .Values.falco.grpc.enabled }}
+            - mountPath: /etc/falco/certs
+              name: certs-volume
+              readOnly: true
+            {{- end}}
       {{- if .Values.integrations.natsOutput.enabled }}
         - name: {{ .Chart.Name }}-nats
           image: sysdig/falco-nats:latest
@@ -250,6 +255,18 @@ spec:
         {{- if (or .Values.integrations.natsOutput.enabled .Values.integrations.snsOutput.enabled .Values.integrations.pubsubOutput.enabled) }}
         - name: shared-pipe
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.falco.grpc.enabled }}
+        - name: certs-volume
+          secret:
+            secretName: {{ template "falco.fullname" . }}-certs
+            items:
+              - key: server.key
+                path: server.key
+              - key: server.crt
+                path: server.crt
+              - key: ca.crt
+                path: ca.crt
         {{- end }}
   updateStrategy:
 {{ toYaml .Values.daemonset.updateStrategy | indent 4 }}

--- a/stable/falco/templates/secret-certs.yaml
+++ b/stable/falco/templates/secret-certs.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.falco.grpc.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "falco.fullname" . }}-certs
+  labels:
+    app: {{ template "falco.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  server.key: {{ .Values.certs.server.key | b64enc | quote }}
+  server.crt: {{ .Values.certs.server.crt | b64enc | quote }}
+  ca.crt: {{ .Values.certs.ca.crt | b64enc | quote }}
+{{- end }}

--- a/stable/falco/templates/service.yaml
+++ b/stable/falco/templates/service.yaml
@@ -15,3 +15,23 @@ spec:
   - protocol: TCP
     port: {{ .Values.falco.webserver.listenPort }}
 {{- end }}
+{{- if .Values.falco.grpc.enabled }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "falco.fullname" .}}-grpc
+  labels:
+    app: {{ template "falco.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterIP: None
+  selector:
+    app: {{ template "falco.fullname" .}}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.falco.grpc.listenPort }}
+{{- end }}
+

--- a/stable/falco/values.yaml
+++ b/stable/falco/values.yaml
@@ -235,7 +235,7 @@ falco:
   # By modifying the threadiness configuration you can fine-tune the number of threads (and context) it will use.
   grpc:
     enabled: false
-    bindAddress: "0.0.0.0:5060"
+    listenPort: 5060
     threadiness: 8
     privateKey: "/etc/falco/certs/server.key"
     certChain: "/etc/falco/certs/server.crt"


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.
No.
#### What this PR does / why we need it:

This PR aims to make the Falco gRPC server fully usable. In details:
* Add headless service for gRPC server
* Allow gRPC certificates configuration by using `--set-file`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
