### PR TITLE
[stable/jenkins] Support multiple agents

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.11.4 Support multiple agents
+
+Move pod template configuration based on `agent` values to a new template `jenkins.casc.podTemplate`.
+
+Update README with an example of using additional `agent` values to configure kubernetes pod templates in the default configuration as code.
+
 ## 1.11.3
 
 Update the kubernetes plugin from 1.24.1 to 1.25.1 and grant 'watch' permission to 'events' which is required since this plugin version.

--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,11 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
-## 1.11.4 Support multiple agents
+## 1.12.0 Support additional agents
 
-Move pod template configuration based on `agent` values to a new template `jenkins.casc.podTemplate`.
+Add support for easy confingurations of additional agents which inherit values from the default agent.
+Also moved pod template configuration based on `agent` values to a new template `jenkins.casc.podTemplate`.
 
-Update README with an example of using additional `agent` values to configure kubernetes pod templates in the default configuration as code.
+Update README with an example of using additional agents to configure kubernetes pod templates in the default configuration as code.
 
 ## 1.11.3
 

--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -7,10 +7,7 @@ NOTE: The change log until version 1.5.7 is auto generated based on git commits.
 
 ## 1.12.0 Support additional agents
 
-Add support for easy confingurations of additional agents which inherit values from the default agent.
-Also moved pod template configuration based on `agent` values to a new template `jenkins.casc.podTemplate`.
-
-Update README with an example of using additional agents to configure kubernetes pod templates in the default configuration as code.
+Add support for easy configuration of additional agents which inherit values from `agent`.
 
 ## 1.11.3
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.11.3
+version: 1.11.4
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.11.4
+version: 1.12.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -193,7 +193,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload sent to a Jenkins webhooks, e.g. URL of a pull-request being built. To display such data as processed HTML instead of raw text set `master.enableRawHtmlMarkupFormatter` to true. This option requires installation of OWASP Markup Formatter Plugin (antisamy-markup-formatter). The plugin is **not** installed by default, please update `master.installPlugins`.
 
-### Jenkins Agent
+### Jenkins Agent(s)
 
 | Parameter                  | Description                                     | Default                |
 | -------------------------- | ----------------------------------------------- | ---------------------- |
@@ -201,10 +201,10 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.customJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
 | `agent.enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
 | `agent.image`              | Agent image name                                | `jenkins/jnlp-slave`   |
-| `agent.imagePullSecretName` | Agent image pull secret                         | Not set                |
+| `agent.imagePullSecretName` | Agent image pull secret                        | Not set                |
 | `agent.tag`                | Agent image tag                                 | `3.27-1`               |
 | `agent.privileged`         | Agent privileged container                      | `false`                |
-| `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}`|
+| `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}` |
 | `agent.volumes`            | Additional volumes                              | `[]`                   |
 | `agent.envVars`            | Environment variables for the agent Pod         | `[]`                   |
 | `agent.command`            | Executed command when side container starts     | Not set                |
@@ -214,10 +214,10 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.containerCap`       | Maximum number of agent                         | 10                     |
 | `agent.podName`            | Agent Pod base name                             | Not set                |
 | `agent.idleMinutes`        | Allows the Pod to remain active for reuse       | 0                      |
-| `agent.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set                |
+| `agent.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set  |
 | `agent.slaveConnectTimeout`| Timeout in seconds for an agent to be online    | 100                    |
-| `agent.podTemplates`       | Configures extra pod templates for the default kubernetes cloud | `{}`                              |
-
+| `agent.podTemplates`       | Configures extra pod templates for the default kubernetes cloud | `{}`   |
+| `additionalAgents`         | Configure additional agents which inherit settings from the default agent | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -484,6 +484,7 @@ Docs taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile:
 _Jenkins is run with user `jenkins`, uid = 1000. If you bind mount a volume from the host or a data container,ensure you use the same uid_
 
 ## Adding custom pod templates
+
 It is possible to add custom pod templates for the default configured kubernetes cloud.
 Add a key under `agent.podTemplates` for each pod template. Each key (prior to | character) is just a label, and can be any value.
 Keys are only used to give the pod template a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label
@@ -533,21 +534,6 @@ agent:
     limits:
       cpu: "1"
       memory: "2048Mi"
-  podTemplates:
-    additionalAgents: |-
-      {{- /* save .Values.agent */}}
-      {{- $agent := .Values.agent }}
-
-      {{- range $name, $additionalAgent := .Values.additionalAgents }}
-        {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
-        {{- $additionalAgent := merge $additionalAgent $agent }}
-        {{- /* set .Values.agent to $additionalAgent */}}
-        {{- $_ := set $.Values "agent" $additionalAgent }}
-        {{- include "jenkins.casc.podTemplate" $ | nindent 0 }}
-      {{- end }}
-
-      {{- /* restore .Values.agent */}}
-      {{- $_ := set .Values "agent" $agent }}
 
 # Each additional agent corresponds to a chart `agent` in terms of the configurable values.
 additionalAgents:

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -217,7 +217,7 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set  |
 | `agent.slaveConnectTimeout`| Timeout in seconds for an agent to be online    | 100                    |
 | `agent.podTemplates`       | Configures extra pod templates for the default kubernetes cloud | `{}`   |
-| `additionalAgents`         | Configure additional agents which inherit settings from the default agent | `{}` |
+| `additionalAgents`         | Configure additional agents which inherit values from `agent` | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -517,31 +517,26 @@ agent:
 ```
 Best reference is https://<jenkins_url>/configuration-as-code/reference#Cloud-kubernetes.
 
-### Adding pod templates using additional `agent` values (multiple agents)
+### Adding pod templates using additionalAgents
 
-Additional `agent` values may be used to configure kubernetes pod templates in the default configuration as code. For example,
+`additionalAgents` may be used to configure additional kubernetes pod templates. Each additional agent corresponds to `agent` in terms of the configurable values and inherits all values from `agent` so you only need to specify values which differ. For example,
+
 ```yaml
-master:
-  JCasC:
-    enabled: true
-    defaultConfig: true
-
 agent:
-  enabled: true
   podName: default
   customJenkinsLabels: default
+  # set resources for additional agents to inherit
   resources:
     limits:
       cpu: "1"
       memory: "2048Mi"
 
-# Each additional agent corresponds to a chart `agent` in terms of the configurable values.
 additionalAgents:
   maven:
     podName: maven
     customJenkinsLabels: maven
     # An example of overriding the jnlp container
-    sideContainerName: jnlp
+    # sideContainerName: jnlp
     image: jenkins/jnlp-agent-maven
     tag: latest
   python:

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -102,6 +102,19 @@ jenkins:
       {{- if .Values.agent.enabled }}
       templates:
       {{- include "jenkins.casc.podTemplate" . | nindent 8 }}
+    {{- if .Values.additionalAgents }}
+      {{- /* save .Values.agent */}}
+      {{- $agent := .Values.agent }}
+      {{- range $name, $additionalAgent := .Values.additionalAgents }}
+        {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
+        {{- $additionalAgent := merge $additionalAgent $agent }}
+        {{- /* set .Values.agent to $additionalAgent */}}
+        {{- $_ := set $.Values "agent" $additionalAgent }}
+        {{- include "jenkins.casc.podTemplate" $ | nindent 8 }}
+      {{- end }}
+      {{- /* restore .Values.agent */}}
+      {{- $_ := set .Values "agent" $agent }}
+    {{- end }}
       {{- if .Values.agent.podTemplates }}
         {{- range $key, $val := .Values.agent.podTemplates }}
           {{- tpl $val $ | nindent 8 }}

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -180,6 +180,93 @@ Returns kubernetes pod template configuration as code
   yamlMergeStrategy: "override"
 {{- end -}}
 
+{{/*
+Returns kubernetes pod template xml configuration
+*/}}
+{{- define "jenkins.xml.podTemplate" -}}
+<org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+  <inheritFrom></inheritFrom>
+  <name>{{ .Values.agent.podName }}</name>
+  <instanceCap>2147483647</instanceCap>
+  <idleMinutes>{{ .Values.agent.idleMinutes }}</idleMinutes>
+  <label>{{ .Release.Name }}-{{ .Values.agent.componentName }} {{ .Values.agent.customJenkinsLabels  | join " " }}</label>
+  <serviceAccount>{{ include "jenkins.serviceAccountAgentName" . }}</serviceAccount>
+  <nodeSelector>
+    {{- $local := dict "first" true }}
+    {{- range $key, $value := .Values.agent.nodeSelector }}
+      {{- if not $local.first }},{{- end }}
+      {{- $key }}={{ $value }}
+      {{- $_ := set $local "first" false }}
+    {{- end }}</nodeSelector>
+    <nodeUsageMode>NORMAL</nodeUsageMode>
+  <volumes>
+{{- range $index, $volume := .Values.agent.volumes }}
+    <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+{{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
+      <{{ $key }}>{{ $value }}</{{ $key }}>
+{{- end }}{{- end }}
+    </org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+{{- end }}
+  </volumes>
+  <containers>
+    <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+      <name>{{ .Values.agent.sideContainerName }}</name>
+{{- if .Values.agent.imageTag }}
+      <image>{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}</image>
+{{- else }}
+      <image>{{ .Values.agent.image }}:{{ .Values.agent.tag }}</image>
+{{- end }}
+{{- if .Values.agent.privileged }}
+      <privileged>true</privileged>
+{{- else }}
+      <privileged>false</privileged>
+{{- end }}
+      <alwaysPullImage>{{ .Values.agent.alwaysPullImage }}</alwaysPullImage>
+      <workingDir>/home/jenkins</workingDir>
+      <command>{{ .Values.agent.command }}</command>
+      <args>{{ .Values.agent.args }}</args>
+      <ttyEnabled>{{ .Values.agent.TTYEnabled }}</ttyEnabled>
+      # Resources configuration is a little hacky. This was to prevent breaking
+      # changes, and should be cleanned up in the future once everybody had
+      # enough time to migrate.
+      <resourceRequestCpu>{{.Values.agent.resources.requests.cpu}}</resourceRequestCpu>
+      <resourceRequestMemory>{{.Values.agent.resources.requests.memory}}</resourceRequestMemory>
+      <resourceLimitCpu>{{.Values.agent.resources.limits.cpu}}</resourceLimitCpu>
+      <resourceLimitMemory>{{.Values.agent.resources.limits.memory}}</resourceLimitMemory>
+      <envVars>
+        <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+          <key>JENKINS_URL</key>
+          <value>http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
+        </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+      </envVars>
+    </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+  </containers>
+  <envVars>
+{{- range $index, $var := .Values.agent.envVars }}
+    <org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
+      <key>{{ $var.name }}</key>
+      <value>{{ $var.value }}</value>
+    </org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
+{{- end }}
+  </envVars>
+  <annotations/>
+{{- if .Values.agent.imagePullSecretName }}
+  <imagePullSecrets>
+    <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+      <name>{{ .Values.agent.imagePullSecretName }}</name>
+    </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+  </imagePullSecrets>
+{{- else }}
+  <imagePullSecrets/>
+{{- end }}
+  <nodeProperties/>
+{{- if .Values.agent.yamlTemplate }}
+  <yaml>{{ tpl .Values.agent.yamlTemplate . | html | indent 4 | trim }}</yaml>
+{{- end }}
+  <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
+</org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+{{- end -}}
+
 {{- define "jenkins.kubernetes-version" -}}
   {{- if .Values.master.installPlugins -}}
     {{- range .Values.master.installPlugins -}}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -47,87 +47,20 @@ data:
           <name>kubernetes</name>
           <templates>
 {{- if .Values.agent.enabled }}
-            <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
-              <inheritFrom></inheritFrom>
-              <name>{{ .Values.agent.podName }}</name>
-              <instanceCap>2147483647</instanceCap>
-              <idleMinutes>{{ .Values.agent.idleMinutes }}</idleMinutes>
-              <label>{{ .Release.Name }}-{{ .Values.agent.componentName }} {{ .Values.agent.customJenkinsLabels  | join " " }}</label>
-              <serviceAccount>{{ include "jenkins.serviceAccountAgentName" . }}</serviceAccount>
-              <nodeSelector>
-                {{- $local := dict "first" true }}
-                {{- range $key, $value := .Values.agent.nodeSelector }}
-                  {{- if not $local.first }},{{- end }}
-                  {{- $key }}={{ $value }}
-                  {{- $_ := set $local "first" false }}
-                {{- end }}</nodeSelector>
-                <nodeUsageMode>NORMAL</nodeUsageMode>
-              <volumes>
-{{- range $index, $volume := .Values.agent.volumes }}
-                <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
-{{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
-                  <{{ $key }}>{{ $value }}</{{ $key }}>
-{{- end }}{{- end }}
-                </org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
-{{- end }}
-              </volumes>
-              <containers>
-                <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
-                  <name>{{ .Values.agent.sideContainerName }}</name>
-{{- if .Values.agent.imageTag }}
-                  <image>{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}</image>
-{{- else }}
-                  <image>{{ .Values.agent.image }}:{{ .Values.agent.tag }}</image>
-{{- end }}
-{{- if .Values.agent.privileged }}
-                  <privileged>true</privileged>
-{{- else }}
-                  <privileged>false</privileged>
-{{- end }}
-                  <alwaysPullImage>{{ .Values.agent.alwaysPullImage }}</alwaysPullImage>
-                  <workingDir>/home/jenkins</workingDir>
-                  <command>{{ .Values.agent.command }}</command>
-                  <args>{{ .Values.agent.args }}</args>
-                  <ttyEnabled>{{ .Values.agent.TTYEnabled }}</ttyEnabled>
-                  # Resources configuration is a little hacky. This was to prevent breaking
-                  # changes, and should be cleanned up in the future once everybody had
-                  # enough time to migrate.
-                  <resourceRequestCpu>{{.Values.agent.resources.requests.cpu}}</resourceRequestCpu>
-                  <resourceRequestMemory>{{.Values.agent.resources.requests.memory}}</resourceRequestMemory>
-                  <resourceLimitCpu>{{.Values.agent.resources.limits.cpu}}</resourceLimitCpu>
-                  <resourceLimitMemory>{{.Values.agent.resources.limits.memory}}</resourceLimitMemory>
-                  <envVars>
-                    <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
-                      <key>JENKINS_URL</key>
-                      <value>http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
-                    </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
-                  </envVars>
-                </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
-              </containers>
-              <envVars>
-{{- range $index, $var := .Values.agent.envVars }}
-                <org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
-                  <key>{{ $var.name }}</key>
-                  <value>{{ $var.value }}</value>
-                </org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
-{{- end }}
-              </envVars>
-              <annotations/>
-{{- if .Values.agent.imagePullSecretName }}
-              <imagePullSecrets>
-                <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
-                  <name>{{ .Values.agent.imagePullSecretName }}</name>
-                </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
-              </imagePullSecrets>
-{{- else }}
-              <imagePullSecrets/>
-{{- end }}
-              <nodeProperties/>
-{{- if .Values.agent.yamlTemplate }}
-              <yaml>{{ tpl .Values.agent.yamlTemplate . | html | indent 4 | trim }}</yaml>
-{{- end }}
-              <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
-            </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+  {{- include "jenkins.xml.podTemplate" . | nindent 12 }}
+  {{- if .Values.additionalAgents }}
+    {{- /* save .Values.agent */}}
+    {{- $agent := .Values.agent }}
+    {{- range $name, $additionalAgent := .Values.additionalAgents }}
+      {{- /* merge original .Values.agent into additional agent to ensure it at least has the default values */}}
+      {{- $additionalAgent := merge $additionalAgent $agent }}
+      {{- /* set .Values.agent to $additionalAgent */}}
+      {{- $_ := set $.Values "agent" $additionalAgent }}
+      {{- include "jenkins.xml.podTemplate" $ | nindent 12 }}
+    {{- end }}
+    {{- /* restore .Values.agent */}}
+    {{- $_ := set .Values "agent" $agent }}
+  {{- end }}
 {{- end -}}
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -494,6 +494,26 @@ agent:
   #          resourceRequestMemory: "512Mi"
   #          resourceLimitCpu: "1"
   #          resourceLimitMemory: "1024Mi"
+
+# Here you can add additional agents
+# They inherit all values from default agent so you only need to specify values which differ
+additionalAgents: {}
+#  maven:
+#    podName: maven
+#    customJenkinsLabels: maven
+#    # An example of overriding the jnlp container
+#    sideContainerName: jnlp
+#    image: jenkins/jnlp-agent-maven
+#    tag: latest
+#  python:
+#    podName: python
+#    customJenkinsLabels: python
+#    sideContainerName: python
+#    image: python
+#    tag: "3"
+#    command: "/bin/sh -c"
+#    args: "cat"
+#    TTYEnabled: true
 persistence:
   enabled: true
   ## A manually managed Persistent Volume and Claim

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -496,13 +496,13 @@ agent:
   #          resourceLimitMemory: "1024Mi"
 
 # Here you can add additional agents
-# They inherit all values from default agent so you only need to specify values which differ
+# They inherit all values from `agent` so you only need to specify values which differ
 additionalAgents: {}
 #  maven:
 #    podName: maven
 #    customJenkinsLabels: maven
 #    # An example of overriding the jnlp container
-#    sideContainerName: jnlp
+#    # sideContainerName: jnlp
 #    image: jenkins/jnlp-agent-maven
 #    tag: latest
 #  python:
@@ -514,6 +514,7 @@ additionalAgents: {}
 #    command: "/bin/sh -c"
 #    args: "cat"
 #    TTYEnabled: true
+
 persistence:
   enabled: true
   ## A manually managed Persistent Volume and Claim


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Add support for easy configuration of additional agents which inherit values from `agent`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes helm#20870

#### Special notes for your reviewer:
Moved the pod template JCasC to a new template `jenkins.casc.podTemplate`. `name` fields moved to the top so they stand out. See http://mergely.com/2K5B28FF/?ws=1

Moved the pod template xml configuration to a new template `jenkins.xml.podTemplate`. See http://mergely.com/UNMhX7xx/?ws=1

I chose not to make use of either of the kubernetes plugin casc fields related to agent inheritance.

`defaultsProviderTemplate` - the agent from which all other agents inherit configuration. Merging `agent` into the additional agents in the chart allows all agents to make use of the chart's default configuration for `agent`. To wait for the kubernetes plugin to merge the values at runtime would mean each agent would need to set `sideContainerName` (so container values could be inherited) as well as set any fields which get assigned a default value when nil and thus aren't eligible for inheritance (e.g. `command` and `workingDir`).

`inheritFrom` - indicates from which agent this agent should inherit configuration. I thought an `agent.inheritFrom` field would look out of place in the chart but perhaps this could be added in a future PR.

# `helm template` tests
I placed the following in stable/jenkins/agent-values.yaml
```yaml
agent:
  podName: default
  customJenkinsLabels: default
  # set resources for additional agents to inherit
  resources:
    limits:
      cpu: "1"
      memory: "2048Mi"

# Each additional agent corresponds to a chart `agent` in terms of the configurable values.
additionalAgents:
  maven:
    podName: maven
    customJenkinsLabels: maven
    # An example of overriding the jnlp container
    # sideContainerName: jnlp
    image: jenkins/jnlp-agent-maven
    tag: latest
  python:
    podName: python
    customJenkinsLabels: python
    sideContainerName: python
    image: python
    tag: "3"
    command: "/bin/sh -c"
    args: "cat"
    TTYEnabled: true
```
for helm 2 use `--execute` instead of `--show-only`
## default JCasC with auto-reload (jcasc-config.yaml)
### single agent
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true
```
### multiple agents
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--values stable/jenkins/agent-values.yaml
```
## default JCasC NO auto-reload (config.yaml)
### single agent
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--set master.enableXmlConfig=false \
--set master.sidecars.configAutoReload.enabled=false \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true
```
### multiple agents
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--set master.enableXmlConfig=false \
--set master.sidecars.configAutoReload.enabled=false \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--values stable/jenkins/agent-values.yaml
```
## XML configuration (config.yaml)
### single agent
```
helm template stable/jenkins \
--show-only templates/config.yaml
```
### multiple agents
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--values stable/jenkins/agent-values.yaml
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
