### PR TITLE
[incubator/cassandra] Disable Cassandra exporter and service monitor by default.

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cassandra
-version: 0.14.4
-appVersion: 3.11.5
+version: 0.15.0
+appVersion: 3.11.6
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/templates/servicemonitor.yaml
+++ b/incubator/cassandra/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.exporter.enabled .Values.exporter.servicemonitor.enabled }}
+{{- if and .Values.exporter.enabled .Values.exporter.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -9,8 +9,8 @@ metadata:
     chart: {{ template "cassandra.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.exporter.servicemonitor.additionalLabels }}
-{{ toYaml .Values.exporter.servicemonitor.additionalLabels | indent 4 }}
+    {{- if .Values.exporter.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.exporter.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
 spec:
   jobLabel: {{ template "cassandra.name" . }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/cassandra/
 image:
   repo: cassandra
-  tag: 3.11.5
+  tag: 3.11.6
   pullPolicy: IfNotPresent
   ## Specify ImagePullSecrets for Pods
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -212,10 +212,9 @@ backup:
 ## Cassandra exported configuration
 ## ref: https://github.com/criteo/cassandra_exporter
 exporter:
-  # If exporter is enabled this will create a ServiceMonitor by default as well
-  enabled: true
-  servicemonitor:
-    enabled: true
+  enabled: false
+  serviceMonitor:
+    enabled: false
     additionalLabels: {}
       # prometheus: default
   image:


### PR DESCRIPTION
cc @maorfr @Jasstkn 

Hi @Jasstkn I know you added this feature recently, would like your input if you feel ok with this.

A saner default is to disable the exporter and service monitor by default as not everyone is using Prometheus let alone Prometheus Operator. Also changing the key name from `servicemonitor` to `serviceMonitor` as it seems to be the standard way of spelling it across charts.

The chart fails to deploy in environments that do not have the serviceMonitor CRD such as [Jaeger helm charts test](https://github.com/jaegertracing/helm-charts/runs/524418629?check_suite_focus=true) which depends on this chart rather than vendoring in it's own cassandra.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
