### PR TITLE
[stable/neo4j] Remove doubled -- for -a

### DIFF
--- a/stable/neo4j/templates/NOTES.txt
+++ b/stable/neo4j/templates/NOTES.txt
@@ -18,7 +18,7 @@ kubectl run -it --rm cypher-shell \
     --image=neo4j:3.2.3-enterprise \
     --restart=Never \
     --namespace {{ .Release.Namespace }} \
-    --command -- ./bin/cypher-shell -u neo4j -p <password> --a {{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
+    --command -- ./bin/cypher-shell -u neo4j -p <password> -a {{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
 
 This will print out the addresses of the members of the cluster.
 


### PR DESCRIPTION
@mneedham

#### What this PR does / why we need it:

`--a` works because the full flag is `--address` and any substring of that works, but the proper short flag is `-a`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)