### PR TITLE
[stable/jenkins] configure agent.args in values.yaml

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.11.1 Configure agent.args in values.yaml
+
 ## 1.11.0 Add support for configuring custom pod templates
 
 Add `agent.podTemplates` option for declaring custom pod templates in the default configured kubernetes cloud.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.11.0
+version: 1.11.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -208,7 +208,7 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.volumes`            | Additional volumes                              | `[]`                   |
 | `agent.envVars`            | Environment variables for the agent Pod         | `[]`                   |
 | `agent.command`            | Executed command when side container starts     | Not set                |
-| `agent.args`               | Arguments passed to executed command            | Not set                |
+| `agent.args`               | Arguments passed to executed command            | `${computer.jnlpmac} ${computer.name}` |
 | `agent.sideContainerName`  | Side container name in agent                    | jnlp                   |
 | `agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
 | `agent.containerCap`       | Maximum number of agent                         | 10                     |

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -103,7 +103,7 @@ jenkins:
       templates:
       - containers:
         - alwaysPullImage: {{ .Values.agent.alwaysPullImage }}
-          args: "{{ .Values.agent.args | replace "$" "^$"}}"
+          args: "{{ .Values.agent.args | replace "$" "^$" }}"
           command: {{ .Values.agent.command }}
           envVars:
           - containerEnvVar:

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -103,11 +103,7 @@ jenkins:
       templates:
       - containers:
         - alwaysPullImage: {{ .Values.agent.alwaysPullImage }}
-          {{- if .Values.agent.args }}
-          args: "{{ .Values.agent.args }}"
-          {{- else }}
-          args: "^${computer.jnlpmac} ^${computer.name}"
-          {{- end }}
+          args: "{{ .Values.agent.args | replace "$" "^$"}}"
           command: {{ .Values.agent.command }}
           envVars:
           - containerEnvVar:

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -86,11 +86,7 @@ data:
                   <alwaysPullImage>{{ .Values.agent.alwaysPullImage }}</alwaysPullImage>
                   <workingDir>/home/jenkins</workingDir>
                   <command>{{ .Values.agent.command }}</command>
-{{- if .Values.agent.args }}
                   <args>{{ .Values.agent.args }}</args>
-{{- else }}
-                  <args>${computer.jnlpmac} ${computer.name}</args>
-{{- end }}
                   <ttyEnabled>{{ .Values.agent.TTYEnabled }}</ttyEnabled>
                   # Resources configuration is a little hacky. This was to prevent breaking
                   # changes, and should be cleanned up in the future once everybody had

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -443,7 +443,7 @@ agent:
 
   # Executed command when side container gets started
   command:
-  args:
+  args: "${computer.jnlpmac} ${computer.name}"
   # Side container name
   sideContainerName: "jnlp"
   # Doesn't allocate pseudo TTY by default


### PR DESCRIPTION
#### What this PR does / why we need it:

We have agent.args is empty by default, but then we set default when rendering templates. This is confusing to users and could be simplified.

- ./templates/_helpers.tpl

  ```
          {{- if .Values.agent.args }}
          args: "{{ .Values.agent.args }}"
          {{- else }}
          args: "^${computer.jnlpmac} ^${computer.name}"
          {{- end }}
  ```

- ./templates/config.yaml
  ```
  {{- if .Values.agent.args }}
                    <args>{{ .Values.agent.args }}</args>
  {{- else }}
                    <args>${computer.jnlpmac} ${computer.name}</args>
  {{- end }}
  ```


It would be best if we could set this here to:
```yaml
args: "${computer.jnlpmac} ${computer.name}"
```

and take care of escaping dollar signs in the template.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
