### PR TITLE
chore(nginx-ingress): unify component label

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.34.2
+version: 1.34.3
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/NOTES.txt
+++ b/stable/nginx-ingress/templates/NOTES.txt
@@ -22,7 +22,7 @@ It may take a few minutes for the LoadBalancer IP to be available.
 You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
 {{- else if contains "ClusterIP"  .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},app.kubernetes.io/component=controller,release={{ .Release.Name }}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to access your application."
 {{- end }}

--- a/stable/nginx-ingress/templates/addheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/addheaders-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-add-headers

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
@@ -27,7 +27,7 @@ spec:
       labels:
         app: {{ template "nginx-ingress.name" . }}
         chart: {{ template "nginx-ingress.chart" . }}
-        component: "{{ .Values.controller.name }}"
+        app.kubernetes.io/component: controller
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
@@ -27,7 +27,7 @@ spec:
       labels:
         app: {{ template "nginx-ingress.name" . }}
         chart: {{ template "nginx-ingress.chart" . }}
-        component: "{{ .Values.controller.name }}"
+        app.kubernetes.io/component: controller
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/psp.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/psp.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/role.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/role.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-metrics

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
@@ -14,6 +14,6 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
-      component: "{{ .Values.controller.name }}"
+      app.kubernetes.io/component: controller
   minAvailable: {{ .Values.controller.minAvailable }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-prometheusrules.yaml
+++ b/stable/nginx-ingress/templates/controller-prometheusrules.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- if .Values.controller.metrics.prometheusRule.additionalLabels }}

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
@@ -33,6 +33,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      component: "{{ .Values.controller.name }}"
+      app.kubernetes.io/component: controller
       release: {{ .Release.Name }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-admission

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.defaultBackend.name }}"
+    app.kubernetes.io/component: default-backend
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
@@ -14,6 +14,6 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
-      component: "{{ .Values.defaultBackend.name }}"
+      app.kubernetes.io/component: default-backend
   minAvailable: {{ .Values.defaultBackend.minAvailable }}
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.defaultBackend.name }}"
+    app.kubernetes.io/component: default-backend
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}

--- a/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-proxy-headers

--- a/stable/nginx-ingress/templates/tcp-configmap.yaml
+++ b/stable/nginx-ingress/templates/tcp-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-tcp

--- a/stable/nginx-ingress/templates/udp-configmap.yaml
+++ b/stable/nginx-ingress/templates/udp-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
+    app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-udp


### PR DESCRIPTION
This is to unify all `component` label in all resources of the chart to avoid misbehavior 