### PR TITLE
[stable/jenkins] Add `master.jenkinsHome` and `master.jenkinsRef` options

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.22
+
+Add `master.jenkinsHome` and `master.jenkinsRef` options to use docker images derivates from Jenkins
+
 ## 1.9.21
 
 Add `master.terminationGracePeriodSeconds` option

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.21
+version: 1.9.22
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -78,6 +78,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.podLabels`                | Custom Pod labels                    | Not set                                   |
 | `master.adminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin` |
 | `master.adminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value |
+| `master.jenkinsHome`              | Custom Jenkins home path             | `/var/jenkins_home`                       |
+| `master.jenkinsRef`               | Custom Jenkins reference path        | `/usr/share/jenkins/ref`                  |
 | `master.jenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set            |
 | `master.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 4096Mi}}`|
 | `master.initContainerEnv`         | Environment variables for Init Container                                 | Not set |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -220,81 +220,81 @@ data:
     </jenkins.CLI>
 {{- end }}
   apply_config.sh: |-
-    mkdir -p /usr/share/jenkins/ref/secrets/;
+    mkdir -p {{ .Values.master.jenkinsRef }}/secrets/;
 {{- if .Values.master.enableXmlConfig }}
-    echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
+    echo "false" > {{ .Values.master.jenkinsRef }}/secrets/slave-to-master-security-kill-switch;
 {{- if .Values.master.overwriteConfig }}
-    cp /var/jenkins_config/config.xml /var/jenkins_home;
-    cp /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
-    cp /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml /var/jenkins_home;
+    cp /var/jenkins_config/config.xml {{ .Values.master.jenkinsHome }};
+    cp /var/jenkins_config/jenkins.CLI.xml {{ .Values.master.jenkinsHome }};
+    cp /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml {{ .Values.master.jenkinsHome }};
   {{- if .Values.master.additionalConfig }}
   {{- range $key, $val := .Values.master.additionalConfig }}
-    cp /var/jenkins_config/{{- $key }} /var/jenkins_home;
+    cp /var/jenkins_config/{{- $key }} {{ .Values.master.jenkinsHome }};
   {{- end }}
   {{- end }}
 {{- else }}
-    yes n | cp -i /var/jenkins_config/config.xml /var/jenkins_home;
-    yes n | cp -i /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
-    yes n | cp -i /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml /var/jenkins_home;
+    yes n | cp -i /var/jenkins_config/config.xml {{ .Values.master.jenkinsHome }};
+    yes n | cp -i /var/jenkins_config/jenkins.CLI.xml {{ .Values.master.jenkinsHome }};
+    yes n | cp -i /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml {{ .Values.master.jenkinsHome }};
   {{- if .Values.master.additionalConfig }}
   {{- range $key, $val := .Values.master.additionalConfig }}
-    yes n | cp -i /var/jenkins_config/{{- $key }} /var/jenkins_home;
+    yes n | cp -i /var/jenkins_config/{{- $key }} {{ .Values.master.jenkinsHome }};
   {{- end }}
   {{- end }}
 {{- end }}
 {{- else }}
 {{- if .Values.master.JCasC.enabled }}
     # Prevent Setup Wizard when JCasC is enabled
-    echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.UpgradeWizard.state
-    echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.InstallUtil.lastExecVersion
+    echo $JENKINS_VERSION > {{ .Values.master.jenkinsHome }}/jenkins.install.UpgradeWizard.state
+    echo $JENKINS_VERSION > {{ .Values.master.jenkinsHome }}/jenkins.install.InstallUtil.lastExecVersion
 {{- end }}
 {{- end }}
 {{- if .Values.master.overwritePlugins }}
     # remove all plugins from shared volume
-    rm -rf /var/jenkins_home/plugins/*
+    rm -rf {{ .Values.master.jenkinsHome }}/plugins/*
 {{- end }}
 {{- if .Values.master.installPlugins }}
     # Install missing plugins
-    cp /var/jenkins_config/plugins.txt /var/jenkins_home;
-    rm -rf /usr/share/jenkins/ref/plugins/*.lock
-    /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+    cp /var/jenkins_config/plugins.txt {{ .Values.master.jenkinsHome }};
+    rm -rf {{ .Values.master.jenkinsRef }}/plugins/*.lock
+    /usr/local/bin/install-plugins.sh `echo $(cat {{ .Values.master.jenkinsHome }}/plugins.txt)`;
     # Copy plugins to shared volume
-    yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
+    yes n | cp -i {{ .Values.master.jenkinsRef }}/plugins/* /var/jenkins_plugins/;
 {{- end }}
 {{- if .Values.master.scriptApproval }}
   {{- if .Values.master.overwriteConfig }}
-    cp /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+    cp /var/jenkins_config/scriptapproval.xml {{ .Values.master.jenkinsHome }}/scriptApproval.xml;
   {{- else }}
-    yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+    yes n | cp -i /var/jenkins_config/scriptapproval.xml {{ .Values.master.jenkinsHome }}/scriptApproval.xml;
   {{- end }}
 {{- end }}
 {{- if .Values.master.initScripts }}
-    mkdir -p /var/jenkins_home/init.groovy.d/;
+    mkdir -p {{ .Values.master.jenkinsHome }}/init.groovy.d/;
     {{- if .Values.master.overwriteConfig }}
-    rm -f /var/jenkins_home/init.groovy.d/*.groovy
+    rm -f {{ .Values.master.jenkinsHome }}/init.groovy.d/*.groovy
     {{- end }}
-    yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
+    yes n | cp -i /var/jenkins_config/*.groovy {{ .Values.master.jenkinsHome }}/init.groovy.d/;
 {{- end }}
 {{- if .Values.master.JCasC.enabled}}
   {{- if not .Values.master.sidecars.configAutoReload.enabled }}
-    mkdir -p /var/jenkins_home/casc_configs;
-    rm -rf /var/jenkins_home/casc_configs/*
-    cp -v /var/jenkins_config/*.yaml /var/jenkins_home/casc_configs
+    mkdir -p {{ .Values.master.jenkinsHome }}/casc_configs;
+    rm -rf {{ .Values.master.jenkinsHome }}/casc_configs/*
+    cp -v /var/jenkins_config/*.yaml {{ .Values.master.jenkinsHome }}/casc_configs
   {{- end }}
 {{- end }}
 {{- if .Values.master.enableXmlConfig }}
 {{- if .Values.master.credentialsXmlSecret }}
-    yes n | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+    yes n | cp -i /var/jenkins_credentials/credentials.xml {{ .Values.master.jenkinsHome }};
 {{- end }}
 {{- if .Values.master.jobs }}
     for job in $(ls /var/jenkins_jobs); do
-      mkdir -p /var/jenkins_home/jobs/$job
-      yes {{ if not .Values.master.overwriteJobs }}n{{ end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+      mkdir -p {{ .Values.master.jenkinsHome }}/jobs/$job
+      yes {{ if not .Values.master.overwriteJobs }}n{{ end }} | cp -i /var/jenkins_jobs/$job {{ .Values.master.jenkinsHome }}/jobs/$job/config.xml
     done
 {{- end }}
 {{- end }}
 {{- if .Values.master.secretsFilesSecret }}
-    yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
+    yes n | cp -i /var/jenkins_secrets/* {{ .Values.master.jenkinsRef }}/secrets/;
 {{- end }}
 {{- range $key, $val := .Values.master.initScripts }}
   init{{ $key }}.groovy: |-

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -42,7 +42,7 @@ spec:
             - --container
             - jenkins
             - --path
-            - /var/jenkins_home
+            - {{ .Values.master.jenkinsHome }}
             - --dst
             - {{ .Values.backup.destination }}
             {{- with .Values.backup.extraArgs }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -120,7 +120,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
-            - mountPath: /var/jenkins_home
+            - mountPath: {{ .Values.master.jenkinsHome }}
               name: jenkins-home
               {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
@@ -138,7 +138,7 @@ spec:
               name: jenkins-jobs
               readOnly: true
             {{- end }}
-            - mountPath: /usr/share/jenkins/ref/secrets/
+            - mountPath: {{ .Values.master.jenkinsRef }}/secrets/
               name: secrets-dir
             {{- end }}
             {{- if .Values.master.secretsFilesSecret }}
@@ -147,7 +147,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.master.installPlugins }}
-            - mountPath: /usr/share/jenkins/ref/plugins
+            - mountPath: {{ .Values.master.jenkinsRef }}/plugins
               name: plugins
             - mountPath: /var/jenkins_plugins
               name: plugin-dir
@@ -212,7 +212,7 @@ spec:
             {{- end }}
             {{- if .Values.master.JCasC.enabled }}
             - name: CASC_JENKINS_CONFIG
-              value: {{ .Values.master.sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
+              value: {{ .Values.master.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.master.jenkinsRef)) }}
             {{- end }}
           ports:
             {{- if .Values.master.httpsKeyStore.enable }}
@@ -265,7 +265,7 @@ spec:
             {{- end }}
             - mountPath: /tmp
               name: tmp
-            - mountPath: /var/jenkins_home
+            - mountPath: {{ .Values.master.jenkinsHome }}
               name: jenkins-home
               readOnly: false
               {{- if .Values.persistence.subPath }}
@@ -285,7 +285,7 @@ spec:
               name: jenkins-jobs
               readOnly: true
             {{- end }}
-            - mountPath: /usr/share/jenkins/ref/secrets/
+            - mountPath: {{ .Values.master.jenkinsRef }}/secrets/
               name: secrets-dir
               readOnly: false
             {{- end }}
@@ -295,13 +295,13 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.master.installPlugins }}
-            - mountPath: /usr/share/jenkins/ref/plugins/
+            - mountPath: {{ .Values.master.jenkinsRef }}/plugins/
               name: plugin-dir
               readOnly: false
             {{- end }}
             {{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
             - name: sc-config-volume
-              mountPath: {{ .Values.master.sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
+              mountPath: {{ .Values.master.sidecars.configAutoReload.folder | default (printf "%s/casc_configs" (.Values.master.jenkinsRef)) }}
             {{- end }}
 
 {{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
@@ -329,7 +329,7 @@ spec:
             - name: sc-config-volume
               mountPath: {{ .Values.master.sidecars.configAutoReload.folder | quote }}
             - name: jenkins-home
-              mountPath: /var/jenkins_home
+              mountPath: {{ .Values.master.jenkinsHome }}
               {{- if .Values.persistence.subPath }}
                 subPath: {{ .Values.persistence.subPath }}
               {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -103,6 +103,12 @@ master:
   adminUser: "admin"
   # adminPassword: <defaults to random>
   # adminSshKey: <defaults to auto-generated>
+  # This values should not be changed unless you use your custom image of jenkins or any devired from. If you want to use
+  # Cloudbees Jenkins Distribution docker, you should set jenkinsHome: "/var/cloudbees-jenkins-distribution"
+  jenkinsHome: "/var/jenkins_home"
+  # This values should not be changed unless you use your custom image of jenkins or any devired from. If you want to use
+  # Cloudbees Jenkins Distribution docker, you should set jenkinsRef: "/usr/share/cloudbees-jenkins-distribution/ref"
+  jenkinsRef: "/usr/share/jenkins/ref"
   # If CasC auto-reload is enabled, an SSH (RSA) keypair is needed.  Can either provide your own, or leave unconfigured to allow a random key to be auto-generated.
   # If you supply your own, it is recommended that the values file that contains your key not be committed to source control in an unencrypted format
   rollingUpdate: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR enables those want to use their custom docker images from Jenkins or even to use Cloudbees Jenkins Distribution docker image. Now you can set the jenkins home path and the jenkins reference path where plugins and secrets are installed

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

/assign @torstenwalter

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
