### PR TITLE
[stable/superset] Make it possible to configure start up

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.9
+version: 1.1.10
 appVersion: "0.35.2"
 keywords:
 - bi

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -50,6 +50,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initFile`                 | Content of init shell script                    | See [values.yaml](./values.yaml)                             |
 | `replicas`                 | Number of replicas of superset                  | `1`                                                          |
 | `extraEnv`                 | Extra environment variables passed to pods      | `{}`                                                         |
+| `extraArguments`           | Extra arguments passed to init_superset.sh      | `[]`                                                         |
 | `extraEnvFromSecret`       | The name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
 | `deploymentAnnotations`              | Key Value pairs of deployment level annotations. Useful for 3rd party integrations | `{}` |
 | `persistence.enabled`      | Enable persistence                              | `false`                                                      |

--- a/stable/superset/templates/deployment.yaml
+++ b/stable/superset/templates/deployment.yaml
@@ -50,7 +50,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/bin/env"]
-          args: ["python", "/usr/local/bin/gunicorn", "-b", "0.0.0.0:8088", "--limit-request-line", "0", "--limit-request-field_size", "0", "superset:app"]
+          args:
+          - bash
+          - /home/superset/init_superset.sh
+          {{- range .Values.extraArguments }}
+          - {{ . }}
+          {{- end }}
           volumeMounts:
             - name: superset-configs
               mountPath: /home/superset

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -13,8 +13,19 @@ image:
   pullSecrets: []
 
 initFile: |-
-  /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
-  superset run
+  if [ "$1" == "development-mode" ]; then
+    /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
+    superset run
+  elif [ "$1" == "production-mode" ]; then
+    gunicorn -b 0.0.0.0:8088 \
+      --limit-request-line 0 \
+      --limit-request-field_size 0 \
+      --timeout 300 superset:app
+  else
+    echo "You need to specify which mode to start in by setting production-mode"
+    echo "or development-mode in extraArguments."
+    exit 1
+  fi
 
 configFile: |-
   #---------------------------------------------------------
@@ -57,6 +68,11 @@ extraConfigFiles: {}
 ## Extra environment variables that will be passed onto deployment pod
 ##
 extraEnv: {}
+
+## Extra arguments that will be passed to init_superset.sh
+## For the sample initFile this is development-mode or production-mode
+extraArguments:
+- production-mode
 
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for secret keys, etc


### PR DESCRIPTION
#### What this PR does / why we need it:
Superset used to start by running init_superset.sh which has configurable
content. This commit adds that possibility back together with the
option to pass additional arguments to that script for configuring
start up.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #21421 

#### Special notes for your reviewer:
@MarcusSorealheis  This removes the 'production' gunicorn start up in favor of the development server 'superset run' in init_superset.sh, should init_superset.sh be changed to use gunicorn? It is possible to add a toggle for prod/dev as well so you don't accidentally create a user with a bad password (Could randomize the password if we want to do changes there as well).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
