### PR TITLE
[stable/mongodb-replicaset] feature: Add support for secret annotations when auth is enabled

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.14.1
+version: 3.15.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `auth.metricsPassword`              | MongoDB clusterMonitor password                                           | ``                                                  |
 | `auth.existingMetricsSecret`        | If set, and existing secret with this name is used for the metrics user   | ``                                                  |
 | `auth.existingAdminSecret`          | If set, and existing secret with this name is used for the admin user     | ``                                                  |
+| `auth.secretAnnotations`            | Annotations to be added to the secret if auth is enabled                  | `{}`                                                |
 | `serviceAnnotations`                | Annotations to be added to the service                                    | `{}`                                                |
 | `configmap`                         | Content of the MongoDB config file                                        | ``                                                  |
 | `initMongodStandalone`              | If set, initContainer executes script in standalone mode                  | ``                                                  |

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -91,7 +91,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `auth.metricsPassword`              | MongoDB clusterMonitor password                                           | ``                                                  |
 | `auth.existingMetricsSecret`        | If set, and existing secret with this name is used for the metrics user   | ``                                                  |
 | `auth.existingAdminSecret`          | If set, and existing secret with this name is used for the admin user     | ``                                                  |
-| `auth.secretAnnotations`            | Annotations to be added to the secret if auth is enabled                  | `{}`                                                |
+| `secretAnnotations`                 | Annotations to be added to the secret if auth is enabled                  | `{}`                                                |
 | `serviceAnnotations`                | Annotations to be added to the service                                    | `{}`                                                |
 | `configmap`                         | Content of the MongoDB config file                                        | ``                                                  |
 | `initMongodStandalone`              | If set, initContainer executes script in standalone mode                  | ``                                                  |

--- a/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
@@ -10,6 +10,10 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
+{{- if .Values.auth.secretAnnotations }}
+  annotations:
+{{ toYaml .Values.auth.secretAnnotations | indent 4 }}
+{{- end }}
   name: {{ template "mongodb-replicaset.adminSecret" . }}
   namespace: {{ template "mongodb-replicaset.namespace" . }}
 type: Opaque

--- a/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
@@ -10,9 +10,9 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
-{{- if .Values.auth.secretAnnotations }}
+{{- if .Values.secretAnnotations }}
   annotations:
-{{ toYaml .Values.auth.secretAnnotations | indent 4 }}
+{{ toYaml .Values.secretAnnotations | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.adminSecret" . }}
   namespace: {{ template "mongodb-replicaset.namespace" . }}

--- a/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
@@ -10,6 +10,10 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
+{{- if .Values.auth.secretAnnotations }}
+  annotations:
+{{ toYaml .Values.auth.secretAnnotations | indent 4 }}
+{{- end }}
   name: {{ template "mongodb-replicaset.keySecret" . }}
   namespace: {{ template "mongodb-replicaset.namespace" . }}
 type: Opaque

--- a/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
@@ -10,9 +10,9 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
-{{- if .Values.auth.secretAnnotations }}
+{{- if .Values.secretAnnotations }}
   annotations:
-{{ toYaml .Values.auth.secretAnnotations | indent 4 }}
+{{ toYaml .Values.secretAnnotations | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.keySecret" . }}
   namespace: {{ template "mongodb-replicaset.namespace" . }}

--- a/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
@@ -10,9 +10,9 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
-{{- if .Values.auth.secretAnnotations }}
+{{- if .Values.secretAnnotations }}
   annotations:
-{{ toYaml .Values.auth.secretAnnotations | indent 4 }}
+{{ toYaml .Values.secretAnnotations | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.metricsSecret" . }}
   namespace: {{ template "mongodb-replicaset.namespace" . }}

--- a/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
@@ -10,6 +10,10 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
+{{- if .Values.auth.secretAnnotations }}
+  annotations:
+{{ toYaml .Values.auth.secretAnnotations | indent 4 }}
+{{- end }}
   name: {{ template "mongodb-replicaset.metricsSecret" . }}
   namespace: {{ template "mongodb-replicaset.namespace" . }}
 type: Opaque

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -31,7 +31,6 @@ auth:
   # metricsUser: metrics
   # metricsPassword: password
   # key: keycontent
-  secretAnnotations: {}
 
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -147,6 +146,9 @@ persistentVolume:
     - ReadWriteOnce
   size: 10Gi
   annotations: {}
+
+# Annotations to be added to the secrets
+secretAnnotations: {}
 
 # Annotations to be added to the service
 serviceAnnotations: {}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -31,6 +31,7 @@ auth:
   # metricsUser: metrics
   # metricsPassword: password
   # key: keycontent
+  secretAnnotations: {}
 
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
To use *mongodb-replicaset* chart with `auth.enabled` is set and not adding the username/password credentials to `values.yaml`, kubernetes secret is created outside the chart and being referenced by using `auth.existingAdminSecret` and `auth.existingKeySecret `.

Started experimenting with [vault-bank](https://banzaicloud.com/docs/bank-vaults/mutating-webhook/) for injecting secrets from HashiCorp vault to kubernetes pods/secrets and this feature will be really useful.

For users who do use vault-bank or any other dynamic secret injector, adding secret annotations when `auth` is enabled will eliminate creating secret out of the helm chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
