### PR TITLE
[stable/prometheus-operator] fix: remove status field in CRDs

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.12.10
+version: 8.12.11
 appVersion: 0.37.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/crds/crd-alertmanager.yaml
+++ b/stable/prometheus-operator/crds/crd-alertmanager.yaml
@@ -4472,9 +4472,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/stable/prometheus-operator/crds/crd-podmonitor.yaml
+++ b/stable/prometheus-operator/crds/crd-podmonitor.yaml
@@ -260,9 +260,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/stable/prometheus-operator/crds/crd-prometheus.yaml
+++ b/stable/prometheus-operator/crds/crd-prometheus.yaml
@@ -5792,9 +5792,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/stable/prometheus-operator/crds/crd-prometheusrules.yaml
+++ b/stable/prometheus-operator/crds/crd-prometheusrules.yaml
@@ -86,9 +86,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/stable/prometheus-operator/crds/crd-servicemonitor.yaml
+++ b/stable/prometheus-operator/crds/crd-servicemonitor.yaml
@@ -458,9 +458,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/stable/prometheus-operator/crds/crd-thanosrulers.yaml
+++ b/stable/prometheus-operator/crds/crd-thanosrulers.yaml
@@ -3813,9 +3813,3 @@ spec:
   - name: v1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

Having the status field in the CRDs prevents continuous deployment tools (like
Argo CD) from converging.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
