### PR TITLE
[stable/nginx-ingress] Adding ability to specify an override value for the release label

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.34.4
+version: 1.35.0
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.34.3
+version: 1.34.4
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -225,6 +225,7 @@ Parameter | Description | Default
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
 `tcp` | TCP service key:value pairs. The value is evaluated as a template. | `{}`
 `udp` | UDP service key:value pairs The value is evaluated as a template. | `{}`
+`releaseLabelOverride` | If provided, the value will be used as the `release` label instead of .Release.Name | `""`
 
 These parameters can be passed via Helm's `--set` option
 ```console

--- a/stable/nginx-ingress/templates/NOTES.txt
+++ b/stable/nginx-ingress/templates/NOTES.txt
@@ -22,7 +22,7 @@ It may take a few minutes for the LoadBalancer IP to be available.
 You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
 {{- else if contains "ClusterIP"  .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ template "nginx-ingress.releaseLabel" . }}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to access your application."
 {{- end }}

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -38,6 +38,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
+{{/*
+Allow for the ability to override the release name used as a label in many places.
+*/}}
+{{- define "nginx-ingress.releaseLabel" -}}
+{{- .Values.releaseLabelOverride | default .Release.Name | trunc 63 -}}
+{{- end -}}
+
 {{/*
 Construct the path for the publish-service.
 

--- a/stable/nginx-ingress/templates/addheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/addheaders-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-add-headers
 data:
 {{ toYaml .Values.controller.addHeaders | indent 2 }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 rules:
   - apiGroups:
       - admissionregistration.k8s.io

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
@@ -29,7 +29,7 @@ spec:
         chart: {{ template "nginx-ingress.chart" . }}
         component: "{{ .Values.controller.name }}"
         heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
+        release: {{ template "nginx-ingress.releaseLabel" . }}
     spec:
       {{- if .Values.controller.admissionWebhooks.patch.priorityClassName }}
       priorityClassName: {{ .Values.controller.admissionWebhooks.patch.priorityClassName }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
@@ -29,7 +29,7 @@ spec:
         chart: {{ template "nginx-ingress.chart" . }}
         component: "{{ .Values.controller.name }}"
         heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
+        release: {{ template "nginx-ingress.releaseLabel" . }}
     spec:
       {{- if .Values.controller.admissionWebhooks.patch.priorityClassName }}
       priorityClassName: {{ .Values.controller.admissionWebhooks.patch.priorityClassName }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/psp.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/psp.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/role.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/role.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 rules:
   - apiGroups:
       - ""

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 {{- end }}

--- a/stable/nginx-ingress/templates/admission-webhooks/validating-webhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/validating-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "admission-webhook"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-admission
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io

--- a/stable/nginx-ingress/templates/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
 {{- if .Values.controller.addHeaders }}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: controller
   name: {{ template "nginx-ingress.controller.fullname" . }}
   annotations:    
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.controller.useComponentLabel }}
       app.kubernetes.io/component: controller
     {{- end }}
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        release: {{ .Release.Name }}
+        release: {{ template "nginx-ingress.releaseLabel" . }}
         app.kubernetes.io/component: controller
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8}}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: controller
   name: {{ template "nginx-ingress.controller.fullname" . }}
   annotations:
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.controller.useComponentLabel }}
       app.kubernetes.io/component: controller
     {{- end }}
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        release: {{ .Release.Name }}
+        release: {{ template "nginx-ingress.releaseLabel" . }}
         app.kubernetes.io/component: controller
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   scaleTargetRef:

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
 spec:
 {{- if not .Values.controller.metrics.service.omitClusterIP }}
@@ -41,7 +41,7 @@ spec:
       targetPort: metrics
   selector:
     app: {{ template "nginx-ingress.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: controller
   type: "{{ .Values.controller.metrics.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -7,13 +7,13 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     app.kubernetes.io/component: controller
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ template "nginx-ingress.releaseLabel" . }}
       {{- if .Values.controller.useComponentLabel }}
       app.kubernetes.io/component: controller
       {{- end }}

--- a/stable/nginx-ingress/templates/controller-prometheusrules.yaml
+++ b/stable/nginx-ingress/templates/controller-prometheusrules.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.controller.metrics.prometheusRule.additionalLabels }}
 {{ toYaml .Values.controller.metrics.prometheusRule.additionalLabels | indent 4 }}
     {{- end }}

--- a/stable/nginx-ingress/templates/controller-psp.yaml
+++ b/stable/nginx-ingress/templates/controller-psp.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 spec:
   allowedCapabilities:
     - NET_BIND_SERVICE

--- a/stable/nginx-ingress/templates/controller-role.yaml
+++ b/stable/nginx-ingress/templates/controller-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/nginx-ingress/templates/controller-rolebinding.yaml
+++ b/stable/nginx-ingress/templates/controller-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -16,7 +16,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
 {{- if not .Values.controller.service.omitClusterIP }}
@@ -88,7 +88,7 @@ spec:
   {{- end }}
   selector:
     app: {{ template "nginx-ingress.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: controller
   type: "{{ .Values.controller.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/controller-serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.serviceAccountName" . }}
 {{- end -}}

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
@@ -34,5 +34,5 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       component: "{{ .Values.controller.name }}"
-      release: {{ .Release.Name }}
+      release: {{ template "nginx-ingress.releaseLabel" . }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -13,7 +13,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-admission
 spec:
 {{- if not .Values.controller.admissionWebhooks.service.omitClusterIP }}
@@ -38,7 +38,7 @@ spec:
       targetPort: webhook
   selector:
     app: {{ template "nginx-ingress.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: controller
   type: "{{ .Values.controller.admissionWebhooks.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -6,14 +6,14 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: default-backend
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.defaultBackend.useComponentLabel }}
       app.kubernetes.io/component: default-backend
     {{- end }}
@@ -29,7 +29,7 @@ spec:
     {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        release: {{ .Release.Name }}
+        release: {{ template "nginx-ingress.releaseLabel" . }}
         app.kubernetes.io/component: default-backend
         {{- if .Values.defaultBackend.podLabels }}
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -7,13 +7,13 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ template "nginx-ingress.releaseLabel" . }}
       component: "{{ .Values.defaultBackend.name }}"
   minAvailable: {{ .Values.defaultBackend.minAvailable }}
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-psp.yaml
+++ b/stable/nginx-ingress/templates/default-backend-psp.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/stable/nginx-ingress/templates/default-backend-role.yaml
+++ b/stable/nginx-ingress/templates/default-backend-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-backend
 rules:
   - apiGroups:      ['{{ template "podSecurityPolicy.apiGroup" . }}']

--- a/stable/nginx-ingress/templates/default-backend-rolebinding.yaml
+++ b/stable/nginx-ingress/templates/default-backend-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-backend
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -13,7 +13,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
 {{- if not .Values.defaultBackend.service.omitClusterIP }}
@@ -39,7 +39,7 @@ spec:
       targetPort: http
   selector:
     app: {{ template "nginx-ingress.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: default-backend
   type: "{{ .Values.defaultBackend.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/default-backend-serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.defaultBackend.serviceAccountName" . }}
 {{- end }}

--- a/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
 data:
 {{- if .Values.controller.proxySetHeaders }}

--- a/stable/nginx-ingress/templates/tcp-configmap.yaml
+++ b/stable/nginx-ingress/templates/tcp-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-tcp
 data:
 {{ tpl (toYaml .Values.tcp) . | indent 2 }}

--- a/stable/nginx-ingress/templates/udp-configmap.yaml
+++ b/stable/nginx-ingress/templates/udp-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.fullname" . }}-udp
 data:
 {{ tpl (toYaml .Values.udp) . | indent 2 }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -534,6 +534,9 @@ defaultBackend:
 
   priorityClassName: ""
 
+# If provided, the value will be used as the `release` label instead of .Release.Name
+releaseLabelOverride: ""
+
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
   create: true


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Provides the ability to override the `release` label that is used throughout the chart.  Which is normally set to `.Release.Name`.  The ability to override this parameter is allowing me to deploy a pair of DaemonSets with two helm releases in the same namespace.  Allowing a more redundant setup when using external load balancers and service configuration that benefit from having guaranteed multiple pods per node.

#### Which issue this PR fixes
  - fixes # 17366

#### Special notes for your reviewer:

Spoke with @ChiefAlexander via Slack on 3/31 to discuss a couple different approaches, this was the one that bubbled to the top during the discussion.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
