### PR TITLE
[stable/instana-agent] Chart version 1.0.26

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/
-icon: http://instana-management-assets.s3-website-eu-west-1.amazonaws.com/stan_icon_front_black_big.png
+icon: https://instana-management-assets.s3-eu-west-1.amazonaws.com/stan-logo-2020.png
 maintainers:
 - email: jon.brisbin@instana.com
   name: jbrisbin
@@ -21,4 +21,4 @@ maintainers:
 name: instana-agent
 sources:
 - https://github.com/instana/instana-agent-docker
-version: 1.0.25
+version: 1.0.26

--- a/stable/instana-agent/templates/NOTES.txt
+++ b/stable/instana-agent/templates/NOTES.txt
@@ -61,6 +61,6 @@ It may take a few moments for the agents to fully deploy. You can see what agent
 
 You can get the logs for all of the agents with `kubectl logs`:
 
-    kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} -c instana-agent
+    kubectl logs -l app.kubernetes.io/name={{ .Release.Name }} -n {{ .Release.Namespace }} -c instana-agent
 
 {{- end }}

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -55,16 +55,25 @@ The name of the PodSecurityPolicy used.
 Add Helm metadata to resource labels.
 */}}
 {{- define "instana-agent.commonLabels" -}}
+{{- if .Values.templating -}}
+app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "instana-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "instana-agent.chart" . }}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Add Helm metadata to selector labels specifically for deployments/daemonsets/statefulsets.
 */}}
 {{- define "instana-agent.selectorLabels" -}}
+{{- if .Values.templating -}}
+app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "instana-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/agentsecret.yaml
+++ b/stable/instana-agent/templates/agentsecret.yaml
@@ -1,11 +1,19 @@
-{{- if .Values.agent.key }}
+{{- if or .Values.agent.key .Values.agent.downloadKey }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "instana-agent.fullname" . }}-agent-secret
+  name: {{ template "instana-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "instana-agent.commonLabels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if .Values.templating }}
+  key: {{ .Values.agent.key }}
+{{- else }}
   key: {{ .Values.agent.key | b64enc | quote }}
+{{- end }}
+{{- if .Values.agent.downloadKey }}
+  downloadKey: {{ .Values.agent.downloadKey | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRole
+{{- if .Values.agent.supportOpenshift }}
+apiVersion: v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- end }}
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:
@@ -41,6 +45,12 @@ rules:
   resources:
     - "endpoints"
   verbs: ["create", "update", "patch"]
+{{- if .Values.agent.supportOpenshift }}
+- apiGroups: ["apps.openshift.io"]
+  resources:
+    - "deploymentconfigs"
+  verbs: ["get", "list", "watch"]
+{{- end -}}
 {{- if .Values.podSecurityPolicy.enable}}
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRoleBinding
+{{- if .Values.agent.supportOpenshift }}
+apiVersion: v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- end }}
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:
@@ -12,5 +16,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ template "instana-agent.fullname" . }}
+  {{- if not .Values.agent.supportOpenshift }}
   apiGroup: rbac.authorization.k8s.io
+  {{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "instana-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "instana-agent.commonLabels" . | nindent 4 }}
 data:

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "instana-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "instana-agent.commonLabels" . | nindent 4 }}
 spec:
@@ -19,6 +20,12 @@ spec:
         {{- toYaml .Values.agent.pod.annotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.agent.pod.nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .Values.agent.pod.nodeSelector }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ template "instana-agent.serviceAccountName" . }}
       hostIPC: true
       hostNetwork: true
@@ -32,8 +39,10 @@ spec:
               value: {{ .Values.agent.leaderElectorPort | quote }}
             - name: INSTANA_ZONE
               value: {{ .Values.zone.name | quote }}
+              {{- if .Values.cluster.name }}
             - name: INSTANA_KUBERNETES_CLUSTER_NAME
               value: {{ .Values.cluster.name | quote }}
+              {{- end }}
             - name: INSTANA_AGENT_ENDPOINT
               value: {{ .Values.agent.endpointHost | quote }}
             - name: INSTANA_AGENT_ENDPOINT_PORT
@@ -41,7 +50,7 @@ spec:
             - name: INSTANA_AGENT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.fullname" . }}-agent-secret
+                  name: {{ template "instana-agent.fullname" . }}
                   key: key
             {{- if .Values.agent.mode }}
             - name: INSTANA_AGENT_MODE
@@ -51,8 +60,8 @@ spec:
             - name: INSTANA_DOWNLOAD_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.fullname" . }}-download-secret
-                  key: key
+                  name: {{ template "instana-agent.fullname" . }}
+                  key: downloadKey
             {{- end }}
             {{- if .Values.agent.proxyHost }}
             - name: INSTANA_AGENT_PROXY_HOST
@@ -87,6 +96,7 @@ spec:
               value: {{ .Values.agent.redactKubernetesSecrets | quote }}
             {{- end }}
             - name: JAVA_OPTS
+              # Approximately 1/3 of container memory limits to allow for direct-buffer memory usage and JVM overhead
               value: "-Xmx{{ div (default 512 .Values.agent.pod.requests.memory) 3 }}M -XX:+ExitOnOutOfMemoryError"
             - name: INSTANA_AGENT_POD_NAME
               valueFrom:
@@ -155,7 +165,7 @@ spec:
               cpu: 0.1
               memory: 64Mi
           livenessProbe:
-            httpGet:
+            httpGet: # Leader elector liveness is tied to agent, published on localhost:42699
               path: /com.instana.agent.coordination.sidecar/health
               port: 42699
             initialDelaySeconds: 300

--- a/stable/instana-agent/templates/namespace.yaml
+++ b/stable/instana-agent/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.templating }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+{{- end }}

--- a/stable/instana-agent/templates/podsecuritypolicy.yaml
+++ b/stable/instana-agent/templates/podsecuritypolicy.yaml
@@ -4,6 +4,7 @@ kind: PodSecurityPolicy
 apiVersion: policy/v1beta1
 metadata:
   name: {{ template "instana-agent.podSecurityPolicyName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "instana-agent.commonLabels" . | nindent 4 }}
 spec:

--- a/stable/instana-agent/templates/serviceaccount.yaml
+++ b/stable/instana-agent/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "instana-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "instana-agent.commonLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -78,6 +78,9 @@ agent:
   host:
     repository: null
 
+  # agent.supportOpenshift specifies whether the cluster role should include openshift permissions
+  # supportOpenshift: true
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

- Add variables to allow for templating the helm chart into a single yaml file (for internal use only)
- Update chart icon
- Add `app.kubernetes.io/version` label to all resources
- Change `name` and `app` labels to more standard `app.kubernetes.io/name` label
- Rename various resources:
  - Rename `ConfigMap` from `instana-configuration` to `instana-agent`
  - Rename `ClusterRole` from `instana-agent-role` to `instana-agent`
  - Rename `ClusterRoleBinding` from `instana-agent-role-binding` to `instana-agent`
  - Rename `Secret` from `instana-agent-secret` to `instana-agent`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
