### PR TITLE
[incubator/cassandra] Fixes for serviceMonitor template

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.14.3
+version: 0.14.4
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -158,8 +158,8 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |
 | `backup.google.serviceAccountSecret` | Secret containing credentials if GCS is used as destination |                                                |
 | `exporter.enabled`                   | Enable Cassandra exporter                       | `false`                                                    |
-| `exporter.servicemonitor`            | Enable ServiceMonitor for exporter              | `true`                                                     |
-| `exporter.additionalLabels`          | Additional labels for Service Monitor           | `{}`                                                       |
+| `exporter.servicemonitor.enabled`    | Enable ServiceMonitor for exporter              | `true`                                                    |
+| `exporter.servicemonitor.additionalLabels`| Additional labels for Service Monitor           | `{}`                                                       |
 | `exporter.image.repo`                | Exporter image repository                       | `criteord/cassandra_exporter`                              |
 | `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |
 | `exporter.port`                      | Exporter port                                   | `5556`                                                     |

--- a/incubator/cassandra/templates/servicemonitor.yaml
+++ b/incubator/cassandra/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.exporter.enabled .Values.exporter.servicemonitor }}
+{{- if and .Values.exporter.enabled .Values.exporter.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -9,8 +9,8 @@ metadata:
     chart: {{ template "cassandra.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- if .Values.exporter.servicemonitor.additionalLabels }}
+{{ toYaml .Values.exporter.servicemonitor.additionalLabels | indent 4 }}
     {{- end }}
 spec:
   jobLabel: {{ template "cassandra.name" . }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -213,10 +213,11 @@ backup:
 ## ref: https://github.com/criteo/cassandra_exporter
 exporter:
   # If exporter is enabled this will create a ServiceMonitor by default as well
-  servicemonitor: true
-  enabled: false
-  additionalLabels: {}
-    # prometheus: default
+  enabled: true
+  servicemonitor:
+    enabled: true
+    additionalLabels: {}
+      # prometheus: default
   image:
     repo: criteord/cassandra_exporter
     tag: 2.0.2


### PR DESCRIPTION
Signed-off-by: Maria.Kotlyarevskaya <maria.kotlyarevskaya@nordigy.ru>

#### What this PR does / why we need it:
Fixes wrong declaration of additionalLabels (it used to metrics instead of exporter parent.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
