### PR TITLE
[stable/dex] Add securityContext to deployment

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.8.1
+version: 2.9.0
 appVersion: 2.21.0
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 keywords:

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -95,6 +95,7 @@ Parameters introduced starting from v2
 | `ports.web.nodePort` | K8S Service node port for the dex http/https listener | `32000` |
 | `ports.web.servicePort` | K8S Service port for the dex http/https listener | `32000` |
 | `rbac.create` | If `true`, create & use RBAC resources | `true` |
+| `securityContext` | Allow setting the securityContext of the main dex deployment | `` |
 | `service.loadBalancerIP` | IP override for K8S LoadBalancer Service | `""` |
 | `livenessProbe.enabled` | k8s liveness probe enabled (cannot be enabled when `https = true`) | `false` |
 | `livenessProbe.path` |  k8s liveness probe http path | `"/healthz"`  |

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: main
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -25,6 +25,18 @@ tolerations: []
   #   value: bar
   #   effect: NoSchedule
 
+securityContext:
+  # Rejecting containers trying to run with root privileges
+  # runAsNonRoot: true
+  # Preventing privilege escalation to root privileges
+  # allowPrivilegeEscalation: false
+  # Set the user ID used to run the container
+  # runAsUser: 1001
+  # Set the primary group ID used to run all processes within any container of the pod
+  # runAsGroup: 1001
+  # Set the group ID associated with the container
+  # fsGroup: 1001
+
 replicas: 1
 
 # resources:


### PR DESCRIPTION
[stable/dex] Add securityContext to deployment
Signed-off-by: Frederik Mogensen <sodiaf@gmail.com>

#### What this PR does / why we need it:

This PR adds the option to add securityContext to the dex deployment.

This allows the user to remove specific capabilities, set the user running the container and prevent privilege escalation.

#### Special notes for your reviewer:

I have bumped the minor version of the chart, as I see this as a new feature.

I have not changed any of the behaviour of the chart. So everything is backwards compatible.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
