### PR TITLE
[stable/datadog] Fix `system-probe` startup on latest versions of containerd

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2.0
 
+## 2.0.13
+
+* Fix `system-probe` startup on latest versions of containerd.
+  Here is the error that this change fixes:
+  ```    State:          Waiting
+      Reason:       CrashLoopBackOff
+    Last State:     Terminated
+      Reason:       StartError
+      Message:      failed to create containerd task: OCI runtime create failed: container_linux.go:349: starting container process caused "close exec fds: ensure /proc/self/fd is on procfs: operation not permitted": unknown
+      Exit Code:    128
+   ```
+
 ## 2.0.11
 
 * Add missing syscalls in the `system-probe` seccomp profile

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.12
+version: 2.0.13
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/system-probe-configmap.yaml
+++ b/stable/datadog/templates/system-probe-configmap.yaml
@@ -78,6 +78,7 @@ data:
             "fcntl64",
             "fstat",
             "fstat64",
+            "fstatfs",
             "fsync",
             "futex",
             "getcwd",


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix `system-probe` startup on latest versions of `containerd`.

#### Which issue this PR fixes

On latest versions of `containerd`, the `system-probe` container permanently fails to start with the following error:
```
  State:          Waiting
    Reason:       CrashLoopBackOff
  Last State:     Terminated
    Reason:       StartError
    Message:      failed to create containerd task: OCI runtime create failed: container_linux.go:349: starting container process caused "close exec fds: ensure /proc/self/fd is on procfs: operation not permitted": unknown
    Exit Code:    128
 ```

  - fixes #21348

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
