### PR TITLE
[incubator/zookeeper] Ensure headless service force registers DNS

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.3
+version: 2.1.4
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/service-headless.yaml
+++ b/incubator/zookeeper/templates/service-headless.yaml
@@ -13,7 +13,9 @@ metadata:
 {{- end }}
 spec:
   clusterIP: None
+{{- if .Values.headless.publishNotReadyAddresses }}
   publishNotReadyAddresses: true
+{{- end }}
   ports:
 {{- range $key, $port := .Values.ports }}
     - name: {{ $key }}

--- a/incubator/zookeeper/templates/service-headless.yaml
+++ b/incubator/zookeeper/templates/service-headless.yaml
@@ -13,6 +13,7 @@ metadata:
 {{- end }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
 {{- range $key, $port := .Values.ports }}
     - name: {{ $key }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -37,6 +37,11 @@ service:
 ##
 headless:
   annotations: {}
+  # publishNotReadyAddresses, default false for backward compatibility
+  # set to true to register DNS entries for unready pods, which helps in rare
+  # occasions when cluster is unable to be created, DNS caching is enforced
+  # or pods are in persistent crash loop
+  publishNotReadyAddresses: false
 
 ports:
   client:


### PR DESCRIPTION
Force registering DNS entries will fix issues with java errors such as
java.net.UnknownHostException when fresh pod is created and is not
yet ready. In edge cases it was causing cluster creation failures.

Signed-off-by: Michał Sochoń <kaszpir@gmail.com>


#### Is this a new chart

No.

#### What this PR does / why we need it:

#### Which issue this PR fixes
Fixes #21865 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
