### PR TITLE
[anchore/stable] fix environment setting from existingSecret

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: anchore-engine
-version: 1.5.0
+version: 1.5.1
 appVersion: 0.7.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -91,7 +91,7 @@ spec:
         - name: ANCHORE_CLI_PASS
           valueFrom:
             secretKeyRef:
-              name: {{ include "anchore-engine.fullname" . }}
+              name: {{ default (include "anchore-engine.fullname" .) .Values.anchoreGlobal.existingSecret }}
               key: ANCHORE_ADMIN_PASSWORD
         ports:
         - containerPort: {{ .Values.anchoreApi.service.port }}


### PR DESCRIPTION
Signed-off-by: Bradley Massey <massey.bradley@gmail.com>

#### What this PR does / why we need it:

Hi @Btodhunter - this fixes a small issue from one of my previous pull requests reported in #21763 to get the `ANCHORE_CLI_PASS` environment variable from an `anchoreGlobal.existingSecret`.

#### Which issue this PR fixes
  - fixes #21763 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
