### PR TITLE
[stable/minio] Add variables for etcd and for s3 gateway credentials.

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.23
+version: 5.0.24
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -162,6 +162,8 @@ The following table lists the configurable parameters of the MinIO chart and the
 | `s3gateway.enabled`                       | Use MinIO as a [s3 gateway](https://github.com/minio/minio/blob/master/docs/gateway/s3.md)                                              | `false`                                    |
 | `s3gateway.replicas`                      | Number of s3 gateway instances to run in parallel                                                                                       | `4`                                        |
 | `s3gateway.serviceEndpoint`               | Endpoint to the S3 compatible service                                                                                                   | `""`                                       |
+| `s3gateway.accessKey`                     | Access key of S3 compatible service                                                                                                     | `""`                                       |
+| `s3gateway.secretKey`                     | Secret key of S3 compatible service                                                                                                     | `""`                                       |
 | `azuregateway.enabled`                    | Use MinIO as an [azure gateway](https://docs.minio.io/docs/minio-gateway-for-azure)                                                     | `false`                                    |
 | `azuregateway.replicas`                   | Number of azure gateway instances to run in parallel                                                                                    | `4`                                        |
 | `gcsgateway.enabled`                      | Use MinIO as a [Google Cloud Storage gateway](https://docs.minio.io/docs/minio-gateway-for-gcs)                                         | `false`                                    |
@@ -180,6 +182,11 @@ The following table lists the configurable parameters of the MinIO chart and the
 | `metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                                                                    | `nil`                                      |
 | `metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used                                                             | `nil`                                      |
 | `metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used                                                               | `nil`                                      |
+| `etcd.endpoints`                          | Enpoints of etcd                                                                                                                        | `[]`                                       |
+| `etcd.pathPrefix`                         | Prefix for all etcd keys                                                                                                                | `""`                                       |
+| `etcd.corednsPathPrefix`                  | Prefix for all CoreDNS etcd keys                                                                                                        | `""`                                       |
+| `etcd.clientCert`                         | Certificate used for SSL/TLS connections to etcd [(etcd Security)](https://etcd.io/docs/latest/op-guide/security/)                      | `""`                                       |
+| `etcd.clientCertKey`                      | Key for the certificate [(etcd Security)](https://etcd.io/docs/latest/op-guide/security/)                                               | `""`                                       |
 
 Some of the parameters above map to the env variables defined in the [MinIO DockerHub image](https://hub.docker.com/r/minio/minio/).
 

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -117,7 +117,7 @@ spec:
               subPath: "{{ .Values.persistence.subPath }}"
               {{- end }}
             {{- end }}
-            {{- if .Values.gcsgateway.enabled }}
+            {{- if or .Values.gcsgateway.enabled .Values.etcd.clientCert .Values.etcd.clientCertKey }}
             - name: minio-user
               mountPath: "/etc/credentials"
               readOnly: true
@@ -147,6 +147,42 @@ spec:
             {{- if .Values.gcsgateway.enabled }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/credentials/gcs_key.json"
+            {{- end }}
+            {{- if .Values.etcd.endpoints }}
+            - name: MINIO_ETCD_ENDPOINTS
+              value: {{ join "," .Values.etcd.endpoints | quote }}
+            {{- end }}
+            {{- if .Values.etcd.clientCert }}
+            - name: MINIO_ETCD_CLIENT_CERT
+              value: "/etc/credentials/etcd_client_cert.pem"
+            {{- end }}
+            {{- if .Values.etcd.clientCertKey }}
+            - name: MINIO_ETCD_CLIENT_CERT_KEY
+              value: "/etc/credentials/etcd_client_cert_key.pem"
+            {{- end }}
+            {{- if .Values.etcd.pathPrefix }}
+            - name: MINIO_ETCD_PATH_PREFIX
+              value: {{ .Values.etcd.pathPrefix }}
+            {{- end }}
+            {{- if .Values.etcd.corednsPathPrefix }}
+            - name: MINIO_ETCD_COREDNS_PATH
+              value: {{ .Values.etcd.corednsPathPrefix }}
+            {{- end }}
+            {{- if .Values.s3gateway.enabled -}}
+            {{- if .Values.s3gateway.accessKey }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: awsAccessKeyId
+            {{- end }}
+            {{- if .Values.s3gateway.secretKey }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: awsSecretAccessKey
+            {{- end }}
             {{- end }}
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}

--- a/stable/minio/templates/secrets.yaml
+++ b/stable/minio/templates/secrets.yaml
@@ -15,4 +15,18 @@ data:
 {{- if .Values.gcsgateway.enabled }}
   gcs_key.json: {{ .Values.gcsgateway.gcsKeyJson | b64enc }}
 {{- end }}
+{{- if .Values.s3gateway.enabled -}}
+{{- if .Values.s3gateway.accessKey }}
+  awsAccessKeyId: {{ .Values.s3gateway.accessKey | b64enc | quote }}
+{{- end }}
+{{- if .Values.s3gateway.secretKey }}
+  awsSecretAccessKey: {{ .Values.s3gateway.secretKey | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.etcd.clientCert }}
+  etcd_client_cert.pem: {{ .Values.etcd.clientCert | b64enc | quote }}
+{{- end }}
+{{- if .Values.etcd.clientCertKey }}
+  etcd_client_cert_key.pem: {{ .Values.etcd.clientCertKey | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -242,6 +242,8 @@ s3gateway:
   enabled: false
   replicas: 4
   serviceEndpoint: ""
+  accessKey: ""
+  secretKey: ""
 
 ## Use minio as an azure blob gateway, you should disable data persistence so no volume claim are created.
 ## https://docs.minio.io/docs/minio-gateway-for-azure
@@ -318,3 +320,11 @@ metrics:
     # namespace: monitoring
     # interval: 30s
     # scrapeTimeout: 10s
+
+## ETCD settings: https://github.com/minio/minio/blob/master/docs/sts/etcd.md
+etcd:
+  endpoints: []
+  pathPrefix: ""
+  corednsPathPrefix: ""
+  clientCert: ""
+  clientCertKey: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Added variables for etcd and for s3 gateway credentials.
Using Kubernetes Secrets for storing credentials.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
