### PR TITLE
[stable/jenkins] Default values for securityContext with regards to persistency

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.11.2
+version: 1.11.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -85,8 +85,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.initContainerEnv`         | Environment variables for Init Container                                 | Not set |
 | `master.containerEnv`             | Environment variables for Jenkins Container                              | Not set |
 | `master.usePodSecurityContext`    | Enable pod security context (must be `true` if `runAsUser` or `fsGroup` are set) | `true` |
-| `master.runAsUser`                | uid that jenkins runs with           | `0`                                       |
-| `master.fsGroup`                  | uid that will be used for persistent volume | `0`                                |
+| `master.runAsUser`                | uid that jenkins runs with           | `1000`                                       |
+| `master.fsGroup`                  | uid that will be used for persistent volume | `1000`                                |
 | `master.hostAliases`              | Aliases for IPs in `/etc/hosts`      | `[]`                                      |
 | `master.serviceAnnotations`       | Service annotations                  | `{}`                                      |
 | `master.serviceType`              | k8s service type                     | `ClusterIP`                               |

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -131,9 +131,9 @@ master:
   # Enable pod security context (must be `true` if runAsUser or fsGroup are set)
   usePodSecurityContext: true
   # Set runAsUser to 1000 to let Jenkins run as non-root user 'jenkins' which exists in 'jenkins/jenkins' docker image.
-  # When setting runAsUser to a different value than 0 also set fsGroup to the same value:
-  # runAsUser: <defaults to 0>
-  # fsGroup: <will be omitted in deployment if runAsUser is 0>
+  # When setting runAsUser to a different value than 0 also set fsGroup to the same value (this can be commented if persistence.enabled = false):
+  runAsUser: 1000
+  fsGroup: 1000
   servicePort: 8080
   targetPort: 8080
   # For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
Signed-off-by: Francesco Gualazzi <francesco.gualazzi@lastminute.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Chart is not able to deploy out of the box with persistence.enabled = true

#### Which issue this PR fixes
A storage permission problem 

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
