### PR TITLE
[stable/chartmuseum] Add serviceMonitor to chartmuseum chart

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.8.0
+version: 2.9.0
 appVersion: 0.11.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -166,6 +166,12 @@ their default values. See values.yaml for all available options.
 | `service.loadBalancerSourceRanges`      | Restricts access for LoadBalancer (only for Service type LoadBalancer)      | `[]`                                 |
 | `service.servicename`                   | Custom name for service                                                     | ``                                   |
 | `service.labels`                        | Additional labels for service                                               | `{}`                                 |
+| `serviceMonitor.enabled`                | Enable the ServiceMontor resource to be deployed                            | `false`                              |
+| `serviceMonitor.labels`                 | Labels for the servicemonitor used by the Prometheus Operator               | `{}`                                 |
+| `serviceMonitor.namespace`              | Namespace of the ServiceMonitor resource                                    | `{{ .Release.Namespace }}`           |
+| `serviceMonitor.metricsPath`            | Path to the Chartmuseum metrics path                                        | `/metrics`                           |
+| `serviceMonitor.interval`               | Scrape interval, If not set, the Prometheus default scrape interval is used | `nil`                                |
+| `serviceMonitor.timeout`                | Scrape request timeout. If not set, the Prometheus default timeout is used  | `nil`                                |
 | `deployment.labels`                     | Additional labels for deployment                                            | `{}`                                 |
 | `deployment.matchlabes`                 | Match labels for deployment selector                                        | `{}`                                 |
 | `ingress.enabled`                       | Enable ingress controller resource                                          | `false`                              |

--- a/stable/chartmuseum/templates/servicemonitor.yaml
+++ b/stable/chartmuseum/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) ) }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/stable/chartmuseum/templates/servicemonitor.yaml
+++ b/stable/chartmuseum/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4 }}
+{{- end }}
+  name: {{ template "chartmuseum.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: 8080
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricsPath }}
+    path: {{ .Values.serviceMonitor.metricsPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+  jobLabel: {{ template "chartmuseum.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "chartmuseum.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -140,6 +140,14 @@ service:
   annotations: {}
   labels: {}
 
+serviceMonitor:
+  enabled: false
+  # namespace: prometheus
+  labels: {}
+  metricsPath: "/metrics"
+  # timeout: 60
+  # interval: 60
+
 resources: {}
 #  limits:
 #    cpu: 100m


### PR DESCRIPTION
Signed-off-by: Philippe Dagenais <pgdagenais@gmail.com>

#### What this PR does / why we need it:
This PR add the serviceMonitor resource to be able to scrape metrics when using the prometheus operator.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
