### PR TITLE
[incubator/buzzfeed-sso] upgrade deprecated Kubernetes APIs

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.1.2
+version: 0.1.3
 appVersion: 2.0.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/templates/_helpers.tpl
+++ b/incubator/buzzfeed-sso/templates/_helpers.tpl
@@ -30,3 +30,25 @@ Create chart name and version as used by the chart label.
 {{- define "buzzfeed-sso.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+    {{- print "apps/v1" -}}
+{{- else -}}
+    {{- print "apps/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the apiVersion of ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+    {{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -4,7 +4,7 @@
 {{- $authSecret := .Values.auth.customSecret | default ($fullName) -}}
 {{- $name := include "buzzfeed-sso.name" . -}}
 {{- $authDomain := .Values.auth.domain -}}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-auth

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -4,7 +4,7 @@
 {{- $authSecret := .Values.auth.customSecret | default ($fullName) -}}
 {{- $name := include "buzzfeed-sso.name" . -}}
 {{- $authDomain := .Values.auth.domain -}}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullName }}-auth

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- if ne .Values.auth.domain "<your_auth_domain>" -}}
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $authDomain := .Values.auth.domain -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- if ne .Values.auth.domain "<your_auth_domain>" -}}
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $authDomain := .Values.auth.domain -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $proxySecret := .Values.proxy.customSecret | default ($fullName) -}}
 {{- $name := include "buzzfeed-sso.name" . -}}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullName }}-proxy

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $proxySecret := .Values.proxy.customSecret | default ($fullName) -}}
 {{- $name := include "buzzfeed-sso.name" . -}}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}-proxy


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes usage of API versions removed in Kubernetes 1.16: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@darioblanco @komljen 