### PR TITLE
[stable/prometheus] Moving cluster.advertise-address param in Alertmanager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.0.3
+version: 11.0.4
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-statefulset.yaml
+++ b/stable/prometheus/templates/alertmanager-statefulset.yaml
@@ -49,8 +49,8 @@ spec:
           args:
             - --config.file=/etc/config/alertmanager.yml
             - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
-            - --cluster.advertise-address=$(POD_IP):6783
           {{- if .Values.alertmanager.statefulSet.headless.enableMeshPeer }}
+            - --cluster.advertise-address=$(POD_IP):6783
             - --cluster.listen-address=0.0.0.0:6783
           {{- range $n := until (.Values.alertmanager.replicaCount | int) }}
             - --cluster.peer={{ template "prometheus.alertmanager.fullname" $ }}-{{ $n }}.{{ template "prometheus.alertmanager.fullname" $ }}-headless:6783


### PR DESCRIPTION
Signed-off-by: Ali Sattari <ali.sattari@gmail.com>

#### What this PR does / why we need it:
The param that defines `cluster.advertise-address` was outside the `if` block for `enableMeshPeer`, makes sense to move it inside the block, as this param can't be repeated or overridden, and should be in sync with `cluster.listen-address` and `cluster.peer`.

#### Special notes for your reviewer:
This caused some confusing situation were I wasn't using peer mesh but set up the cluster by an existing headless service, without setting `cluster.listen-address`, Alertmanager listens on `9094` by default, but the advertisement address was set to `6783` by the chart. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
