### PR TITLE
[stable/rethinkdb] Implement storageClass

### DIFF
--- a/stable/rethinkdb/Chart.yaml
+++ b/stable/rethinkdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rethinkdb
 description: The open-source database for the realtime web
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.1.0
 keywords:
 - rethinkdb

--- a/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
@@ -99,6 +99,13 @@ spec:
       {{- range .Values.cluster.persistentVolume.accessModes }}
         - {{ . | quote }}
       {{- end }}
+      {{- if .Values.cluster.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.cluster.persistentVolume.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ .Values.cluster.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.cluster.persistentVolume.size | quote }}


### PR DESCRIPTION
The `cluster.persistentVolume.storageClass` was never used and would never
properly populate the `volumeClaimTemplate`.

This also adds the convention that "-" will set the null storage class
(as this is a pretty common convention).

@meenie 

#### Is this a new chart
No

#### What this PR does / why we need it:
The `cluster.persistentVolume.storageClass` was documented but never used/implemented.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
