### PR TITLE
[stable/airflow] add serviceMonitor namespaceSelector

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.5.0
+version: 6.6.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -512,6 +512,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `redis.master.persistence.accessModes`   | Access modes                                            | `[ ReadWriteOnce ]`       |
 | `redis.cluster.enabled`                  | enable master-slave cluster                             | `false`                   |
 | `serviceMonitor.enabled`                 | enable service monitor                                  | `false`                   |
+| `serviceMonitor.namespace`                | Namespace in which to install the ServiceMonitor resource. | ``                     |
 | `serviceMonitor.interval`                | Interval at which metrics should be scraped             | `30s`                     |
 | `serviceMonitor.path`                    | The path at which the metrics should be scraped         | `/admin/metrics`          |
 | `serviceMonitor.selector`                | label Selector for Prometheus to find ServiceMonitors   | `prometheus: kube-prometheus` |

--- a/stable/airflow/templates/servicemonitor.yaml
+++ b/stable/airflow/templates/servicemonitor.yaml
@@ -3,6 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "airflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
   labels:
     app: {{ template "airflow.name" . }}
     component: worker
@@ -22,4 +26,7 @@ spec:
   - port: web
     path: {{ .Values.serviceMonitor.path }}
     interval: {{ .Values.serviceMonitor.interval }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
 {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -716,13 +716,15 @@ redis:
 # Don't forget you need to install something like https://github.com/epoch8/airflow-exporter in your airflow docker container
 serviceMonitor:
   enabled: false
-  ## Namespace in which to install the ServiceMonitor resource.
-  namespace:
   interval: "30s"
   path: /admin/metrics
   ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
   selector:
     prometheus: kube-prometheus
+  ## Namespace in which the service monitor is created
+  ## Added to the ServiceMonitor object so that prometheus-operator is able to discover it
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  namespace:
 
 # Enable this if you're using https://github.com/coreos/prometheus-operator
 prometheusRule:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -716,6 +716,8 @@ redis:
 # Don't forget you need to install something like https://github.com/epoch8/airflow-exporter in your airflow docker container
 serviceMonitor:
   enabled: false
+  ## Namespace in which to install the ServiceMonitor resource.
+  namespace:
   interval: "30s"
   path: /admin/metrics
   ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)

--- a/stable/chartmuseum/templates/servicemonitor.yaml
+++ b/stable/chartmuseum/templates/servicemonitor.yaml
@@ -7,7 +7,6 @@ metadata:
 {{ toYaml .Values.serviceMonitor.labels | indent 4 }}
 {{- end }}
   name: {{ template "chartmuseum.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}

--- a/stable/chartmuseum/templates/servicemonitor.yaml
+++ b/stable/chartmuseum/templates/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.labels | indent 4 }}
 {{- end }}
   name: {{ template "chartmuseum.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR propose to choose the namespace and the namespaceSelector for the serviceMonitor. We need this possibility when we have prometheus in a specific namespace (i.e. monitoring)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
