### PR TITLE
[stable/mysql] add basic affinity support (#12054)

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 1.6.2
+version: 1.6.3
 appVersion: 5.7.28
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -83,6 +83,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
 | `persistence.annotations`                    | Persistent Volume annotations                                                                | {}                                                   |
 | `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
+| `affinity`                                   | Affinity rules for pod assignment                                                            | {}                                                   |
 | `tolerations`                                | Pod taint tolerations for deployment                                                         | {}                                                   |
 | `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
 | `metrics.image`                              | Exporter image                                                                               | `prom/mysqld-exporter`                               |

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -70,6 +70,10 @@ extraInitContainers: |
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+## Affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##


### PR DESCRIPTION
Signed-off-by: Niels Nuyttens <niels.nuyttens@gmail.com>

@olemarkus @viglesiasce 

#### What this PR does / why we need it:
Add basic support for `pod affinities`. Currently only `nodeSelector` support is provided.

#### Which issue this PR fixes
*fixes #12054 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
