### PR TITLE
[incubator/solr] Allow adding a custom script to be run before starting Solr (using the entry point of the official Solr Docker Image)

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.4.1"
+version: "1.5.0"
 appVersion: "8.4.0"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.4.0"
+version: "1.4.1"
 appVersion: "8.4.0"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/README.md
+++ b/incubator/solr/README.md
@@ -31,6 +31,8 @@ The following table shows the configuration options for the Solr helm chart:
 | `javaMem`                                     | JVM memory settings to pass to Solr | `-Xms2g -Xmx3g`                                                       |
 | `resources`                                   | Resource limits and requests to set on the solr pods | `{}` |
 | `extraEnvVars`                                | Additional environment variables to set on the solr pods (in yaml syntax) | `[]` |
+| `initScript`                                | The file name of the custom script to be run before starting Solr | `""` |
+
 | `terminationGracePeriodSeconds`               | The termination grace period of the Solr pods | `180`|
 | `image.repository`                            | The repository to pull the docker image from| `solr`                                                                |
 | `image.tag`                                   | The tag on the repository to pull | `7.7.2`                                                               |

--- a/incubator/solr/templates/_helpers.tpl
+++ b/incubator/solr/templates/_helpers.tpl
@@ -81,6 +81,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+  Define the name of the custom script configmap
+*/}}
+{{- define "solr.custom-script.configmap-name" -}}
+{{- printf "%s-%s" (include "solr.fullname" .) "custom-script-config-map" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
   Define the labels that should be applied to all resources in the chart
 */}}
 {{- define "solr.common.labels" -}}

--- a/incubator/solr/templates/solr-custom-script.yaml
+++ b/incubator/solr/templates/solr-custom-script.yaml
@@ -1,0 +1,13 @@
+{{ if not ( eq .Values.initScript  "" ) }}
+---
+
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "{{ include "solr.custom-script.configmap-name" . }}"
+  labels:
+{{ include "solr.common.labels" . | indent 4}}
+data:
+  solr-init.sh: |
+{{ .Files.Get .Values.initScript | indent 4}}
+{{ end }}

--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -55,6 +55,14 @@ spec:
             items:
               - key: solr.xml
                 path: solr.xml
+{{- if not ( eq .Values.initScript  "" ) }}
+        - name: solr-init-script
+          configMap:
+            name: {{ include "solr.custom-script.configmap-name" . }}
+            items:
+              - key: solr-init.sh
+                path: solr-init.sh
+{{- end }}
       initContainers:
         - name: check-zk
           image: busybox:latest
@@ -199,6 +207,10 @@ spec:
           volumeMounts:
             - name: {{ include "solr.pvc-name" . }}
               mountPath: /opt/solr/server/home
+{{- if not ( eq .Values.initScript  "" ) }}
+            - name: solr-init-script
+              mountPath: /docker-entrypoint-initdb.d
+{{- end }}
 {{ if .Values.tls.enabled }}
             - name: "keystore-volume"
               mountPath: "/etc/ssl/keystores"

--- a/incubator/solr/values.yaml
+++ b/incubator/solr/values.yaml
@@ -22,6 +22,10 @@ resources: {}
 # Extra environment variables - allows yaml definitions
 extraEnvVars: []
 
+# Specify the initial script file name here to be executed before starting Solr
+# The file is located relative to the solr chart root folder
+initScript: "custom-script.sh"
+
 # Sets the termination Grace period for the solr pods
 # This can take a while for shards to elect new leaders
 terminationGracePeriodSeconds: 180

--- a/incubator/solr/values.yaml
+++ b/incubator/solr/values.yaml
@@ -24,7 +24,7 @@ extraEnvVars: []
 
 # Specify the initial script file name here to be executed before starting Solr
 # The file is located relative to the solr chart root folder
-initScript: "custom-script.sh"
+initScript: ""
 
 # Sets the termination Grace period for the solr pods
 # This can take a while for shards to elect new leaders


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
**What**
The official Solr Docker image supports the entry point for us to run a script before starting Solr.
This PR extends the chart to allow developers to add a custom script to the entry point in the Solr Docker image.

**Why**
There are a lot of times we need to add libs to each Solr installation. However, Solr has limited support of adding libs dynamically, specifically the custom text analyzers.With the support of adding a custom script, we can write commands to download the libs we want automatically. 

I think supporting custom script in the Chart is a must for a production environment because, without this support, we have to manually add custom analyzer lib on each Solr pod.

#### Which issue this PR fixes
No

#### Special notes for your reviewer:
- Solr official Docker image: Extending the image
  - https://github.com/docker-solr/docker-solr#extending-the-image
- Solr has limited support of adding libs dynamically
  - https://issues.apache.org/jira/browse/SOLR-9175

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
