### PR TITLE
[stable/datadog] Correct handling of processAgent.processCollection setting

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.11
+version: 2.0.12
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/container-process-agent.yaml
+++ b/stable/datadog/templates/container-process-agent.yaml
@@ -7,11 +7,9 @@
 {{ toYaml .Values.agents.containers.processAgent.resources | indent 4 }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
+    {{- if .Values.datadog.processAgent.processCollection }}
     - name: DD_PROCESS_AGENT_ENABLED
-    {{- if .Values.datadog.processAgent.enabled }}
-      value: {{ .Values.datadog.processAgent.processCollection | quote }}
-    {{- else }}
-      value: "disabled"
+      value: "true"
     {{- end }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This addresses the issue when process agent would terminate if `processAgent.processCollection` was set to `false`.

Setting `DD_PROCESS_AGENT_ENABLED` to `false` results in termination of process agent. To disable process collection we need to leave this env var as not set on this container.

Signed-off-by: Ivan Ilichev <ivan.ilichev@datadoghq.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
