### PR TITLE
[stable/cluster-overprovisioner] Adds imagePullSecrets to deployment

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.2.6
+version: 0.3.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `priorityClassDefault.value`       | Priority value of the default priorityClass                                                                                     | `0`               |
 | `image.repository`                 | Image repository                                                                                                                | `k8s.gcr.io/pause`|
 | `image.tag`                        | Image tag                                                                                                                       | `3.1`             |
+| `image.pullSecrets`                | Image pull secrets                                                                                                                   | `[]`              |
 | `image.pullPolicy`                 | Container pull policy                                                                                                           | `IfNotPresent`    |
 | `fullnameOverride`                 | Override the fullname of the chart                                                                                              | `nil`             |
 | `nameOverride`                     | Override the name of the chart                                                                                                  | `nil`             |

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -8,6 +8,7 @@
 {{- $repository := .Values.image.repository }}
 {{- $imageTag := .Values.image.tag }}
 {{- $pullPolicy := .Values.image.pullPolicy }}
+{{- $imagePullSecrets := .Values.image.pullSecrets }}
 
 {{ range .Values.deployments }}
 apiVersion: apps/v1
@@ -50,6 +51,12 @@ spec:
           imagePullPolicy: {{ $pullPolicy }}
           resources:
             {{- toYaml .resources | nindent 12 }}
+    {{- if $imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
     {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -12,6 +12,13 @@ image:
   tag: 3.1
   pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
 nameOverride: ""
 
 fullnameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds imagePullSecrets to deployment, allowing to pull the image from a private registry

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
