### PR TITLE
[stable/prometheus-operator] Add namespaceOverride support for node-exporter servicemonitor

### DIFF
--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-node-exporter
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{- if .Values.nodeExporter.namespaceOverride -}}
+    {{- .Values.nodeExporter.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
   labels:
     app: {{ template "prometheus-operator.name" . }}-node-exporter
 {{ include "prometheus-operator.labels" . | indent 4 }}


### PR DESCRIPTION
node-exporter Chart allows to specify a custom namespace.
This namespace should also be used when defined for servicemonitor