### PR TITLE
stable/metrics-server clusterIP immutability fix

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.6
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.10.1
+version: 2.10.2
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -31,6 +31,7 @@ Parameter | Description | Default
 `readinessProbe` | Container readiness probe | See values.yaml
 `service.annotations` | Annotations to add to the service | `{}`
 `service.labels` | Labels to be added to the metrics-server service | `{}`
+`service.clusterIP` | ClusteIP of the service (set to "-" to pass an empty value) | `nil`
 `service.port` | Service port to expose | `443`
 `service.type` | Type of service to create | `ClusterIP`
 `podDisruptionBudget.enabled` | Create a PodDisruptionBudget | `false`

--- a/stable/metrics-server/templates/metric-server-service.yaml
+++ b/stable/metrics-server/templates/metric-server-service.yaml
@@ -13,6 +13,9 @@ metadata:
   annotations:
     {{- toYaml .Values.service.annotations | trim | nindent 4 }}
 spec:
+  {{- with .Values.service.clusterIP  }}
+  clusterIP: {{ if eq "-" . }}""{{ else }}{{ . | quote }}{{ end }}
+  {{- end}}
   ports:
     - port: {{ .Values.service.port }}
       protocol: TCP

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -97,6 +97,7 @@ service:
   #  Add these labels to have metrics-server show up in `kubectl cluster-info`
   #  kubernetes.io/cluster-service: "true"
   #  kubernetes.io/name: "Metrics-server"
+  clusterIP: ""
   port: 443
   type: ClusterIP
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
@olemarkus @kennethaasan 

#### Is this a new chart
This is not a new chart. It is for issue #21185 

#### What this PR does / why we need it:
This PR fixes the clusterIP immutability issue when letting k8s auto-assign an address. See issue #21185 

#### Which issue this PR fixes
This PR fixes issue #21185. 

#### Special notes for your reviewer:
The fix follows similar implementation from this discussion. https://github.com/helm/helm/issues/6378

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

