### PR TITLE
incubator/webpagetest-server add all paths to wptest server ingress

### DIFF
--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
-version: 0.2.1
+version: 0.2.2
 appVersion: "2018-03-08"
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png

--- a/incubator/webpagetest-server/templates/ingress.yaml
+++ b/incubator/webpagetest-server/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/incubator/webpagetest-server/templates/ingress.yaml
+++ b/incubator/webpagetest-server/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /*
+          - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -18,6 +18,7 @@ ingress:
   # Used to create Ingress record (should used with service.type: ClusterIP).
   hosts:
     - web-page-test.local
+  path: / # depending on the ingress controller you may want to set this to /* to handle all the routes
   # It's best to add annotations to restrict who can access
   annotations:
     # kubernetes.io/ingress.class: nginx

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -18,7 +18,8 @@ ingress:
   # Used to create Ingress record (should used with service.type: ClusterIP).
   hosts:
     - web-page-test.local
-  path: / # depending on the ingress controller you may want to set this to /* to handle all the routes
+  # depending on the ingress controller you may want to set this to /* to handle all the routes
+  path: /
   # It's best to add annotations to restrict who can access
   annotations:
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
@timothyclarke these charts work pretty well, but the i have been manually making this small edit to the ingress portion (I am using this with aws-alb-ingress-controller + external-dns)

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Is this a new chart
NO

#### What this PR does / why we need it:
Fixes ingress for routes other than homepage (fixes assets, and other urls)

#### Which issue this PR fixes
none

#### Special notes for your reviewer:
I have been using the official docker images `webpagetest/server` and `webpagetest/agent` (they work fine)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
