### PR TITLE
[incubator/sparkoperator] roll back webhook cleanup job from being a …

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.6.9
+version: 0.6.11
 appVersion: v1beta2-1.1.1-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -42,6 +42,12 @@ rules:
   resources: ["podgroups"]
   verbs: ["*"]
   {{- end }}
+  {{ if .Values.enableWebhook }}
+  # This permission is granted only if the webhook is enabled
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["delete"]
+  {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -37,5 +37,13 @@ spec:
           -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
           -H \"Accept: application/json\" \
           -H \"Content-Type: application/json\" \
-          https://kubernetes.default.svc/api/v1/namespaces/{{ .Release.Namespace }}/secrets/spark-webhook-certs"
+          https://kubernetes.default.svc/api/v1/namespaces/{{ .Release.Namespace }}/secrets/spark-webhook-certs \
+          && \
+          curl -ik \
+          -X DELETE \
+          -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
+          -H \"Accept: application/json\" \
+          -H \"Content-Type: application/json\" \
+          --data \"{\\\"kind\\\":\\\"DeleteOptions\\\",\\\"apiVersion\\\":\\\"batch/v1\\\",\\\"propagationPolicy\\\":\\\"Foreground\\\"}\" \
+          https://kubernetes.default.svc/apis/batch/v1/namespaces/{{ .Release.Namespace }}/jobs/{{ include "sparkoperator.fullname" . }}-webhook-init"
 {{ end }}

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -4,9 +4,6 @@ kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-webhook-init
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}


### PR DESCRIPTION
…hook

Signed-off-by: Julien Dumazert <julien.dumazert@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

PR #20742 has turned the webhook init job into a Helm hook.
**This caused the chart with webhook enabled to be impossible to install, as reported by several people.**
Please see this [thread](https://github.com/helm/charts/pull/20742#discussion_r395997748).

##### In-depth explanation of the bug

The init job creates a secret mounted into the spark-operator pod.
So the job must be created before the spark-operator deployment.

the init job requires permissions granted by the spark-operator service account.
So the job must be created after the spark-operator service account.

This clearly shows that the init cannot be a Helm hook, since Helm hooks are either pre-install or post-install.

##### What's kept from PR #20742 ?

PR #20742 claims that it is an issue that the init job is not rerun when running `helm upgrade`.
I am not sure why this is an issue, as the webhook secret can be reused as is over upgrades.

Nevertheless, I've assumed that the contributor had their reasons, so I kept this requirement: the init job must be rerun upon upgrade.

##### Proposed solution

The init job is again part of the chart, and not a Helm hook anymore.
This way, it is run after the spark-operator SA is created, and before the spark-operator deployment is created.

So that the init job is rerun upon upgrade, the webhook cleanup job is modified to delete the init job upon uninstall and upgrade.
For this to work, I had to grant additional permissions to the spark-operator service account (the permission to delete jobs).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
