### PR TITLE
[stable/prometheus] Make service account annotations configurable

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.0.2
+version: 11.0.3
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -354,14 +354,18 @@ Parameter | Description | Default
 `server.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
+`serviceAccounts.alertmanager.annotations` | annotations for the alertmanager service account | `{}`
 `serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`
 `serviceAccounts.kubeStateMetrics.name` | name of the kubeStateMetrics service account to use or create | `{{ prometheus.kubeStateMetrics.fullname }}`
 `serviceAccounts.nodeExporter.create` | If true, create the nodeExporter service account | `true`
 `serviceAccounts.nodeExporter.name` | name of the nodeExporter service account to use or create | `{{ prometheus.nodeExporter.fullname }}`
+`serviceAccounts.nodeExporter.annotations` | annotations for the nodeExporter service account | `{}`
 `serviceAccounts.pushgateway.create` | If true, create the pushgateway service account | `true`
 `serviceAccounts.pushgateway.name` | name of the pushgateway service account to use or create | `{{ prometheus.pushgateway.fullname }}`
+`serviceAccounts.pushgateway.annotations` | annotations for the pushgateway service account | `{}`
 `serviceAccounts.server.create` | If true, create the server service account | `true`
 `serviceAccounts.server.name` | name of the server service account to use or create | `{{ prometheus.server.fullname }}`
+`serviceAccounts.server.annotations` | annotations for the server service account | `{}`
 `server.terminationGracePeriodSeconds` | Prometheus server Pod termination grace period | `300`
 `server.retention` | (optional) Prometheus data retention | `"15d"`
 `serverFiles.alerts` | (Deprecated) Prometheus server alerts configuration | `{}`

--- a/stable/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/stable/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
+  annotations:
+{{ toYaml .Values.serviceAccounts.alertmanager.annotations | indent 4 }}
 {{- end -}}

--- a/stable/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/stable/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
+  annotations:
+{{ toYaml .Values.serviceAccounts.nodeExporter.annotations | indent 4 }}
 {{- end -}}

--- a/stable/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/stable/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
+  annotations:
+{{ toYaml .Values.serviceAccounts.pushgateway.annotations | indent 4 }}
 {{- end -}}

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -6,5 +6,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
+  annotations:
+{{ toYaml .Values.serviceAccounts.server.annotations | indent 4 }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -13,15 +13,19 @@ serviceAccounts:
   alertmanager:
     create: true
     name:
+    annotations: {}
   nodeExporter:
     create: true
     name:
+    annotations: {}
   pushgateway:
     create: true
     name:
+    annotations: {}
   server:
     create: true
     name:
+    annotations: {}
 
 alertmanager:
   ## If false, alertmanager will not be installed


### PR DESCRIPTION
#### What this PR does / why we need it:

This change makes the annotations for service accounts configurable.

This change is useful when you need to set specific annotations to
service accounts, for example when using IAM Roles for service accounts
in AWS EKS.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
