### PR TITLE
[stable/kube2iam] Increase default resources

### DIFF
--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -81,11 +81,11 @@ rbac:
 
 resources: {}
   # limits:
-  #   cpu: 4m
-  #   memory: 16Mi
+  #   cpu: 50m
+  #   memory: 64Mi
   # requests:
-  #   cpu: 4m
-  #   memory: 16Mi
+  #   cpu: 50m
+  #   memory: 64Mi
 
 ## Strategy for DaemonSet updates (requires Kubernetes 1.6+)
 ## Ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

I have been running kube2iam in prod for years and I found some folks agreeing about credentials issue because of kube2iam when in fact the problem was... **throttling**. For old kernel version I do not recommend cpu limits but increase it up to 50m is needed. Also the memory usage in >0.10 version is always higher than 35Mi so increase to 64 is needed.
Having this values as defaults will prevent people that don't monitor throttling properly (or directly doesn't) face this kind of issues.

#### Which issue this PR fixes

  - None
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
