### PR TITLE
[stable/jenkins] Remove configuration-as-code-support-plugin

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,13 +5,17 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.10.0 Remove configuration-as-code-support plugins
+
+In recent version of configuration-as-code-plugin this is no longer necessary.
+
 ## 1.9.24
 
 Update JCasC auto-reload docs and remove stale ssh key references from version "1.8.0 JCasC auto reload works without ssh keys"
 
-## 1.9.23
+## 1.9.23 Support jenkinsUriPrefix when JCasC is enabled
 
-Add jenkinsUriPrefix to casc reload uri
+Fixed a bug in the configuration as code reload url, where it wouldn't work with a jenkinsUriPrefix set.
 
 ## 1.9.22
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.24
+version: 1.10.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -67,7 +67,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.image`                    | Master image name                    | `jenkins/jenkins`                         |
 | `master.tag`                      | Master image tag                     | `lts`                                     |
 | `master.imagePullPolicy`          | Master image pull policy             | `Always`                                  |
-| `master.imagePullSecret`          | Master image pull secret             | Not set                                   |
+| `master.imagePullSecretName`      | Master image pull secret             | Not set                                   |
 | `master.numExecutors`             | Set Number of executors              | 0                                         |
 | `master.customJenkinsLabels`      | Append Jenkins labels to the master  | `{}`                                      |
 | `master.useSecurity`              | Use basic security                   | `true`                                    |
@@ -201,7 +201,7 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.customJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
 | `agent.enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
 | `agent.image`              | Agent image name                                | `jenkins/jnlp-slave`   |
-| `agent.imagePullSecret`    | Agent image pull secret                         | Not set                |
+| `agent.imagePullSecretName` | Agent image pull secret                         | Not set                |
 | `agent.tag`                | Agent image tag                                 | `3.27-1`               |
 | `agent.privileged`         | Agent privileged container                      | `false`                |
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}`|
@@ -371,7 +371,7 @@ master:
     configAutoReload:
       enabled: true
 rbac:
-  install: true
+  create: true
 ```
 
 ## RBAC

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -322,11 +322,6 @@ data:
   {{- if not (contains "configuration-as-code" (quote .Values.master.installPlugins)) }}
     configuration-as-code:{{ .Values.master.JCasC.pluginVersion }}
   {{- end }}
-  {{- if semverCompare "<=1.19" (printf "%v" .Values.master.JCasC.pluginVersion) }}
-    {{- if not (contains "configuration-as-code-support" (quote .Values.master.installPlugins)) }}
-    configuration-as-code-support:{{ .Values.master.JCasC.supportPluginVersion }}
-    {{- end }}
-  {{- end }}
 {{- end }}
 {{- end }}
 {{ else }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -253,9 +253,6 @@ master:
     enabled: false
     defaultConfig: false
     pluginVersion: "1.36"
-    # it's only used when plugin version is <=1.18 for later version the
-    # configuration as code support plugin is no longer needed
-    supportPluginVersion: "1.18"
     configScripts: {}
     # welcome-message: |
     #   jenkins:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

It removes support for configuration-as-code-support-plugin, which is deprecated quite a while now. It's not needed with newer versions of the configuration-as-code plugin.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #19149

#### Special notes for your reviewer:

Changes in the README are just fixes where the docs have been wrong.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
