### PR TITLE
[ci] Print helm version in job lint-charts in order to make debugging of issues more easy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run:
           name: lint
           command: |
+            helm version --client
             git remote add k8s https://github.com/helm/charts
             git fetch k8s master
             ct lint --config test/ct.yaml


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Make repeating helm linting locally more easy.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
./.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] (kind of) Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
