### PR TITLE
[stable/prisma] Add missing config params supported by Prisma docker image

### DIFF
--- a/stable/prisma/Chart.yaml
+++ b/stable/prisma/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prisma
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.29.1
 kubeVersion: "^1.8.0-0"
 description: Prisma turns your database into a realtime GraphQL API

--- a/stable/prisma/README.md
+++ b/stable/prisma/README.md
@@ -50,9 +50,12 @@ Parameter                        | Description                                  
 `database.connector`             | Database connector                           | `postgres`
 `database.host`                  | Host for the database endpoint               | `""`
 `database.port`                  | Port for the database endpoint               | `""`
+`database.name`                  | Database name for Prisma objects             | `prisma`
 `database.user`                  | Database user                                | `prisma`
 `database.password`              | Database password                            | `""`
 `database.migrations`            | Enable database migrations                   | `true`
+`database.ssl`                   | Enable SSL for DB connections                | `false`
+`database.connectionLimit`       | The maximum number of database connections   | `2`
 `auth.enabled`                   | Enable Prisma Management API authentication  | `false`
 `auth.secret`                    | Secret to use for authentication             | `nil`
 `service.type`                   | Type of Service                              | `ClusterIP`

--- a/stable/prisma/templates/configmap.yaml
+++ b/stable/prisma/templates/configmap.yaml
@@ -21,3 +21,6 @@ data:
         user: $PRISMA_DB_USER
         password: $PRISMA_DB_PASSWORD
         migrations: $PRISMA_DB_MIGRATIONS
+        database: $PRISMA_DB_NAME
+        ssl: $PRISMA_DB_SSL
+        connectionLimit: $PRISMA_DB_CONNECTIONLIMIT

--- a/stable/prisma/templates/deployment.yaml
+++ b/stable/prisma/templates/deployment.yaml
@@ -63,6 +63,12 @@ spec:
                   key: {{ template "prisma.databaseSecret.key" . }}
             - name: PRISMA_DB_MIGRATIONS
               value: {{ .Values.database.migrations | quote }}
+            - name: PRISMA_DB_NAME
+              value: {{ .Values.database.name | quote }}
+            - name: PRISMA_DB_SSL
+              value: {{ .Values.database.ssl | quote }}
+            - name: PRISMA_DB_CONNECTIONLIMIT
+              value: {{ .Values.database.connectionLimit | quote }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/prisma/values.yaml
+++ b/stable/prisma/values.yaml
@@ -35,6 +35,18 @@ database:
   host: ""
   port: ""
 
+  ## Database name where model will be created
+  ##
+  name: prisma
+
+  ## Enable SSL
+  ##
+  ssl: false
+
+  ## The maximum number of database connections (must be at least 2).
+  ##
+  connectionLimit: 2
+
   ## Database credentials
   ##
   user: prisma


### PR DESCRIPTION
Signed-off-by: Peter Belko <peter.belko@gmail.com>

#### What this PR does / why we need it:

Adds 3 new config parameters for DB connections. These are supported by Docker image but not by Helm chart:
* database name
* SSL enabled flag
* max open DB connections

Documentation of these properties can be found [here](https://www.prisma.io/docs/1.29/prisma-server/deployment-environments/docker-rty1/#database-properties)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
