### PR TITLE
[stable/home-assistant] Ability to run under a specific service account

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.107.7
 description: Home Assistant
 name: home-assistant
-version: 0.12.6
+version: 0.12.7
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -179,6 +179,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `monitoring.serviceMonitor.labels`            | Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator | `{}` |
 | `monitoring.serviceMonitor.bearerTokenFile`   | Set bearerTokenFile for home-assistant auth (use long lived access tokens) | `nil` |
 | `monitoring.serviceMonitor.bearerTokenSecret` | Set bearerTokenSecret for home-assistant auth (use long lived access tokens) | `nil` |
+| `serviceAccountName`      | Run under specific service account | `nil` |
 
 
 

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range . }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -100,6 +100,9 @@ extraEnvSecrets:
   #   secret: mqtt
   #   key: password
 
+# Run under a specific service account
+# serviceAccountName:
+
 # Enable pod security context (must be `true` if runAsUser or fsGroup are set)
 usePodSecurityContext: true
 # Set runAsUser to 1000 to let home-assistant run as non-root user 'hass' which exists in 'runningman84/alpine-homeassistant' docker image.


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds the option to specify a serviceAccountName for the
deployment. This is especially needed with podSecurityPolicy
to allow using a privilieged service account to run the containers
as root as long has Home-Assistant refuses to implement uid != 0.

#### Which issue this PR fixes
see discussion in https://github.com/home-assistant/docker/issues/104

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
