### PR TITLE
[stable/datadog] fix: DD_TAGS including [] due to quote instead of join

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.1.1
+version: 2.1.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -18,7 +18,7 @@
 {{- end }}
 {{- if .Values.datadog.tags }}
 - name: DD_TAGS
-  value: {{ .Values.datadog.tags | quote }}
+  value: {{ .Values.datadog.tags | join " " }}
 {{- end }}
 - name: KUBERNETES
   value: "yes"


### PR DESCRIPTION
#### What this PR does / why we need it:
According to https://docs.datadoghq.com/agent/docker/?tab=standard this should be formatted as `key1:value1 key2:value2` not `[key1:value1 key2:value2]`.

#### Which issue this PR fixes
  - fixes #21663 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
