### PR TITLE
[stable/elastic-stack] update filebeat for 1.16

### DIFF
--- a/stable/elastic-stack/Chart.yaml
+++ b/stable/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 1.9.0
+version: 2.0.0
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/stable/elastic-stack/README.md
+++ b/stable/elastic-stack/README.md
@@ -5,7 +5,7 @@ You can optionally disable logstash and install Fluentd if you prefer. It also o
 
 ## Prerequisites Details
 
-* Kubernetes 1.8+
+* Kubernetes 1.10+
 * PV dynamic provisioning support on the underlying infrastructure
 
 ## Chart Details

--- a/stable/elastic-stack/requirements.lock
+++ b/stable/elastic-stack/requirements.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 3.2.4
 - name: filebeat
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.7.0
+  version: 3.1.1
 - name: logstash
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.3.0
@@ -29,5 +29,5 @@ dependencies:
 - name: elasticsearch-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.1.0
-digest: sha256:e3d77fb315df2d0b952cd0b310cef17db552108f081c2951c832538bbf7b77db
-generated: "2019-11-06T00:25:12.383848379-06:00"
+digest: sha256:cc74fbe9206f209f8f1b04584012fa601c9ef28e4cca367f2f2a836b4deceeee
+generated: "2020-03-26T14:40:14.407826+01:00"

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: kibana.enabled
 - name: filebeat
-  version: ^1.7.0
+  version: ^3.1.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: filebeat.enabled
 - name: logstash


### PR DESCRIPTION
Signed-off-by: Adrien Kohlbecker <adrien.kohlbecker@gmail.com>

#### Is this a new chart

no

#### What this PR does / why we need it:

https://github.com/helm/charts/pull/18620 added 1.16 support to `stable/elastic-stack` with the default values. However, the `filebeat` dependency wasn't upgraded, and so installing on 1.16 still fails when `filebeat.enable: true` is set.

I've updated the major version since https://github.com/helm/charts/commit/74053d9b06612d7b0e791369bcd5173782e8ee42 is bumping the minimum kubernetes version.

I understand the elastic-stack chart is deprecated but since that MR above got merged as a hotfix I believe this one should be valuable too. I've opened https://gitlab.com/gitlab-org/gitlab/-/issues/212564 to schedule a migration on our end soon.

#### Which issue this PR fixes

See https://gitlab.com/gitlab-org/gitlab/-/issues/212255 for the source issue I'm trying to fix.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
