### PR TITLE
[stable/hackmd] Changed hackmd image upload path

### DIFF
--- a/stable/hackmd/Chart.yaml
+++ b/stable/hackmd/Chart.yaml
@@ -1,6 +1,6 @@
 name: hackmd
 apiVersion: v1
-version: "1.2.4"
+version: "1.2.5"
 appVersion: "1.3.0-alpine"
 description: Realtime collaborative markdown notes on all platforms.
 icon: https://hackmd.io/favicon.png

--- a/stable/hackmd/README.md
+++ b/stable/hackmd/README.md
@@ -46,6 +46,7 @@ Parameter | Description | Default
 `persistence.size` | Persistent Volume size | `2Gi`
 `persistence.storageClass` | Persistent Volume Storage Class |  `unset`
 `extraVars` | Hackmd's extra environment variables | `[]`
+`uploadsPath` | Hackmd's image storage | `/codimd/public/uploads`
 `podAnnotations` | Pod annotations | `{}`
 `sessionSecret` | Hackmd's session secret | `""` (Randomly generated)
 `postgresql.install` | Enable PostgreSQL as a chart dependency | `true`
@@ -57,11 +58,11 @@ Parameter | Description | Default
 
 ### Use persistent volume for image uploads
 
-If you want to use a Kubernetes Persistent volume for image upload (enabled by default), you can encourter a problem where your volume doesn't have proper ownershuip, so HackMD won't be able to write into it. You can use set the `HMD_IMAGE_UPLOAD_TYPE` to `filesystem` in your `values.yaml` to have the Docker entrypoint change volume's ownership:
+If you want to use a Kubernetes Persistent volume for image upload (enabled by default), you can encourter a problem where your volume doesn't have proper ownershuip, so HackMD won't be able to write into it. You can use set the `CMD_IMAGE_UPLOAD_TYPE` to `filesystem` in your `values.yaml` to have the Docker entrypoint change volume's ownership:
 
 ```yaml
 extraVars:
-  - name: HMD_IMAGE_UPLOAD_TYPE
+  - name: CMD_IMAGE_UPLOAD_TYPE
     value: filesystem
 ```
 

--- a/stable/hackmd/templates/deployment.yaml
+++ b/stable/hackmd/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             {{- end }}
           volumeMounts:
             - name: data
-              mountPath: "/hackmd/public/uploads"
+              mountPath: {{ .Values.uploadsPath }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/hackmd/values.yaml
+++ b/stable/hackmd/values.yaml
@@ -69,6 +69,7 @@ persistence:
 podAnnotations: {}
 
 extraVars: []
+uploadsPath: "/codimd/public/uploads"
 
 nodeSelector: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `uploadsPath` variable. Changed hackmd image upload path to `/codimd/public/uploads`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
