### PR TITLE
[stable/home-assistant] Bumping home-assistant image to 0.106.6

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.106.6
 description: Home Assistant
 name: home-assistant
-version: 0.12.2
+version: 0.12.3
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -36,7 +36,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `homeassistant/home-assistant` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.103.3`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.106.6`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
 | `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.103.3
+  tag: 0.106.6
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This bumps the home-assistant container image to the current latest version (0.106.6)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
