### PR TITLE
[stable/verdaccio] Adding service-account as optional

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.7.5
+version: 0.7.6
 appVersion: 3.11.6
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/README.md
+++ b/stable/verdaccio/README.md
@@ -77,7 +77,9 @@ and their default values.
 | `service.port`                     | Service port to expose                                          | `4873`                                                   |
 | `service.nodePort`                 | Service port to expose                                          | none                                                     |
 | `service.type`                     | Type of service to create                                       | `ClusterIP`                                              |
-| `extraEnvVars`                     | Define environment variables to be passed to the container                                       | `{}`  
+| `serviceAccount.enabled`           | Enable service account                                          | `false`                                                  |
+| `serviceAccount.name`              | Service account Name                                            | none                                                     |
+| `extraEnvVars`                     | Define environment variables to be passed to the container      | `{}`                                                     | 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/verdaccio/templates/deployment.yaml
+++ b/stable/verdaccio/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "verdaccio.fullname" . }}
 spec:
+  {{- if .Values.serviceAccount.enabled }}
+  serviceAccountName: {{ template ".Values.serviceAccount.name" . }}
+  {{- end}}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/stable/verdaccio/templates/service-account.yaml
+++ b/stable/verdaccio/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template ".Values.serviceAccount.name" . }}
+  labels:
+    app: {{ template "verdaccio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/stable/verdaccio/values.yaml
+++ b/stable/verdaccio/values.yaml
@@ -48,6 +48,11 @@ ingress:
 #     hosts:
 #       - npm.blah.com
 
+## Service account
+serviceAccount:
+  enabled: false
+  # name:
+
 # Extra Environment Values - allows yaml definitions
 extraEnvVars:
 #  - name: VALUE_FROM_SECRET


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding serviceAccount as an option, because I am trying to use secrets via vault and without serviceAccount it was impossible

#### Which issue this PR fixes

I need to place uplinks with auth-property in the settings of verdaccio and this secret is protected by vault (DOC:  https://verdaccio.org/docs/en/uplinks#auth-property)

#### Special notes for your reviewer:

If you have any other better way please show me that I will make the adjustments in the PR

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
