### PR TITLE
[stable/node-problem-detector] remove flag--name which not working

### DIFF
--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -17,7 +17,7 @@ $ helm install stable/node-problem-detector
 To install the chart with the release name `my-release` and default configuration:
 
 ```console
-$ helm install --name my-release stable/node-problem-detector
+$ helm install my-release stable/node-problem-detector
 ```
 
 ## Uninstalling the Chart


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fix installation chart instruction because if we do 
```
helm install --name node-problem-detector stable/node-problem-detector
```

we will get the error :
```
Error: unknown flag: --name
```
#### maintainers :
@max-rocket-internet 
@Random-Liu
@andyxning 
@wangzhen127

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [X] DCO
