### PR TITLE
[stable/oauth2-proxy] use proper scope in usage of secret name helper

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 2.4.0
+version: 2.4.1
 apiVersion: v1
 appVersion: 5.1.0
 home: https://pusher.github.io/oauth2_proxy/

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -149,7 +149,7 @@ spec:
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
       - name: google-secret
         secret:
-          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.secretName" . }}{{ end }}
+          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.secretName" $ }}{{ end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

`{{- with .Values.config.google }}` on L143 changes scope here and when _not_ using an existing secret, the template oauth2-proxy.secretName is invoked with the wrong context (`.` or `.Values.config.google`)

The result: 

```
› helm template . --set='config.google.serviceAccountJson=abc' --set='config.google.adminEmail=jbielick@gmail.com'
Error: render error in "oauth2-proxy/templates/deployment.yaml": template: oauth2-proxy/templates/_helpers.tpl:38:14: executing "oauth2-proxy.secretName" at <.Values.config.existingSecret>: nil pointer evaluating interface {}.config
```

It should be invoked with the global context so it can access `.Values`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
