### PR TITLE
[stable/atlantis] AWS credentials toYaml error

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.11.1"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.11.1
+version: 3.11.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/secret-aws.yaml
+++ b/stable/atlantis/templates/secret-aws.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{- if .Values.aws.credentials }}
-  credentials: {{ toYaml .Values.aws.credentials | b64enc }}
+  credentials: {{ .Values.aws.credentials | b64enc }}
 {{- end }}
   config: {{ .Values.aws.config | b64enc }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Scott Crooks <scott.crooks@gmail.com>

#### What this PR does / why we need it:

In the previous PR (https://github.com/helm/charts/pull/21305), I used `toYaml`, which is redundant, and leads to an error in the `~/.aws/credentials` file if you're using a YAML multi-line string like so:

```yaml
aws:
  credentials: |-
    [default]
    aws_access_key_id = <some-access-key>
    aws_secret_access_key = <some-secret-key>
```

This gets rendered as:

```
|-
  [default]
  aws_access_key_id = <some-access-key>
  aws_secret_access_key = <some-secret-key>
```

Which is wrong.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
