### PR TITLE
[stable/nginx-ingress] Adding ability to add labels to the controller and default backend deployment

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.35.0
+version: 1.36.0
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -87,6 +87,7 @@ Parameter | Description | Default
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
 `controller.nodeSelector` | node labels for pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to pods | `{}`
+`controller.deploymentLabels` | labels to add to the deployment metadata | `{}`
 `controller.podLabels` | labels to add to the pod container metadata | `{}`
 `controller.podSecurityContext` | Security context policies to add to the controller pod | `{}`
 `controller.replicaCount` | desired number of controller pods | `1`
@@ -201,6 +202,7 @@ Parameter | Description | Default
 `defaultBackend.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
 `defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
+`defaultBackend.deploymentLabels` | labels to add to the deployment metadata | `{}`
 `defaultBackend.podLabels` | labels to add to the pod container metadata | `{}`
 `defaultBackend.replicaCount` | desired number of default backend pods | `1`
 `defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: controller
+    {{- if .Values.controller.deploymentLabels }}
+{{ toYaml .Values.controller.deploymentLabels | indent 4 }}
+    {{- end }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
   annotations:
 {{ toYaml .Values.controller.deploymentAnnotations | indent 4}}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
     app.kubernetes.io/component: default-backend
+    {{- if .Values.defaultBackend.deploymentLabels }}
+{{ toYaml .Values.defaultBackend.deploymentLabels | indent 4 }}
+    {{- end }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
   selector:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -72,6 +72,9 @@ controller:
   ##
   ingressClass: nginx
 
+  # labels to add to the deployment metadata
+  deploymentLabels: {}
+
   # labels to add to the pod container metadata
   podLabels: {}
   #  key: value
@@ -490,6 +493,9 @@ defaultBackend:
   ## notes on enabling and using sysctls
   ##
   podSecurityContext: {}
+
+  # labels to add to the deployment metadata
+  deploymentLabels: {}
 
   # labels to add to the pod container metadata
   podLabels: {}


### PR DESCRIPTION
Signed-off-by: Jesus Perucha <jperucha@outlook.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Provides the ability to add labels to the controller and default backend deployment. It complements the already available ability to add pod labels.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
