### PR TITLE
[stable/node-problem-detector] Add support for extra volumes

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.7.0"
+version: "1.7.1"
 appVersion: v0.8.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -56,10 +56,12 @@ The following table lists the configurable parameters for this chart and their d
 | `settings.heartBeatPeriod`            | Syncing interval with API server           | `5m0s`                                                       |
 | `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
 | `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
-| `tolerations`                         | Optional daemonset tolerations             | `["effect: NoSchedule,operator: Exists"]`                                                         |
+| `tolerations`                         | Optional daemonset tolerations             | `["effect: NoSchedule,operator: Exists"]`                    |
 | `nodeSelector`                        | Optional daemonset nodeSelector            | `{}`                                                         |
 | `env`                                 | Optional daemonset environment variables   | `[]`                                                         |
 | `labels`                              | Optional daemonset labels                  | `{}`                                                         |
+| `extraVolumes`                        | Optional daemonset volumes to add          | `[]`                                                         |
+| `extraVolumeMounts`                   | Optional daemonset volumeMounts to add     | `[]`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -62,6 +62,9 @@ spec:
             - name: custom-config
               mountPath: /custom-config
               readOnly: true
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
           ports:
             - containerPort: {{ .Values.settings.prometheus_port }}
               name: exporter
@@ -90,3 +93,6 @@ spec:
         - name: custom-config
           configMap:
             name: {{ include "node-problem-detector.customConfig" . }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -93,3 +93,7 @@ env:
 #    valueFrom:
 #      fieldRef:
 #        fieldPath: metadata.name
+
+extraVolumes: []
+
+extraVolumeMounts: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows users to specify additional `volumes` / `volumeMounts` to mount in
the `DeamonSet` containers. This is useful for custom plugins scripts
that need to load additional data to run.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
