### PR TITLE
[stable/zeppelin] Zeppelin uses latest api versions

### DIFF
--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 name: zeppelin
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.7.2
 home: https://zeppelin.apache.org/
 sources:

--- a/stable/zeppelin/templates/deployment.yaml
+++ b/stable/zeppelin/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-zeppelin
@@ -8,10 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  strategy:
-    rollingUpdate:
-      maxUnavailable: 0
-  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "zeppelin.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### Is this a new chart
It is not.

#### What this PR does / why we need it:
The beta Kubernetes API that this chart uses has been removed from newer versions of Kubernetes. This updates the Deployment API to the stable one and includes a new required property. 

#### Which issue this PR fixes
  - fixes #20057 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
