### PR TITLE
[stable/node-problem-detector] Customizable securityContext

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.7.2"
+version: "1.7.3"
 appVersion: v0.8.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -42,22 +42,23 @@ The following table lists the configurable parameters for this chart and their d
 | `image.pullPolicy`                    | Image pull policy                          | `IfNotPresent`                                               |
 | `image.repository`                    | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
 | `image.tag`                           | Image tag                                  | `v0.6.3`                                                     |
-| `hostpath.logdir`                     | Log directory path on K8s host             | `/var/log`
+| `hostpath.logdir`                     | Log directory path on K8s host             | `/var/log`                                                   |
 | `nameOverride`                        | Override the name of the chart             | `nil`                                                        |
 | `rbac.create`                         | RBAC                                       | `true`                                                       |
 | `rbac.pspEnabled`                     | PodSecuritypolicy                          | `false`                                                      |
 | `hostNetwork`                         | Run pod on host network                    | `false`                                                      |
 | `priorityClassName`                   | Priority class name                        | `""`                                                         |
+| `securityContext`                     | Pod security context                       | `{privileged: true}`                                         |
 | `resources`                           | Pod resource requests and limits           | `{}`                                                         |
 | `settings.custom_monitor_definitions` | User-specified custom monitor definitions  | `{}`                                                         |
-| `settings.log_monitors`               | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `settings.log_monitors`               | System log monitor config files            | `[/config/kernel-monitor.json, /config/docker-monitor.json]` |
 | `settings.custom_plugin_monitors`     | Custom plugin monitor config files         | `[]`                                                         |
 | `settings.prometheus_address`         | Prometheus exporter address                | `0.0.0.0`                                                    |
 | `settings.prometheus_port`            | Prometheus exporter port                   | `20257`                                                      |
 | `settings.heartBeatPeriod`            | Syncing interval with API server           | `5m0s`                                                       |
 | `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
 | `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
-| `tolerations`                         | Optional daemonset tolerations             | `["effect: NoSchedule,operator: Exists"]`                    |
+| `tolerations`                         | Optional daemonset tolerations             | `[{effect: NoSchedule, operator: Exists}]`                   |
 | `nodeSelector`                        | Optional daemonset nodeSelector            | `{}`                                                         |
 | `env`                                 | Optional daemonset environment variables   | `[]`                                                         |
 | `labels`                              | Optional daemonset labels                  | `{}`                                                         |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
             - "/bin/sh"
             - "-c"
             - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }} --k8s-exporter-heartbeat-period={{ .Values.settings.heartBeatPeriod }}"
+{{- if .Values.securityContext }}
           securityContext:
-            privileged: true
+{{ toYaml .Values.securityContext | indent 12 }}
+{{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -60,6 +60,9 @@ hostNetwork: false
 
 priorityClassName: ""
 
+securityContext:
+  privileged: true
+
 resources: {}
 
 annotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

When not using any of the default monitors that require a privileged
execution environment and only running custom monitors, it can be
useful to run NPD as a non-root user. This PR makes the securityContext
customizable, while keeping `privileged: true` as a default.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
