### PR TITLE
[stable/rethinkdb] Add nodeSelector for both the proxy and cluster

### DIFF
--- a/stable/rethinkdb/Chart.yaml
+++ b/stable/rethinkdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rethinkdb
 description: The open-source database for the realtime web
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.1.0
 keywords:
 - rethinkdb

--- a/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "rethinkdb.serviceAccountName" . }}
+      {{- if .Values.cluster.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.cluster.nodeSelector | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-cluster
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
@@ -29,6 +29,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "rethinkdb.serviceAccountName" . }}
+      {{- if .Values.proxy.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.proxy.nodeSelector | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-proxy
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/rethinkdb/values.yaml
+++ b/stable/rethinkdb/values.yaml
@@ -7,6 +7,7 @@ image:
 # RethinkDB Cluster Config
 cluster:
   replicas: 3
+  nodeSelector: {}
   resources: {}
     # limits:
     #   cpu: 100m
@@ -54,6 +55,7 @@ cluster:
 # RethinkDB Proxy Config
 proxy:
   replicas: 1
+  nodeSelector: {}
   resources: {}
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
This enables a nodeSelector for both the proxy and cluster.

@meenie 

#### Is this a new chart
No

#### What this PR does / why we need it:
Adds the ability to use the `nodeSelector` paradigm to limit what nodes RethinkDB will be deployed to

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
