### PR TITLE
[stable/stackdriver-exporter] update k8s deployement api version

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.2.2
+version: 1.2.3
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}


### PR DESCRIPTION
As of v1.16, k8s won't accept a deployment with apps/v1beta1
or apps/v1beta2 apiVersion. The accepted apiVersion is apps/v1
that is available since k8s v1.9.

See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16

@apenney 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
