### PR TITLE
[incubator/sparkoperator] Use `securitycontext` from the chart values for the init and cleanup jobs too

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.6.7
+version: 0.6.8
 appVersion: v1beta2-1.1.0-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/templates/crd-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/crd-cleanup-job.yaml
@@ -23,6 +23,12 @@ spec:
         - name: delete-sparkapp-crd
           image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- range $securityPolicy, $value := .Values.securityContext }}
+              {{ $securityPolicy }}: {{ $value }}
+              {{- end }}
+          {{- end }}
           command:
             - "/bin/sh"
             - "-c"
@@ -35,6 +41,12 @@ spec:
         - name: delete-scheduledsparkapp-crd
           image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- range $securityPolicy, $value := .Values.securityContext }}
+              {{ $securityPolicy }}: {{ $value }}
+              {{- end }}
+          {{- end }}
           command:
             - "/bin/sh"
             - "-c"

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -23,6 +23,12 @@ spec:
       - name: clean-secret
         image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- range $securityPolicy, $value := .Values.securityContext }}
+            {{ $securityPolicy }}: {{ $value }}
+            {{- end }}
+        {{- end }}
         command:
         - "/bin/sh"
         - "-c"

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -23,5 +23,11 @@ spec:
       - name: main
         image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          {{- range $securityPolicy, $value := .Values.securityContext }}
+            {{ $securityPolicy }}: {{ $value }}
+            {{- end }}
+        {{- end }}
         command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", "{{ .Release.Name }}-webhook", "-p"]
 {{ end }}


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

The `securityContext` value of the chart is not applied to the init and cleanup jobs that run when installing, upgrading or deleting the chart. If the cluster has special security requirements (e.g. does not allow containers that run as root), this will cause the jobs to fail.

This PR applies `securityContext` to the job containers as well.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@yuchaoran2011 @liyinan926
