### PR TITLE
[stable/eventrouter] Serve prometheus metrics, add ServiceMonitor

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.3
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/README.md
+++ b/stable/eventrouter/README.md
@@ -20,17 +20,21 @@ eventrouter has been installed!
 
 The following table lists the configurable parameters of the eventrouter chart and their default values.
 
-|        Parameter        |                                                         Description                                                         |              Default               |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `image.repository`      | Container image name                                                                                                        | `gcr.io/heptio-images/eventrouter` |
-| `image.tag`             | Container image tag                                                                                                         | `v0.3`                             |
-| `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                             |
-| `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                                 |
-| `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                             |
-| `tolerations`           | List of node taints to tolerate                                                                                             | `[]`                               |
-| `nodeSelector`          | Node labels for pod assignment                                                                                              | `{}`                               |
-| `sink`                  | Sink to send the events to                                                                                                  | `glog`                             |
-| `podAnnotations`        | Annotations for pod metadata                                                                                                | `{}`                               |
-| `containerPorts`        | List of ports for the container                                                                                             | `[]`                               |
-| `securityContext`       | Security context for the pod                                                                                                | `{}`                               |
-| `enablePrometheus`      | Enable prometheus                                                                                                           | `true                              |
+|        Parameter          |                                                         Description                                                         |              Default               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `image.repository`        | Container image name                                                                                                        | `gcr.io/heptio-images/eventrouter` |
+| `image.tag`               | Container image tag                                                                                                         | `v0.3`                             |
+| `rbac.create`             | If `true`, create and use RBAC resources                                                                                    | `true`                             |
+| `serviceAccount.name`     | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                                 |
+| `serviceAccount.create`   | If true, create a new service account                                                                                       | `true`                             |
+| `tolerations`             | List of node taints to tolerate                                                                                             | `[]`                               |
+| `nodeSelector`            | Node labels for pod assignment                                                                                              | `{}`                               |
+| `sink`                    | Sink to send the events to                                                                                                  | `glog`                             |
+| `podAnnotations`          | Annotations for pod metadata                                                                                                | `{}`                               |
+| `containerPorts`          | List of ports for the container                                                                                             | `[]`                               |
+| `securityContext`         | Security context for the pod                                                                                                | `{}`                               |
+| `enablePrometheus`        | Enable prometheus                                                                                                           | `true`                             |
+| `services.annotations`    | Service annotations, only used if `enablePrometheus` is `true`                                                              | `{}`                               |
+| `services.type`           | Service type, only used if `enablePrometheus` is `true`                                                                     | `ClusterIP`                        |
+| `serviceMonitor.enabled`  | Manage a Prometheus Operator's service monitor, only used if `enablePrometheus` is `true`                                   | `false`                            |
+| `serviceMonitor.interval` | Interval which Prometheus Operator's service monitor is polled, only used if `serviceMonitor.enabled` is `true`             | `15s`                              |

--- a/stable/eventrouter/templates/service.yaml
+++ b/stable/eventrouter/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.enablePrometheus -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "eventrouter.fullname" . }}
+  labels:
+{{ include "eventrouter.labels" . | indent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type}}
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: {{ template "eventrouter.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/stable/eventrouter/templates/servicemonitor.yaml
+++ b/stable/eventrouter/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.enablePrometheus .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "eventrouter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "eventrouter.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+{{ include "eventrouter.labels" . | indent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/stable/eventrouter/values.yaml
+++ b/stable/eventrouter/values.yaml
@@ -37,3 +37,12 @@ securityContext: {}
   # runAsUser: 1000
 
 enablePrometheus: true
+
+# only required if `enablePrometheus` is true
+service:
+  annotations: {}
+  type: ClusterIP
+
+serviceMonitor:
+  enabled: false
+  interval: 15s


### PR DESCRIPTION
### What this PR does / why we need it:

There is a value `enablePrometheus`, but there is no service that expose that port. This PR add that.

and also add a `ServiceMonitor`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
