### PR TITLE
[stable/tensorflow-serving] drop time annotation

### DIFF
--- a/stable/tensorflow-serving/Chart.yaml
+++ b/stable/tensorflow-serving/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 1.0.1
+version: 1.1.0
 appVersion: 1.14.0
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:

--- a/stable/tensorflow-serving/templates/deployment.yaml
+++ b/stable/tensorflow-serving/templates/deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "tensorflow-serving.chart" . }}
     app: {{ template "tensorflow-serving.name" . }}
-  annotations:
-    "helm.sh/created": {{ .Release.Time.Seconds | quote }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:


### PR DESCRIPTION
This annotation uses `.Release.Time.Seconds` helm feature, which is not
avaiable in Helm 3 any more. This also makes the chart unstable, sinc content changes each time it is rendered, wich confuses some automatic deployment tools.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
