### PR TITLE
[stable/metrics-server] Update rbac apiversion from v1beta1 to v1

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.6
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.10.0
+version: 2.10.1
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/templates/cluster-role.yaml
+++ b/stable/metrics-server/templates/cluster-role.yaml
@@ -23,6 +23,7 @@ rules:
   {{- if .Values.rbac.pspEnabled }}
   - apiGroups:
     - extensions
+    - policy
     resources:
     - podsecuritypolicies
     resourceNames:

--- a/stable/metrics-server/templates/role-binding.yaml
+++ b/stable/metrics-server/templates/role-binding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "metrics-server.fullname" .  }}-auth-reader


### PR DESCRIPTION
Signed-off-by: Mike Tougeron <tougeron@adobe.com>

#### What this PR does / why we need it:
This updates the rbac apiVersion from v1beta1 to v1. Other areas of the chart are already using v1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
