### PR TITLE
[stable/prometheus-pushgateway] configureable deployment strategy

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `ingress.tls`                     | Ingress TLS configuration                                                                                                     | `[]`                              |
 | `resources`                       | CPU/Memory resource requests/limits                                                                                           | `{}`                              |
 | `replicaCount`                    | Number of replicas                                                                                                            | `1`                               |
+| `strategy`                        | Deployment strategy                                                                                                           | `{ "type": "Recreate" }`          |
 | `service.type`                    | Service type                                                                                                                  | `ClusterIP`                       |
 | `service.port`                    | The service port                                                                                                              | `9091`                            |
 | `service.nodePort`                | The optional service node port when `service.type` is `NodePort`                                                              | ``                                |

--- a/stable/prometheus-pushgateway/templates/deployment.yaml
+++ b/stable/prometheus-pushgateway/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "prometheus-pushgateway.name" . }}

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -135,6 +135,10 @@ serviceMonitor:
 # If not set then a PodDisruptionBudget will not be created
 podDisruptionBudget: {}
 
+# Deployment Strategy type
+strategy:
+  type: Recreate
+
 persistentVolume:
   ## If true, pushgateway will create/use a Persistent Volume Claim
   ## If false, use emptyDir


### PR DESCRIPTION
#### What this PR does / why we need it:
When the pushgateway is configured to use a PV for storage and the PV does not allow multi attach, updates can't be applied because the newly created pod can never attach the storage volume and thus never starts. The old pod never gets deleted (and manually deleting the old pod also doesn't work in all cases). I changed the default behavior because I don't consider this a relevant change in behavior for the pushgateway.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
