### PR TITLE
[stable/ipfs] generated yaml syntax fixes for ipfs ingress

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.4.1
+version: 0.4.2
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.22

--- a/stable/ipfs/templates/ingress-api.yaml
+++ b/stable/ipfs/templates/ingress-api.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingressApi.enabled -}}
+{{- $serviceName := include "ipfs.fullname" . -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ include "ipfs.fullname" . }}
+              serviceName: {{ $serviceName }}
               servicePort: 5001
         {{- end -}}
         {{- if .Values.ingressApi.tls }}

--- a/stable/ipfs/templates/ingress-api.yaml
+++ b/stable/ipfs/templates/ingress-api.yaml
@@ -17,7 +17,7 @@ spec:
   rules:
           {{- range .Values.ingressApi.hosts }}
           {{- $url := splitList "/" . }}
-    - host: {{ first $url }}
+    - host: {{ first $url | quote }}
       http:
         paths:
           - path: /{{ rest $url | join "/" }}

--- a/stable/ipfs/templates/ingress-api.yaml
+++ b/stable/ipfs/templates/ingress-api.yaml
@@ -27,6 +27,6 @@ spec:
         {{- end -}}
         {{- if .Values.ingressApi.tls }}
   tls:
-        {{ toYaml .Values.ingressApi.tls | indent 4 }}
+{{ toYaml .Values.ingressApi.tls | indent 4 }}
         {{- end -}}
         {{- end -}}

--- a/stable/ipfs/templates/ingress-gateway.yaml
+++ b/stable/ipfs/templates/ingress-gateway.yaml
@@ -27,6 +27,6 @@ spec:
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}
   tls:
-        {{ toYaml .Values.ingressGateway.tls | indent 4 }}
+{{ toYaml .Values.ingressGateway.tls | indent 4 }}
         {{- end -}}
         {{- end -}}

--- a/stable/ipfs/templates/ingress-gateway.yaml
+++ b/stable/ipfs/templates/ingress-gateway.yaml
@@ -17,7 +17,7 @@ spec:
   rules:
           {{- range .Values.ingressGateway.hosts }}
           {{- $url := splitList "/" . }}
-    - host: {{ first $url }}
+    - host: {{ first $url | quote }}
       http:
         paths:
           - path: /{{ rest $url | join "/" }}

--- a/stable/ipfs/templates/ingress-gateway.yaml
+++ b/stable/ipfs/templates/ingress-gateway.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingressGateway.enabled -}}
+{{- $serviceName := include "ipfs.fullname" . -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ include "ipfs.fullname" . }}
+              serviceName: {{ $serviceName }}
               servicePort: 8080
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR fixes issues I experienced when trying to configure an IPFS gateway.

#### Which issue this PR fixes

- When enabling an ingress, the ingress templates would try to retrieve eg `.Values.ingressApi.hosts[*].Chart.Name` instead of `.Chart.Name`. I don't know if my fix is the best fix for this, but it looks like how the code used to work in a previous version.
- When enabling TLS for an ingress, the first line of the TLS settings would have and additional 8 spaces of indentation, leading to YAML parse errors.
- When using a wildcard host name, useful for making gateways, the wildcard would cause YAML parse errors due to underquoting of the host name in the template.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)