### PR TITLE
[stable/stackdriver-exporter] Feature apiVersion compatibility switch

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.2.2
+version: 1.2.3
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/templates/_helpers.tpl
+++ b/stable/stackdriver-exporter/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
@@ -106,4 +106,3 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add apiVersion compatibility switch for deployment
* Bump nginx-ingress chart version

Ran into some issues using this chart when slowing moving K8S clusters from version 1.15 to 1.16.
Didn't hit the same issues with the nginx-ingress chart, so used the same solution for this chart.

Based on the work in [stable/nginx-ingress](https://github.com/helm/charts/commit/1a2989849c9a115d43ed28842472e9e214ccccf8)

ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16
ref: https://github.com/helm/charts/commit/1a2989849c9a115d43ed28842472e9e214ccccf8


#### Special notes for your reviewer:

@apenney 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Daniel Lawrence <dannyla@linux.com>