### PR TITLE
Neo4jlabs plugins

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -73,12 +73,14 @@ their default values.
 | `core.persistentVolume.mountPath`     | Persistent Volume mount root path                                                                                                       | `/data`                                         |
 | `core.persistentVolume.subPath`       | Subdirectory of the volume to mount                                                                                                     | `nil`                                           |
 | `core.persistentVolume.annotations`   | Persistent Volume Claim annotations                                                                                                     | `{}`                                            |
+| `core.plugins`                        | Plugin list to be installed (valid values [here](https://github.com/neo4j/docker-neo4j/blob/master/neo4jlabs-plugins.json))             | `{}`                                            |
 | `readReplica.numberOfServers`         | Number of machines in READ_REPLICA mode                                                                                                 | `0`                                             |
 | `readReplica.autoscaling.enabled`  | Enable horizontal pod autoscaler  | `false`  |
 | `readReplica.autoscaling.targetAverageUtilization`  | Target CPU utilization  | `70`  |
 | `readReplica.autoscaling.minReplicas` | Min replicas for autoscaling  | `1`  |
 | `readReplica.autoscaling.maxReplicas`  | Max replicas for autoscaling  | `3` |
 | `readReplica.initContainers`          | Init containers to add to the replica pod. Example use case is a script that installs the APOC library                                  | `{}`                                            |
+| `readReplica.plugins`                 | Plugin list to be installed (valid values [here](https://github.com/neo4j/docker-neo4j/blob/master/neo4jlabs-plugins.json))             | `{}`                                            |
 | `resources`                           | Resources required (e.g. CPU, memory)                                                                                                   | `{}`                                            |
 | `clusterDomain`                       | Cluster domain                                                                                                                          | `cluster.local`                                 |
 

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -36,6 +36,10 @@ spec:
             value: DNS
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          {{- if .Values.core.plugins }}
+          - name: NEO4JLABS_PLUGINS
+            value: {{ .Values.core.plugins | toJson | quote }}
+          {{- end }}
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -39,6 +39,10 @@ spec:
             value: DNS
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          {{- if .Values.readReplica.plugins }}
+          - name: NEO4JLABS_PLUGINS
+            value: {{ .Values.readReplica.plugins | toJson | quote }}
+          {{- end }}
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:


### PR DESCRIPTION
Hi,

Leverage the usage of `NEO4JLABS_PLUGINS` for helm installation.

Tested example to install apoc plugin
```shell
--set "core.plugins={apoc,n10s}"
```

or 

```yaml
image: "neo4j"
imageTag: "4.0.3"
core:
    plugins:
      - apoc
```


