### PR TITLE
[stable/grafana]: Only replace variable datasources in shared dashboards

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.11
+version: 5.0.12
 appVersion: 6.7.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -61,7 +61,7 @@ data:
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
       {{ end }}
-    {{- if $value.url -}}{{ $value.url }}{{- else -}} https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download{{- end -}}{{ if $value.datasource }}| sed 's|\"datasource\":[^,]*|\"datasource\": \"{{ $value.datasource }}\"|g'{{ end }}{{- if $value.b64content -}} | base64 -d {{- end -}} \
+    {{- if $value.url -}}{{ $value.url }}{{- else -}} https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download{{- end -}}{{ if $value.datasource }}| sed 's|\"datasource\": *\"\$[^,]*|\"datasource\": \"{{ $value.datasource }}\"|g'{{ end }}{{- if $value.b64content -}} | base64 -d {{- end -}} \
     > /var/lib/grafana/dashboards/{{ $provider }}/{{ $key }}.json
       {{- end -}}
     {{- end }}


### PR DESCRIPTION
@zanhsieh @rtluckie @maorfr

#### What this PR does / why we need it:
Avoid replacing hard-coded datasource entries in shared dashboards on
downloading them. This is the root causes for #21541, where the
following data source is also replace:

```json
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
```

To avoid this situation, this commit adds the requirement that the
datasource entry to replace starts with a dollar sign as the first
character in the quoted string region. This was the case for all
dashboards that I have checked.

#### Which issue this PR fixes
  - fixes #21541 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
