### PR TITLE
[stable/nginx-ingress] fix service selector(metrics/webhook)

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.34.1
+version: 1.34.2
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -41,7 +41,7 @@ spec:
       targetPort: metrics
   selector:
     app: {{ template "nginx-ingress.name" . }}
-    component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
   type: "{{ .Values.controller.metrics.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -38,7 +38,7 @@ spec:
       targetPort: webhook
   selector:
     app: {{ template "nginx-ingress.name" . }}
-    component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
   type: "{{ .Values.controller.admissionWebhooks.service.type }}"
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

I fixed controller/default-backend service selector in #21512.
But I forgot to fix metrics/webhook service selector.
This PR fixes it.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
