### PR TITLE
[incubator/cassandra] Enable ability to use ClusterIP autoassigned addresses

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.14.4
+version: 0.14.5
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/service.yaml
+++ b/incubator/cassandra/templates/service.yaml
@@ -12,7 +12,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  clusterIP: None
   type: {{ .Values.service.type }}
   ports:
     {{- if .Values.exporter.enabled }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
@KongZ @maorfr . Testing the chart in Microsoft Azure as a dependency of other chart (no publicly available). I've seen ClusterIP was not automatically assigned by K8s because it was explicitly set to `None`. Not setting `ClusterIP` parameter at all allows K8s to autoassign addresses

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
