### PR TITLE
[stable/grafana] Revert "[stable/grafana] move datasource provider to containers (#209…

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.6
+version: 5.0.7
 appVersion: 6.6.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -13,7 +13,7 @@ securityContext:
 {{- if .Values.priorityClassName }}
 priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-{{- if ( or .Values.persistence.enabled .Values.dashboards  .Values.extraInitContainers) }}
+{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled .Values.extraInitContainers) }}
 initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
@@ -58,6 +58,33 @@ initContainers:
         readOnly: {{ .readOnly }}
     {{- end }}
 {{- end }}
+{{- if .Values.sidecar.datasources.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-datasources
+    image: "{{ .Values.sidecar.image }}"
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      - name: METHOD
+        value: LIST
+      - name: LABEL
+        value: "{{ .Values.sidecar.datasources.label }}"
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/datasources"
+      - name: RESOURCE
+        value: "both"
+      {{- if .Values.sidecar.datasources.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ .Values.sidecar.datasources.searchNamespace }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+    resources:
+{{ toYaml .Values.sidecar.resources | indent 6 }}
+    volumeMounts:
+      - name: sc-datasources-volume
+        mountPath: "/etc/grafana/provisioning/datasources"
+{{- end}}
 {{- if .Values.extraInitContainers }}
 {{ toYaml .Values.extraInitContainers | indent 2 }}
 {{- end }}
@@ -94,33 +121,6 @@ containers:
     volumeMounts:
       - name: sc-dashboard-volume
         mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
-{{- end}}
-{{- if .Values.sidecar.datasources.enabled }}
-  - name: {{ template "grafana.name" . }}-sc-datasources
-    image: "{{ .Values.sidecar.image }}"
-    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
-    env:
-      - name: METHOD
-        value: {{ .Values.sidecar.datasources.watchMethod }}
-      - name: LABEL
-        value: "{{ .Values.sidecar.datasources.label }}"
-      - name: FOLDER
-        value: "/etc/grafana/provisioning/datasources"
-      - name: RESOURCE
-        value: "both"
-      {{- if .Values.sidecar.datasources.searchNamespace }}
-      - name: NAMESPACE
-        value: "{{ .Values.sidecar.datasources.searchNamespace }}"
-      {{- end }}
-      {{- if .Values.sidecar.skipTlsVerify }}
-      - name: SKIP_TLS_VERIFY
-        value: "{{ .Values.sidecar.skipTlsVerify }}"
-      {{- end }}
-    resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
-    volumeMounts:
-      - name: sc-datasources-volume
-        mountPath: "/etc/grafana/provisioning/datasources"
 {{- end}}
   - name: {{ .Chart.Name }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -458,8 +458,6 @@ sidecar:
   # skipTlsVerify: true
   dashboards:
     enabled: false
-    ## Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
-    watchMethod: WATCH
     SCProvider: true
     # label that the configmaps with dashboards are marked with
     label: grafana_dashboard
@@ -487,8 +485,6 @@ sidecar:
       allowUiUpdates: false
   datasources:
     enabled: false
-    ## Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
-    watchMethod: WATCH
     # label that the configmaps with datasources are marked with
     label: grafana_datasource
     # If specified, the sidecar will search for datasource config-maps inside this namespace.


### PR DESCRIPTION
…85)"

This reverts commit 18e4853b

fixes #20909

#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
We need it to fix #20909 - datasources are read by Grafana provisioning on startup.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
