### PR TITLE
[stable/grafana] Add support for extraExposePorts

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.7
+version: 5.0.8
 appVersion: 6.6.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -66,6 +66,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `service.loadBalancerIP`                  | IP address to assign to load balancer (if supported) | `nil`                                            |
 | `service.loadBalancerSourceRanges`        | list of IP CIDRs allowed access to lb (if supported) | `[]`                                             |
 | `serivce.externalIPs`                     | service external IP addresses                 | `[]`                                                    |
+| `extraExposePorts`                        | Additional service ports for sidecar containers| `[]`                                                   | 
 | `ingress.enabled`                         | Enables Ingress                               | `false`                                                 |
 | `ingress.annotations`                     | Ingress annotations                           | `{}`                                                    |
 | `ingress.labels`                          | Custom labels                                 | `{}`                                                    |

--- a/stable/grafana/templates/service.yaml
+++ b/stable/grafana/templates/service.yaml
@@ -42,5 +42,9 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
+  {{- if .Values.extraExposePorts }}
+  {{- tpl (toYaml .Values.extraExposePorts) . | indent 4 }}
+  {{- end }}
   selector:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
+

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -119,6 +119,12 @@ service:
   labels: {}
   portName: service
 
+extraExposePorts: []
+ # - name: keycloak
+ #   port: 8080
+ #   targetPort: 8080
+ #   type: ClusterIP  
+
 ingress:
   enabled: false
   annotations: {}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -123,7 +123,7 @@ extraExposePorts: []
  # - name: keycloak
  #   port: 8080
  #   targetPort: 8080
- #   type: ClusterIP  
+ #   type: ClusterIP
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### Is this a new chart: no

#### What this PR does / why we need it:
exposing other service ports for sidecar containers.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
