### PR TITLE
[stable/prometheus-operator] Add support for creating a Service and Ingress for each Alertmanager replica

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.12.8
+version: 8.12.9
 appVersion: 0.37.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -257,6 +257,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.ingressPerReplica.labels` | Prometheus per replica Ingress additional labels | `{}` |
 | `prometheus.ingressPerReplica.paths` | Prometheus per replica Ingress paths | `[]` |
 | `prometheus.ingressPerReplica.tlsSecretName` | Secret name containing the TLS certificate for Prometheus per replica ingress | `[]` |
+| `prometheus.ingressPerReplica.tlsSecretPerReplica.enabled` | If true, create an secret for TLS certificate for each Ingress | `false` |
+| `prometheus.ingressPerReplica.tlsSecretPerReplica.prefix` | Secret name prefix | `""` |
 | `prometheus.podDisruptionBudget.enabled` | If true, create a pod disruption budget for prometheus pods. The created resource cannot be modified once created - it must be deleted to perform a change | `false` |
 | `prometheus.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""` |
 | `prometheus.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1` |
@@ -387,6 +389,15 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.ingress.labels` | Alertmanager Ingress additional labels | `{}` |
 | `alertmanager.ingress.paths` | Alertmanager Ingress paths | `[]` |
 | `alertmanager.ingress.tls` | Alertmanager Ingress TLS configuration (YAML) | `[]` |
+| `alertmanager.ingressPerReplica.annotations` | Alertmanager pre replica Ingress annotations | `{}` |
+| `alertmanager.ingressPerReplica.enabled` | If true, create an Ingress for each Alertmanager replica in the StatefulSet | `false` |
+| `alertmanager.ingressPerReplica.hostPrefix` |  | `""` |
+| `alertmanager.ingressPerReplica.hostDomain` |  | `""` |
+| `alertmanager.ingressPerReplica.labels` | Alertmanager per replica Ingress additional labels | `{}` |
+| `alertmanager.ingressPerReplica.paths` | Alertmanager per replica Ingress paths | `[]` |
+| `alertmanager.ingressPerReplica.tlsSecretName` | Secret name containing the TLS certificate for Alertmanager per replica ingress | `[]` |
+| `alertmanager.ingressPerReplica.tlsSecretPerReplica.enabled` | If true, create an secret for TLS certificate for each Ingress | `false` |
+| `alertmanager.ingressPerReplica.tlsSecretPerReplica.prefix` | Secret name prefix | `""` |
 | `alertmanager.podDisruptionBudget.enabled` | If true, create a pod disruption budget for Alertmanager pods. The created resource cannot be modified once created - it must be deleted to perform a change | `false` |
 | `alertmanager.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""` |
 | `alertmanager.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1` |
@@ -401,6 +412,14 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.service.port` | Port for Alertmanager Service to listen on | `9093` |
 | `alertmanager.service.targetPort` | AlertManager Service internal port | `9093` |
 | `alertmanager.service.type` | Alertmanager Service type | `ClusterIP` |
+| `alertmanager.servicePerReplica.annotations` | Alertmanager per replica Service Annotations | `{}` |
+| `alertmanager.servicePerReplica.enabled` | If true, create a Service for each Alertmanager replica in the StatefulSet | `false` |
+| `alertmanager.servicePerReplica.labels` | Alertmanager per replica Service Labels | `{}` |
+| `alertmanager.servicePerReplica.loadBalancerSourceRanges` | Alertmanager per replica Service Loadbalancer Source Ranges | `[]` |
+| `alertmanager.servicePerReplica.nodePort` |  Alertmanager per replica Service port for NodePort Service type | `30904` |
+| `alertmanager.servicePerReplica.port` |  Port for Alertmanager per replica Service to listen on | `9093` |
+| `alertmanager.servicePerReplica.targetPort` |  Alertmanager per replica Service internal port | `9093` |
+| `alertmanager.servicePerReplica.type` |  Alertmanager per replica Service type | `ClusterIP` |
 | `alertmanager.serviceAccount.create` | Create a `serviceAccount` for alertmanager | `true` |
 | `alertmanager.serviceAccount.name` | Name for Alertmanager service account | `""` |
 | `alertmanager.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |

--- a/stable/prometheus-operator/templates/alertmanager/ingressperreplica.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingressperreplica.yaml
@@ -1,21 +1,21 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.servicePerReplica.enabled .Values.prometheus.ingressPerReplica.enabled }}
-{{- $count := .Values.prometheus.prometheusSpec.replicas | int -}}
-{{- $servicePort := .Values.prometheus.service.port -}}
-{{- $ingressValues := .Values.prometheus.ingressPerReplica -}}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.servicePerReplica.enabled .Values.alertmanager.ingressPerReplica.enabled }}
+{{- $count := .Values.alertmanager.alertmanagerSpec.replicas | int -}}
+{{- $servicePort := .Values.alertmanager.service.port -}}
+{{- $ingressValues := .Values.alertmanager.ingressPerReplica -}}
 apiVersion: v1
 kind: List
 metadata:
-  name: {{ include "prometheus-operator.fullname" $ }}-prometheus-ingressperreplica
+  name: {{ include "prometheus-operator.fullname" $ }}-alertmanager-ingressperreplica
   namespace: {{ $.Release.Namespace }}
 items:
 {{ range $i, $e := until $count }}
   - apiVersion: extensions/v1beta1
     kind: Ingress
     metadata:
-      name: {{ include "prometheus-operator.fullname" $ }}-prometheus-{{ $i }}
+      name: {{ include "prometheus-operator.fullname" $ }}-alertmanager-{{ $i }}
       namespace: {{ $.Release.Namespace }}
       labels:
-        app: {{ include "prometheus-operator.name" $ }}-prometheus
+        app: {{ include "prometheus-operator.name" $ }}-alertmanager
 {{ include "prometheus-operator.labels" $ | indent 8 }}
       {{- if $ingressValues.labels }}
       {{ toYaml $ingressValues.labels | indent 8 }}
@@ -32,7 +32,7 @@ items:
       {{- range $p := $ingressValues.paths }}
               - path: {{ tpl $p $ }}
                 backend:
-                  serviceName: {{ include "prometheus-operator.fullname" $ }}-prometheus-{{ $i }}
+                  serviceName: {{ include "prometheus-operator.fullname" $ }}-alertmanager-{{ $i }}
                   servicePort: {{ $servicePort }}
       {{- end -}}
       {{- if or $ingressValues.tlsSecretName $ingressValues.tlsSecretPerReplica.enabled }}

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
+    self-monitor: {{ .Values.alertmanager.serviceMonitor.selfMonitor | quote }}
 {{ include "prometheus-operator.labels" . | indent 4 }}
 {{- if .Values.alertmanager.service.labels }}
 {{ toYaml .Values.alertmanager.service.labels | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/servicemonitor.yaml
@@ -12,6 +12,7 @@ spec:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-alertmanager
       release: {{ $.Release.Name | quote }}
+      self-monitor: "true"
   namespaceSelector:
     matchNames:
       - {{ $.Release.Namespace | quote }}

--- a/stable/prometheus-operator/templates/alertmanager/serviceperreplica.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/serviceperreplica.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.servicePerReplica.enabled }}
+{{- $count := .Values.alertmanager.alertmanagerSpec.replicas | int -}}
+{{- $serviceValues := .Values.alertmanager.servicePerReplica -}}
+apiVersion: v1
+kind: List
+metadata:
+  name: {{ include "prometheus-operator.fullname" $ }}-alertmanager-serviceperreplica
+  namespace: {{ $.Release.Namespace }}
+items:
+{{- range $i, $e := until $count }}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ include "prometheus-operator.fullname" $ }}-alertmanager-{{ $i }}
+      namespace: {{ $.Release.Namespace }}
+      labels:
+        app: {{ include "prometheus-operator.name" $ }}-alertmanager
+{{ include "prometheus-operator.labels" $ | indent 8 }}
+      {{- if $serviceValues.annotations }}
+      annotations:
+{{ toYaml $serviceValues.annotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if $serviceValues.clusterIP }}
+      clusterIP: {{ $serviceValues.clusterIP }}
+      {{- end }}
+      {{- if $serviceValues.loadBalancerSourceRanges }}
+      loadBalancerSourceRanges:
+      {{- range $cidr := $serviceValues.loadBalancerSourceRanges }}
+        - {{ $cidr }}
+      {{- end }}
+      {{- end }}
+      ports:
+        - name: {{ $.Values.alertmanager.alertmanagerSpec.portName }}
+          {{- if eq $serviceValues.type "NodePort" }}
+          nodePort: {{ $serviceValues.nodePort }}
+          {{- end }}
+          port: {{ $serviceValues.port }}
+          targetPort: {{ $serviceValues.targetPort }}
+      selector:
+        app: alertmanager
+        alertmanager: {{ template "prometheus-operator.fullname" $ }}-alertmanager
+        statefulset.kubernetes.io/pod-name: alertmanager-{{ include "prometheus-operator.fullname" $ }}-alertmanager-{{ $i }}
+      type: "{{ $serviceValues.type }}"
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -189,6 +189,41 @@ alertmanager:
   secret:
     annotations: {}
 
+  ## Configuration for creating an Ingress that will map to each Alertmanager replica service
+  ## alertmanager.servicePerReplica must be enabled
+  ##
+  ingressPerReplica:
+    enabled: false
+    annotations: {}
+    labels: {}
+
+    ## Final form of the hostname for each per replica ingress is
+    ## {{ ingressPerReplica.hostPrefix }}-{{ $replicaNumber }}.{{ ingressPerReplica.hostDomain }}
+    ##
+    ## Prefix for the per replica ingress that will have `-$replicaNumber`
+    ## appended to the end
+    hostPrefix: ""
+    ## Domain that will be used for the per replica ingress
+    hostDomain: ""
+
+    ## Paths to use for ingress rules
+    ##
+    paths: []
+    # - /
+
+    ## Secret name containing the TLS certificate for alertmanager per replica ingress
+    ## Secret must be manually created in the namespace
+    tlsSecretName: ""
+
+    ## Separated secret for each per replica Ingress. Can be used together with cert-manager
+    ##
+    tlsSecretPerReplica:
+      enabled: false
+      ## Final form of the secret for each per replica ingress is
+      ## {{ tlsSecretPerReplica.prefix }}-{{ $replicaNumber }}
+      ##
+      prefix: "alertmanager"
+
   ## Configuration for Alertmanager service
   ##
   service:
@@ -211,6 +246,31 @@ alertmanager:
     ##
     externalIPs: []
     loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    ## Service type
+    ##
+    type: ClusterIP
+
+  ## Configuration for creating a separate Service for each statefulset Alertmanager replica
+  ##
+  servicePerReplica:
+    enabled: false
+    annotations: {}
+
+    ## Port for Alertmanager Service per replica to listen on
+    ##
+    port: 9093
+
+    ## To be used with a proxy extraContainer port
+    targetPort: 9093
+
+    ## Port to expose on each node
+    ## Only used if servicePerReplica.type is 'NodePort'
+    ##
+    nodePort: 30904
+
+    ## Loadbalancer source IP ranges
+    ## Only used if servicePerReplica.type is "loadbalancer"
     loadBalancerSourceRanges: []
     ## Service type
     ##
@@ -1357,6 +1417,15 @@ prometheus:
     ## Secret name containing the TLS certificate for Prometheus per replica ingress
     ## Secret must be manually created in the namespace
     tlsSecretName: ""
+
+    ## Separated secret for each per replica Ingress. Can be used together with cert-manager
+    ##
+    tlsSecretPerReplica:
+      enabled: false
+      ## Final form of the secret for each per replica ingress is
+      ## {{ tlsSecretPerReplica.prefix }}-{{ $replicaNumber }}
+      ##
+      prefix: "prometheus"
 
   ## Configure additional options for default pod security policy for Prometheus
   ## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

- Adding support for creating separate Service and Ingress resources that will map
to the standard web port of each Alertmanager replica.
We're using the alertmanager.alertmanagerSpec.replicas value to determine how many
of each resource type to be created, and to vary resource names and values.
Because we're using a single set of values to control certain properties, we have to
drop support for setting parameters that need to be unique within a each resource.
Primarily this means no IP configuration options for the Service resource.
The ingress resources are created with a single host entry that is compiled by taking
two values (hostPrefix and hostDomain). The final hostname format is
hostPrefix-replicaIndex.hostDomain, where replicaIndex will be 0, 1, 2 etc.

- Adding support to use the separated secret for each per replica ingress resources for Prometheus and Alertmanager.

- Migrating from specific `kind:IngressList` to general `kind:List` in Prometheus per Replica configuration

#### Which issue this PR fixes

  - Adding support for sending alerts from other K8s clusters in compliance with the requirements from Alermanager: "It's important not to load balance traffic between Prometheus and its Alertmanagers, but instead, point Prometheus to a list of all Alertmanagers."

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
