### PR TITLE
[stable/prometheus] Cleanup kube state metrics.

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.0.6
+version: 11.1.0
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -205,6 +205,7 @@ Parameter | Description | Default
 `initChownData.image.pullPolicy` | init-chown-data container image pull policy | `IfNotPresent`
 `initChownData.resources` | init-chown-data pod resource requests & limits | `{}`
 `kubeStateMetrics.enabled` | If true, create kube-state-metrics sub-chart, see the [kube-state-metrics chart for configuration options](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) | `true`
+`kube-state-metrics` | [kube-state-metrics configuration options](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) | `Same as sub-chart's`
 `nodeExporter.enabled` | If true, create node-exporter | `true`
 `nodeExporter.name` | node-exporter container name | `node-exporter`
 `nodeExporter.image.repository` | node-exporter container image repository| `prom/node-exporter`
@@ -358,8 +359,6 @@ Parameter | Description | Default
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
 `serviceAccounts.alertmanager.annotations` | annotations for the alertmanager service account | `{}`
-`serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`
-`serviceAccounts.kubeStateMetrics.name` | name of the kubeStateMetrics service account to use or create | `{{ prometheus.kubeStateMetrics.fullname }}`
 `serviceAccounts.nodeExporter.create` | If true, create the nodeExporter service account | `true`
 `serviceAccounts.nodeExporter.name` | name of the nodeExporter service account to use or create | `{{ prometheus.nodeExporter.fullname }}`
 `serviceAccounts.nodeExporter.annotations` | annotations for the nodeExporter service account | `{}`
@@ -421,7 +420,7 @@ $ helm install stable/prometheus --name my-release -f values.yaml -f service1-al
 ```
 
 ### RBAC Configuration
-Roles and RoleBindings resources will be created automatically for `server` and `kubeStateMetrics` services.
+Roles and RoleBindings resources will be created automatically for `server` service.
 
 To manually setup RBAC you need to set the parameter `rbac.create=false` and specify the service account to be used for each service by setting the parameters: `serviceAccounts.{{ component }}.create` to `false` and `serviceAccounts.{{ component }}.name` to the name of a pre-existing service account.
 

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -36,16 +36,6 @@ component: {{ .Values.alertmanager.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
-{{- define "prometheus.kubeStateMetrics.labels" -}}
-{{ include "prometheus.kubeStateMetrics.matchLabels" . }}
-{{ include "prometheus.common.metaLabels" . }}
-{{- end -}}
-
-{{- define "prometheus.kubeStateMetrics.matchLabels" -}}
-component: {{ .Values.kubeStateMetrics.name | quote }}
-{{ include "prometheus.common.matchLabels" . }}
-{{- end -}}
-
 {{- define "prometheus.nodeExporter.labels" -}}
 {{ include "prometheus.nodeExporter.matchLabels" . }}
 {{ include "prometheus.common.metaLabels" . }}
@@ -107,23 +97,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name .Values.alertmanager.name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.alertmanager.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create a fully qualified kube-state-metrics name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "prometheus.kubeStateMetrics.fullname" -}}
-{{- if .Values.kubeStateMetrics.fullnameOverride -}}
-{{- .Values.kubeStateMetrics.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.kubeStateMetrics.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.kubeStateMetrics.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -228,17 +201,6 @@ Create the name of the service account to use for the alertmanager component
     {{ default (include "prometheus.alertmanager.fullname" .) .Values.serviceAccounts.alertmanager.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccounts.alertmanager.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the name of the service account to use for the kubeStateMetrics component
-*/}}
-{{- define "prometheus.serviceAccountName.kubeStateMetrics" -}}
-{{- if .Values.serviceAccounts.kubeStateMetrics.create -}}
-    {{ default (include "prometheus.kubeStateMetrics.fullname" .) .Values.serviceAccounts.kubeStateMetrics.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccounts.kubeStateMetrics.name }}
 {{- end -}}
 {{- end -}}
 

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -390,9 +390,13 @@ configmapReload:
 
 kubeStateMetrics:
   ## If false, kube-state-metrics sub-chart will not be installed
-  ## Please see https://github.com/helm/charts/tree/master/stable/kube-state-metrics for configurable values
   ##
   enabled: true
+
+## kube-state-metrics sub-chart configurable values
+## Please see https://github.com/helm/charts/tree/master/stable/kube-state-metrics
+##
+# kube-state-metrics:
 
 nodeExporter:
   ## If false, node-exporter will not be installed


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove no longer used remenants of vendored ksm service. Specify in
values file that `kube-state-metrics` is the top value to configure the
sub-chart, not `kubeStateMetrics` which is simply to enable or
disable the dependency.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
