### PR TITLE
[stable/datadog] Remove duplicate env in initContainer

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.14
+version: 2.0.15
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/containers-init.yaml
+++ b/stable/datadog/templates/containers-init.yaml
@@ -37,9 +37,6 @@
       readOnly: true
   env:
     {{- include "containers-common-env" . | nindent 4 }}
-    {{- if .Values.datadog.env }}
-      {{ toYaml .Values.datadog.env | nindent 4 }}
-    {{- end }}
     {{- if .Values.datadog.dockerSocketPath }}
     - name: DOCKER_HOST
       value: unix://{{ .Values.datadog.dockerSocketPath }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Remove `env` duplication on init container

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
