### PR TITLE
[incubator/aws-alb-ingress-controller] reuse existing service account

### DIFF
--- a/incubator/aws-alb-ingress-controller/Chart.yaml
+++ b/incubator/aws-alb-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-alb-ingress-controller
 description: A Helm chart for AWS ALB Ingress Controller
-version: 0.1.14
+version: 0.2.0
 appVersion: "v1.1.5"
 engine: gotpl
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller

--- a/incubator/aws-alb-ingress-controller/Chart.yaml
+++ b/incubator/aws-alb-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-alb-ingress-controller
 description: A Helm chart for AWS ALB Ingress Controller
-version: 0.1.13
+version: 0.1.14
 appVersion: "v1.1.5"
 engine: gotpl
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller

--- a/incubator/aws-alb-ingress-controller/README.md
+++ b/incubator/aws-alb-ingress-controller/README.md
@@ -60,6 +60,8 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `enableLivenessProbe`     | enable livenessProbe on controller pod                                                                         | `false`                                                                   |
 | `livenessProbeTimeout`     | How long to wait before timeout (in seconds) when checking controller liveness                                |    1                                                                      |
 | `extraEnv`                | map of environment variables to be injected into the controller pod                                            | `{}`                                                                      |
+| `extraArgs`               | map of extra arguments to be setting for controller pod                                                        | `{}`                                                                      |
+| `debugLevel`              | set the debug log level for controller pod                                                                     | `""`                                                                      |
 | `volumesMounts`           | volumeMounts into the controller pod                                                                           | `[]`                                                                      |
 | `volumes`                 | volumes the controller pod                                                                                     | `[]`                                                                      |
 | `nodeSelector`            | node labels for controller pod assignment                                                                      | `{}`                                                                      |
@@ -69,8 +71,10 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `priorityClassName`       | set to ensure your pods survive resource shortages                                                             | `""`                                                                      |
 | `resources`               | controller pod resource requests & limits                                                                      | `{}`                                                                      |
 | `rbac.create`             | If true, create & use RBAC resources                                                                           | `true`                                                                    |
-| `rbac.serviceAccountName` | ServiceAccount ALB ingress controller will use (ignored if rbac.create=true)                                   | `default`                                                                 |
-| `rbac.serviceAccountAnnotations` | Service Account annotations                                                                             | `{}`                                                           |
+|`rbac.serviceAccount.create` | If true and rbac.create is also true, a service account will be created                                      | `true`
+|`rbac.serviceAccount.name`   | existing ServiceAccount to use (ignored if rbac.create=true and rbac.serviceAccount.create=true)             | `default`
+
+| `rbac.serviceAccountAnnotations` | Service Account annotations                                                                             | `{}`                                                                      |
 | `scope.ingressClass`      | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class           | `alb`                                                                     |
 | `scope.singleNamespace`   | If true, the ALB ingress controller will only act on Ingress resources in a single namespace                   | `false` (watch all namespaces)                                            |
 | `scope.watchNamespace`    | If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller)                            |

--- a/incubator/aws-alb-ingress-controller/README.md
+++ b/incubator/aws-alb-ingress-controller/README.md
@@ -73,7 +73,6 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `rbac.create`             | If true, create & use RBAC resources                                                                           | `true`                                                                    |
 |`rbac.serviceAccount.create` | If true and rbac.create is also true, a service account will be created                                      | `true`
 |`rbac.serviceAccount.name`   | existing ServiceAccount to use (ignored if rbac.create=true and rbac.serviceAccount.create=true)             | `default`
-
 | `rbac.serviceAccountAnnotations` | Service Account annotations                                                                             | `{}`                                                                      |
 | `scope.ingressClass`      | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class           | `alb`                                                                     |
 | `scope.singleNamespace`   | If true, the ALB ingress controller will only act on Ingress resources in a single namespace                   | `false` (watch all namespaces)                                            |

--- a/incubator/aws-alb-ingress-controller/templates/_helpers.tpl
+++ b/incubator/aws-alb-ingress-controller/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "aws-alb-ingress-controller.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the service account name used by the pod.
+*/}}
+{{- define "serviceaccount.name" -}}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
+{{ include "aws-alb-ingress-controller.fullname" . }}
+{{- else -}}
+{{ .Values.rbac.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/aws-alb-ingress-controller/templates/clusterrolebinding.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/clusterrolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: {{ include "aws-alb-ingress-controller.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "aws-alb-ingress-controller.fullname" . }}
+    name: {{ template "serviceaccount.name" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/incubator/aws-alb-ingress-controller/templates/deployment.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
+          {{- with .Values.debugLevel }}
+            - -v={{ . }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
@@ -101,5 +104,8 @@ spec:
       volumes:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ include "aws-alb-ingress-controller.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      {{- with .Values.securityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "serviceaccount.name" . }}
       terminationGracePeriodSeconds: 60

--- a/incubator/aws-alb-ingress-controller/templates/serviceaccount.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/incubator/aws-alb-ingress-controller/values.yaml
+++ b/incubator/aws-alb-ingress-controller/values.yaml
@@ -40,6 +40,8 @@ extraEnv: {}
   # AWS_ACCESS_KEY_ID: ""
   # AWS_SECRET_ACCESS_KEY: ""
 
+debugLevel: ""
+
 podAnnotations: {}
   # iam.amazonaws.com/role: alb-ingress-controller
 
@@ -70,7 +72,10 @@ rbac:
   ## If true, create & use RBAC resources
   ##
   create: true
-  serviceAccountName: default
+  serviceAccount:
+    create: true
+    name: default
+
   ## Annotations for the Service Account
   serviceAccountAnnotations: {}
 
@@ -104,6 +109,7 @@ tolerations: []
   #    effect: NoSchedule
 
 affinity: {}
+
 
 volumeMounts: []
   # - name: aws-iam-credentials


### PR DESCRIPTION
Signed-off-by: cw-sakamoto <sakamoto@chatwork.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:
- This PR was supported to make it easier to handle eks IRSA
  - FYI: https://github.com/helm/charts/pull/21204
- Add support `SecurityContext` for this [settings](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration)
- Add option for debug log
   - FYI: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/issues/679


#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
