### PR TITLE
[stable/node-red] - Bump the node-red container version to 1.0.4

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.0.2
+appVersion: 1.0.4
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 1.4.1
+version: 1.4.2
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -38,7 +38,7 @@ The following tables lists the configurable parameters of the Node-RED chart and
 | Parameter                          | Description                                                             | Default                   |
 |:---------------------------------- |:----------------------------------------------------------------------- |:------------------------- |
 | `image.repository`                 | node-red image                                                          | `nodered/node-red`        |
-| `image.tag`                        | node-red image tag                                                      | `1.0.2-12-minimal`        |
+| `image.tag`                        | node-red image tag                                                      | `1.0.4-12-minimal`        |
 | `image.pullPolicy`                 | node-red image pull policy                                              | `IfNotPresent`            |
 | `strategyType`                     | Specifies the strategy used to replace old Pods by new ones             | `Recreate`                |
 | `livenessProbePath`                | Default livenessProbe path                                              | `/`                       |

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -7,7 +7,7 @@ strategyType: Recreate
 
 image:
   repository: nodered/node-red
-  tag: 1.0.1-12-minimal
+  tag: 1.0.4-12-minimal
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR bumps the node-red container image version to the current latest stable (1.0.4)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
