### PR TITLE
[stable/kube2iam] - add labels to ServiceMonitor

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.4.0
+version: 2.5.0
 appVersion: 0.10.9
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -61,6 +61,7 @@ Parameter | Description | Default
 `prometheus.serviceMonitor.enabled` | If true, create a Prometheus Operator ServiceMonitor resource | `false`
 `prometheus.serviceMonitor.interval` | Interval at which the metrics endpoint is scraped | `10s`
 `prometheus.serviceMonitor.namespace` | An alternative namespace in which to install the ServiceMonitor | `""`
+`prometheus.serviceMonitor.labels` | Labels to add to the ServiceMonitor | `{}`
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `resources` | pod resource requests & limits | `{}`

--- a/stable/kube2iam/templates/servicemonitor.yaml
+++ b/stable/kube2iam/templates/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     helm.sh/chart: {{ template "kube2iam.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.prometheus.serviceMonitor.labels }}
+    {{- toYaml .Values.prometheus.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -32,6 +32,8 @@ prometheus:
     interval: 10s
     # Alternative namespace to install the ServiceMonitor in
     namespace: ""
+    # Labels to add to the service monitor
+    labels: {}
 
 image:
   repository: jtblin/kube2iam


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Prometheus objects for the prometheus operator have label selectors for servicemonitors.
At the moment it isn't possible to set labels on the service monitor in kube2iam.
This allows users to specify labels to ensure the ServiceMonitor configures the correct prometheus.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
Nothing special

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
