### PR TITLE
[stable/unifi] - Bumping the container version to 5.12.35

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 5.11.50
+appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.6.4
+version: 0.6.5
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -37,7 +37,7 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | Parameter                                       | Default                      | Description                                                                                                            |
 |-------------------------------------------------|------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `image.repository`                              | `jacobalberty/unifi`         | Image repository                                                                                                       |
-| `image.tag`                                     | `5.11.50`                    | Image tag. Possible values listed [here][docker].                                                                      |
+| `image.tag`                                     | `5.12.35`                    | Image tag. Possible values listed [here][docker].                                                                      |
 | `image.pullPolicy`                              | `IfNotPresent`               | Image pull policy                                                                                                      |
 | `strategyType`                                  | `Recreate`                   | Specifies the strategy used to replace old Pods by new ones                                                            |
 | `guiService.type`                               | `ClusterIP`                  | Kubernetes service type for the Unifi GUI                                                                              |

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -7,7 +7,7 @@ strategyType: Recreate
 
 image:
   repository: jacobalberty/unifi
-  tag: 5.11.50
+  tag: 5.12.35
   pullPolicy: IfNotPresent
 
 # If enabled, the controller, discovery, GUI, and STUN services will not be


### PR DESCRIPTION
#### What this PR does / why we need it:

This bumps the chart's container image to 5.12.35 which is the current latest stable

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
