### PR TITLE
[stable/cluster-autoscaler] Update rbac apiversion from v1beta1 to v1

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 7.1.0
+version: 7.2.0
 appVersion: 1.17.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -135,6 +135,7 @@ rules:
 {{- if .Values.rbac.pspEnabled }}
   - apiGroups:
     - extensions
+    - policy
     resources:
     - podsecuritypolicies
     resourceNames:

--- a/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/stable/cluster-autoscaler/templates/role.yaml
+++ b/stable/cluster-autoscaler/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/cluster-autoscaler/templates/rolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Signed-off-by: Mike Tougeron <tougeron@adobe.com>

#### What this PR does / why we need it:
This updates the rbac apiVersion from v1beta to v1 (available since at least k8s 1.10)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
