### PR TITLE
[stable/prometheus-redis-exporter] Add support for tolerations and affinity

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.3.3
+version: 3.4.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -50,6 +50,8 @@ The following table lists the configurable parameters and their default values.
 | `extraArgs`            | extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter#flags)| {}
 | `env`                  | additional environment variables in YAML format. Can be used to pass credentials as env variables (via secret) as per the image readme [here](https://github.com/oliver006/redis_exporter#environment-variables) | {} |
 | `resources`            | cpu/memory resource requests/limits                 | {}                        |
+| `tolerations`          | toleration labels for pod assignment                | {}                        |
+| `affinity`             | affinity settings for pod assignment                | {}                        |
 | `service.type`         | desired service type                                | `ClusterIP`               |
 | `service.port`         | service external port                               | `9121`                    |
 | `service.annotations`  | Custom annotations for service                      | `{}`                      |

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -88,3 +88,11 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -32,6 +32,13 @@ service:
     # prometheus.io/port: "9121"
     # prometheus.io/scrape: "true"
 resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
 redisAddress: redis://myredis:6379
 annotations: {}
 #  prometheus.io/path: /metrics


### PR DESCRIPTION
Signed-off-by: JulienBreux [julien.breux@gmail.com](mailto:julien.breux@gmail.com)

#### What this PR does / why we need it:

Add possibility to add Tolerations and Affinity to prometheus-redis-exporter pods.
Tolerations and affinity allow better scheduling.


#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 
* [x]  [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
* [x]  Chart Version bumped
* [x]  Variables are documented in the README.md
* [x]  Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
