### PR TITLE
[stable/sysdig] #21438 Bugfix for Security Config w/ auditLog.enabled=true

### DIFF
--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.7.5
+version: 1.7.6
 appVersion: 9.7.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/configmap.yaml
+++ b/stable/sysdig/templates/configmap.yaml
@@ -11,17 +11,18 @@ data:
   dragent.yaml: |
     new_k8s: true
 {{- if .Values.secure.enabled }}
-    security:
-      enabled: true
     commandlines_capture:
       enabled: true
     memdump:
       enabled: true
 {{- end }}
-{{- if .Values.auditLog.enabled }}
+{{- if or .Values.secure.enabled .Values.auditLog.enabled }}
     security:
+      enabled: true
+{{- if .Values.auditLog.enabled }}
       k8s_audit_server_url: {{ .Values.auditLog.auditServerUrl }}
       k8s_audit_server_port: {{ .Values.auditLog.auditServerPort }}
+{{- end }}
 {{- end }}
 {{- if .Values.sysdig.settings }}
 {{ toYaml .Values.sysdig.settings | indent 4 }}


### PR DESCRIPTION
Signed-off-by: Lee Bontecou <jlbontecou@gmail.com>

#### What this PR does / why we need it:
Corrects the rendered configmap for sysdig. Currently two `security` blocks will be created when using `auditLog.enabled=true`. Evidence suggests two of the same block is functionally invalid. 

#### Which issue this PR fixes
  - fixes #21438

#### Special notes for your reviewer:
```
‹bugfix/sysdig-security-config› » helm template stable/sysdig --set auditLog.enabled=true --show-only templates/configmap.yaml
---
# Source: sysdig/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: RELEASE-NAME-sysdig
  labels:
    app: RELEASE-NAME-sysdig
    chart: "sysdig-1.7.5"
    release: "RELEASE-NAME"
    heritage: "Helm"
data:
  dragent.yaml: |
    new_k8s: true
    commandlines_capture:
      enabled: true
    memdump:
      enabled: true
    security:
      enabled: true
      k8s_audit_server_url: 0.0.0.0
      k8s_audit_server_port: 7765
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
