### PR TITLE
[stable/mariadb] Don't enable service links for mariadb pods.

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.3.13
+version: 7.3.14
 appVersion: 10.3.22
 # The redis chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
 deprecated: true

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -80,6 +80,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- include "mariadb.imagePullSecrets" . | indent 6 }}
+      enableServiceLinks: false
       initContainers:
         {{- if .Values.master.extraInitContainers }}
 {{ tpl .Values.master.extraInitContainers . | indent 8 }}

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -83,6 +83,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- include "mariadb.imagePullSecrets" . | indent 6 }}
+      enableServiceLinks: false
       initContainers:
         {{- if .Values.master.extraInitContainers }}
 {{ tpl .Values.master.extraInitContainers . | indent 6}}


### PR DESCRIPTION
#### What this PR does / why we need it:
By default, kubernetes add environment variables to pods for each service in the namespace. For environment which have a lot of resources in the same (for us it's because we generate dedicated helm releases for feature branches), the number of environment variables adds up quickly. How it happens exactly is not clear, but somehow mariadb pods end up with an increasing cpu activity, even when the application is completely idle (no requests coming through). The cpu usage for idle pods is even linearly correlated with the number of services in the namespace. We have noticed a similar behavior for elasticsearch and php pods. We're talking about relatively low cpu activity, between 0.01 and 0.03 vCPU in our case, but on a development cluster with many releases and low default resources, it makes a noticeable difference.

Disabling the service links skips the environment variables, and brings the cpu usage to a much lower value when idle. The service links are mainly useful for applications that need to connect to other services, but this is not the case for mariadb, so there should be no side effects. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (no variable added)
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)