### PR TITLE
Chore: update path to chart_best_practices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thank you for contributing to helm/charts. Before you submit this PR we'd like t
 make sure you are aware of our technical requirements and best practices:
 
 * https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
-* https://github.com/helm/helm/tree/master/docs/chart_best_practices
+* https://github.com/helm/helm-www/tree/master/content/en/docs/topics/chart_best_practices
 
 For a quick overview across what we will look at reviewing your PR, please read
 our review guidelines:


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes GitHub PR template url to point to current best practices directory

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
