### PR TITLE
[stable/prometheus-adapter] Add podLabels support

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.1.3
+version: 2.2.0
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `logLevel`                      | Log level                                                                       | `4`                                         |
 | `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `1m`                                        |
 | `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
+| `podLabels`                     | Labels to add to the pod                                                        | `{}`                                        |
 | `podAnnotations`                | Annotations to add to the pod                                                   | `{}`                                        |
 | `priorityClassName`             | Pod priority                                                                    | ``                                          |
 | `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -20,6 +20,9 @@ spec:
         chart: {{ template "k8s-prometheus-adapter.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
       name: {{ template "k8s-prometheus-adapter.name" . }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/custom-metrics-configmap.yaml") . | sha256sum }}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -123,6 +123,9 @@ extraVolumeMounts: []
 
 tolerations: []
 
+# Labels added to the pod
+podLabels: {}
+
 # Annotations added to the pod
 podAnnotations: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow to add labels to prometheus-adapter pods created by deployment.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
