### PR TITLE
[stable/unifi] add custom cert options

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.6.6
+version: 0.7.0
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.6.5
+version: 0.6.6
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -100,6 +100,10 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `runAsRoot`                                     | `false`                      | Run the controller as UID0 (root user); if set to false, will give container SETFCAP instead                           |
 | `UID`                                           | `999`                        | Run the controller as user UID                                                                                         |
 | `GID`                                           | `999`                        | Run the controller as group GID                                                                                        |
+| `customCert.enabled`                            | `false`                      | Define whether you are using s custom certificate                                                                      |
+| `customCert.isChain`                            | `false`                      | If you are using a Let's Encrypt certificate which already includes the full chain set this to `true`                  |
+| `customCert.certName`                           | `cert.pem`                   | Name of the the certificate file in `<unifi-data>/cert`                                                                |
+| `customCert.keyName`                            | `privkey.pem`                | Name of the the private key file in `<unifi-data>/cert`                                                                |
 | `mongodb.enabled`                               | `false`                      | Use external MongoDB for data storage                                                                                  |
 | `mongodb.dbUri`                                 | `mongodb://mongo/unifi`      | external MongoDB URI                                                                                                   |
 | `mongodb.statDbUri`                             | `mongodb://mongo/unifi_stat` | external MongoDB statdb URI                                                                                            |

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -118,6 +118,14 @@ spec:
             - name: extra-config
               mountPath: /configmap
             {{- end }}
+            {{- if and .Values.customCert .Values.customCert.enabled }}
+            - name: CERT_IS_CHAIN
+              value: "{{ .Values.customCert.isChain }}"
+            - name: CERTNAME
+              value: "{{ .Values.customCert.certName }}"
+            - name: CERT_PRIVATE_NAME
+              value: "{{ .Values.customCert.keyName }}"
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -180,7 +180,15 @@ runAsRoot: false
 UID: 999
 GID: 999
 
-  # define an external mongoDB instead of using the built-in mongodb
+## If you provide your own custom certificate in <unifi-data>/cert
+## you can define the following parameters to configure the controller
+customCert:
+  enabled: false
+  isChain: false
+  certName: cert.pem
+  keyName: privkey.pem
+
+# define an external mongoDB instead of using the built-in mongodb
 mongodb:
   enabled: false
   dbUri: mongodb://mongo/unifi


### PR DESCRIPTION
Signed-off-by: PixelJonas <jonas@janz.digital>

#### Is this a new chart
no

#### What this PR does / why we need it:
If you provide a custom certificate in `<unifi-data>/cert` there are some environment variables you can/must set as described in [the image repo](https://github.com/jacobalberty/unifi-docker#certificate-support). This PR adds the option to set these environment variables

#### Which issue this PR fixes
none

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
