### PR TITLE
[stable/prometheus-blackbox-exporter] Add pod security policy

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 3.5.0
-appVersion: 0.15.1
+version: 4.0.0
+appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:
   - https://github.com/prometheus/blackbox_exporter

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `affinity`                                | node affinity for pod assignment                                                 | `{}`                                                                         |
 | `podAnnotations`                          | annotations to add to each pod                                                   | `{}`                                                                         |
 | `podDisruptionBudget`                     | pod disruption budget                                                            | `{}`                                                                         |
+| `pspEnabled`                              | create pod security policy resources                                             | `true`                                                                       |
 | `priorityClassName`                       | priority class name                                                              | None                                                                         |
 | `allowIcmp`                               | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
 | `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
@@ -73,7 +74,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |
 | `service.port`                            | port for the blackbox http service                                               | `9115`                                                                       |
 | `service.externalIPs`                     | list of external ips                                                             | []                                                                           |
-| `serviceAccount.create`                   | Specifies whether a service account should be created.                           | `false`                                                                      |
+| `serviceAccount.create`                   | Specifies whether a service account should be created.                           | `true`                                                                       |
 | `serviceAccount.name`                     | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
 | `serviceAccount.annotations`              | ServiceAccount annotations                                                       |                                                                              |
 | `serviceMonitor.enabled`                  | If true, a ServiceMonitor CRD is created for a prometheus operator               | `false`                                                                      |
@@ -112,6 +113,10 @@ $ helm install --name my-release -f values.yaml stable/prometheus-blackbox-expor
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Upgrading an existing Release to a new major version
+
+### 4.0.0
+
+This version create the service account by default and introduce pod security policy, it can be enabled by setting `pspEnabled: true`.
 
 ### 2.0.0
 

--- a/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -29,6 +29,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+spec:
+  # Prevents running in privileged mode
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  volumes:
+    - configMap
+    - secret
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
+{{- end }}

--- a/stable/prometheus-blackbox-exporter/templates/role.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+rules:
+  - apiGroups:
+    - policy
+    resources:
+    - podsecuritypolicies
+    resourceNames:
+    - {{ template "prometheus-blackbox-exporter.fullname" . }}-psp
+    verbs:
+    - use
+{{- end -}}

--- a/stable/prometheus-blackbox-exporter/templates/rolebinding.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
+{{- end -}}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -5,6 +5,9 @@ kind: Deployment
 podDisruptionBudget: {}
   # maxUnavailable: 0
 
+## Enable pod security policy
+pspEnabled: true
+
 strategy:
   rollingUpdate:
     maxSurge: 1
@@ -77,7 +80,7 @@ service:
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
-  create: false
+  create: true
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
- add pod security policy
- create service account by default (introduced by: https://github.com/helm/charts/pull/21726) — I'm open to discussion but I reckon this should be created by default
- fix application version to 0.16.0