### PR TITLE
[stable/neo4j]Neo4j 4.0 Support

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,14 +1,16 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 2.0.0
-appVersion: 3.4.5
+version: 3.0.0
+appVersion: 4.0.3
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png
 sources:
   - https://github.com/neo4j/neo4j
   - https://github.com/neo4j/docker-neo4j
-  - https://github.com/mneedham/k8s-kubectl
+  - https://github.com/neo-technology/neo4j-google-k8s-marketplace
 maintainers:
+  - name: moxious
+    email: david.allen@neo4j.com
   - name: mneedham
     email: mark.needham@neo4j.com

--- a/stable/neo4j/OWNERS
+++ b/stable/neo4j/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- mneedham
+- moxious
+- bfeshti
+reviewers:
+- mneedham
+- moxious
+- bfeshti

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -34,7 +34,7 @@ is tailored specifically to GKE.
 To install the chart with the release name `neo4j-helm`:
 
 ```bash
-$ helm install --name neo4j-helm stable/neo4j --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword
+$ helm install my-neo4j stable/neo4j --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword
 ```
 
 You must explicitly accept the neo4j license agreement for the installation to be successful.
@@ -70,6 +70,7 @@ their default values.
 | `podDisruptionBudget`                 | Pod disruption budget                                                                                                                   | `{}`                                            |
 | `authEnabled`                         | Is login/password required?                                                                                                             | `true`                                          |
 | `useAPOC`                             | Should the APOC plugins be automatically installed in the database?                                                                     | `true`                                          |
+| `defaultDatabase`                     | The name of the default database to configure in Neo4j (dbms.default_database)                                                          | `neo4j`                                         |
 | `neo4jPassword`                       | Password to log in the Neo4J database if password is required                                                                           | (random string of 10 characters)                |
 | `core.numberOfServers`                | Number of machines in CORE mode                                                                                                         | `3`                                             |
 | `core.sideCarContainers`              | Sidecar containers to add to the core pod. Example use case is a sidecar which identifies and labels the leader when using the http API | `{}`                                            |
@@ -96,7 +97,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 install`. For example,
 
 ```bash
-$ helm install --name neo4j-helm --set core.numberOfServers=5,readReplica.numberOfServers=3 stable/neo4j
+$ helm install my-neo4j --set core.numberOfServers=5,readReplica.numberOfServers=3 stable/neo4j
 ```
 
 The above command creates a cluster containing 5 core servers and 3 read
@@ -122,6 +123,16 @@ of Kubernetes
 - [How to Restore Neo4j Backups on Kubernetes](https://medium.com/google-cloud/how-to-restore-neo4j-backups-on-kubernetes-and-gke-6841aa1e3961)
 
 ## Upgrading
+
+Version numbers here refer to helm chart versions, not Neo4j product versions.
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+The 2.0.0 chart was based around Neo4j's 3.5.x product series.  The 3.0 chart is based around Neo4j's 4.0.x product
+series, and there are *substantial differences* between these two.  Careful upgrade planning is advised before attempting
+to upgrade an existing chart.  Consult [the upgrade guide](https://neo4j.com/docs/operations-manual/current/upgrade/) and
+expect that additional configuration of this chart will be necessary.
 
 ### To 2.0.0
 

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -16,12 +16,18 @@ This chart bootstraps a [Neo4j](https://github.com/neo4j/docker-neo4j)
 deployment on a [Kubernetes](http://kubernetes.io) cluster using the
 [Helm](https://helm.sh) package manager.
 
+This package is fairly similar to the Neo4j-maintained [GKE Marketplace](https://github.com/neo-technology/neo4j-google-k8s-marketplace) 
+entry, which is also built on helm.  This package tries to avoid Kubernetes distribution-specific features to be general, while the other
+is tailored specifically to GKE.
+
 ## Prerequisites
 
 * Kubernetes 1.6+ with Beta APIs enabled
 * PV provisioner support in the underlying infrastructure
 * Requires the following variables
   You must add `acceptLicenseAgreement` in the values.yaml file and set it to `yes` or include `--set acceptLicenseAgreement=yes` in the command line of helm install to accept the license.
+* This chart requires that you have a license for Neo4j Enterprise Edition.  Trial licenses 
+[can be obtained here](https://neo4j.com/lp/enterprise-cloud/?utm_content=kubernetes)
 
 ## Installing the Chart
 
@@ -63,6 +69,7 @@ their default values.
 | `imagePullPolicy`                     | Image pull policy                                                                                                                       | `IfNotPresent`                                  |
 | `podDisruptionBudget`                 | Pod disruption budget                                                                                                                   | `{}`                                            |
 | `authEnabled`                         | Is login/password required?                                                                                                             | `true`                                          |
+| `useAPOC`                             | Should the APOC plugins be automatically installed in the database?                                                                     | `true`                                          |
 | `neo4jPassword`                       | Password to log in the Neo4J database if password is required                                                                           | (random string of 10 characters)                |
 | `core.numberOfServers`                | Number of machines in CORE mode                                                                                                         | `3`                                             |
 | `core.sideCarContainers`              | Sidecar containers to add to the core pod. Example use case is a sidecar which identifies and labels the leader when using the http API | `{}`                                            |
@@ -105,6 +112,14 @@ $ helm install --name neo4j-helm -f values.yaml stable/neo4j
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 Once you have all 3 pods in running, you can run the "test.sh" script in this directory, which will verify the role attached to each pod and also test recovery of a failed/deleted pod. This script requires that the $RELEASE_NAME environment variable be set, in order to access the pods, if you have specified a custom `namespace` or `replicas` value when installing you can set those via `RELEASE_NAMESPACE` and `CORE_REPLICAS` environment variables for this script.
+
+## Additional Documentation for Running Neo4j in Kubernetes
+
+- [Neo4j Considerations in Orchestration Environments](https://medium.com/neo4j/neo4j-considerations-in-orchestration-environments-584db747dca5) which covers
+how the smart-client routing protocol that Neo4j uses interacts with Kubernetes networking.  Make sure to read this if you are trying to expose the Neo4j database outside
+of Kubernetes
+- [How to Backup Neo4j Running in Kubernetes](https://medium.com/neo4j/how-to-backup-neo4j-running-in-kubernetes-3697761f229a)
+- [How to Restore Neo4j Backups on Kubernetes](https://medium.com/google-cloud/how-to-restore-neo4j-backups-on-kubernetes-and-gke-6841aa1e3961)
 
 ## Upgrading
 

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -75,7 +75,7 @@ their default values.
 | `core.configMap`                      | Configmap providing configuration for core cluster members.  If not specified, defaults that come with the chart will be used.          | `$NAME-neo4j-core-config`                       |
 | `core.numberOfServers`                | Number of machines in CORE mode                                                                                                         | `3`                                             |
 | `core.sideCarContainers`              | Sidecar containers to add to the core pod. Example use case is a sidecar which identifies and labels the leader when using the http API | `{}`                                            |
-| `core.initContainers`                 | Init containers to add to the core pod. Example use case is a script that installs the APOC library                                     | `{}`                                            |
+| `core.initContainers`                 | Init containers to add to the core pod. Example use case is a script that installs custom plugins/extensions                            | `{}`                                            |
 | `core.persistentVolume.enabled`       | Whether or not persistence is enabled                                                                                                   | `true`                                          |
 | `core.persistentVolume.storageClass`  | Storage class of backing PVC                                                                                                            | `standard` (uses beta storage class annotation) |
 | `core.persistentVolume.size`          | Size of data volume                                                                                                                     | `10Gi`                                          |
@@ -88,7 +88,7 @@ their default values.
 | `readReplica.autoscaling.targetAverageUtilization`  | Target CPU utilization  | `70`  |
 | `readReplica.autoscaling.minReplicas` | Min replicas for autoscaling  | `1`  |
 | `readReplica.autoscaling.maxReplicas`  | Max replicas for autoscaling  | `3` |
-| `readReplica.initContainers`          | Init containers to add to the replica pod. Example use case is a script that installs the APOC library                                  | `{}`                                            |
+| `readReplica.initContainers`          | Init containers to add to the replica pods. Example use case is a script that installs custom plugins/extensions                        | `{}`                                            |
 | `resources`                           | Resources required (e.g. CPU, memory)                                                                                                   | `{}`                                            |
 | `clusterDomain`                       | Cluster domain                                                                                                                          | `cluster.local`                                 |
 

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -72,6 +72,7 @@ their default values.
 | `useAPOC`                             | Should the APOC plugins be automatically installed in the database?                                                                     | `true`                                          |
 | `defaultDatabase`                     | The name of the default database to configure in Neo4j (dbms.default_database)                                                          | `neo4j`                                         |
 | `neo4jPassword`                       | Password to log in the Neo4J database if password is required                                                                           | (random string of 10 characters)                |
+| `core.configMap`                      | Configmap providing configuration for core cluster members.  If not specified, defaults that come with the chart will be used.          | `$NAME-neo4j-core-config`                       |
 | `core.numberOfServers`                | Number of machines in CORE mode                                                                                                         | `3`                                             |
 | `core.sideCarContainers`              | Sidecar containers to add to the core pod. Example use case is a sidecar which identifies and labels the leader when using the http API | `{}`                                            |
 | `core.initContainers`                 | Init containers to add to the core pod. Example use case is a script that installs the APOC library                                     | `{}`                                            |
@@ -81,6 +82,7 @@ their default values.
 | `core.persistentVolume.mountPath`     | Persistent Volume mount root path                                                                                                       | `/data`                                         |
 | `core.persistentVolume.subPath`       | Subdirectory of the volume to mount                                                                                                     | `nil`                                           |
 | `core.persistentVolume.annotations`   | Persistent Volume Claim annotations                                                                                                     | `{}`                                            |
+| `readReplica.configMap`               | Configmap providing configuration for RR cluster members.  If not specified, defaults that come with the chart will be used.            | `$NAME-neo4j-replica-config`                    |
 | `readReplica.numberOfServers`         | Number of machines in READ_REPLICA mode                                                                                                 | `0`                                             |
 | `readReplica.autoscaling.enabled`  | Enable horizontal pod autoscaler  | `false`  |
 | `readReplica.autoscaling.targetAverageUtilization`  | Target CPU utilization  | `70`  |
@@ -113,6 +115,20 @@ $ helm install --name neo4j-helm -f values.yaml stable/neo4j
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 Once you have all 3 pods in running, you can run the "test.sh" script in this directory, which will verify the role attached to each pod and also test recovery of a failed/deleted pod. This script requires that the $RELEASE_NAME environment variable be set, in order to access the pods, if you have specified a custom `namespace` or `replicas` value when installing you can set those via `RELEASE_NAMESPACE` and `CORE_REPLICAS` environment variables for this script.
+
+## Using Custom Configuration
+
+The pods in two groups (Cores and read-replicas) are configured with regular ConfigMaps, which turn into environment variables.  Those
+environment variables configure the Neo4j pods according to [Neo4j environment variable configuration](https://neo4j.com/docs/operations-manual/current/docker/configuration/#docker-environment-variables).
+
+If you want to do custom configuration, just do so like this:
+
+```
+--set core.configMap=myConfigMapName --set readReplica.configMap=myReplicaConfigMap
+```
+
+And that will be used instead.   *Note*: configuration of some networking specific settings is still done at container start time,
+and this very small set of variables may still be overridden by the helm chart, in particular advertised addresses & hostnames for the containers.
 
 ## Additional Documentation for Running Neo4j in Kubernetes
 

--- a/stable/neo4j/templates/NOTES.txt
+++ b/stable/neo4j/templates/NOTES.txt
@@ -4,21 +4,22 @@
 ###################################################################
 {{- else }}
 We'll need to wait a few seconds for the Neo4j cluster to form.
-We need to see this line in all of our pods' logs:
+We need to see this line in all of our pods' logs that look like this:
 
 > Remote interface available at http://neo-helm-neo4j-core-2.neo-helm-neo4j.default.svc.cluster.local:7474/
 
 We can see the content of the logs by running the following command:
 
-kubectl logs -l "app={{ template "neo4j.name" . }},component=core"
+kubectl logs -l "app.kubernetes.io/name={{ template "neo4j.name" . }},app.kubernetes.io/component=core"
 
 We can now run a query to find the topology of the cluster.
 
+export NEO4J_PASSWORD=$(kubectl get secrets {{ template "neo4j.secrets.fullname" . }} -o yaml | grep password | sed 's/.*: //' | base64 -D)
 kubectl run -it --rm cypher-shell \
-    --image=neo4j:4.0.2-enterprise \
+    --image={{ .Values.image }}:{{ .Values.imageTag }} \
     --restart=Never \
     --namespace {{ .Release.Namespace }} \
-    --command -- ./bin/cypher-shell -u neo4j -p <password> --a {{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
+    --command -- ./bin/cypher-shell -u neo4j -p "$NEO4J_PASSWORD" -a neo4j://{{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
 
 This will print out the addresses of the members of the cluster.
 

--- a/stable/neo4j/templates/NOTES.txt
+++ b/stable/neo4j/templates/NOTES.txt
@@ -15,7 +15,7 @@ kubectl logs -l "app={{ template "neo4j.name" . }},component=core"
 We can now run a query to find the topology of the cluster.
 
 kubectl run -it --rm cypher-shell \
-    --image=neo4j:3.2.3-enterprise \
+    --image=neo4j:4.0.2-enterprise \
     --restart=Never \
     --namespace {{ .Release.Namespace }} \
     --command -- ./bin/cypher-shell -u neo4j -p <password> --a {{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"

--- a/stable/neo4j/templates/_helpers.tpl
+++ b/stable/neo4j/templates/_helpers.tpl
@@ -41,3 +41,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-secrets" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name for core config.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "neo4j.coreConfig.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-core-config" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name for RR config.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "neo4j.replicaConfig.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-replica-config" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/neo4j/templates/core-configmap.yaml
+++ b/stable/neo4j/templates/core-configmap.yaml
@@ -1,0 +1,21 @@
+# This ConfigMap gets passed to all core cluster members to configure them.
+# Take note that some networking settings like internal hostname still get configured
+# when the pod starts, but most non-networking specific configs can be tailored here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "neo4j.coreConfig.fullname" . }}
+data:
+  NEO4J_ACCEPT_LICENSE_AGREEMENT: "{{ .Values.acceptLicenseAgreement }}"
+  NEO4J_dbms_mode: CORE
+  NUMBER_OF_CORES: "{{ .Values.core.numberOfServers }}"
+  AUTH_ENABLED: "{{ .Values.authEnabled }}"
+  NEO4J_causal__clustering_discovery__type: LIST
+  NEO4J_causal__clustering_initial__discovery__members: "{{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
+  NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"
+  NEO4J_dbms_jvm_additional: "-XX:+ExitOnOutOfMemoryError"
+  {{- if .Values.useAPOC }}
+  NEO4JLABS_PLUGINS: "[\"apoc\"]"
+  NEO4J_apoc_import_file_use__neo4j__config: "true"
+  NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
+  {{- end }}

--- a/stable/neo4j/templates/core-configmap.yaml
+++ b/stable/neo4j/templates/core-configmap.yaml
@@ -13,6 +13,7 @@ data:
   NEO4J_causal__clustering_discovery__type: LIST
   NEO4J_causal__clustering_initial__discovery__members: "{{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
   NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"
+  NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: "2"
   NEO4J_dbms_jvm_additional: "-XX:+ExitOnOutOfMemoryError"
   {{- if .Values.useAPOC }}
   NEO4JLABS_PLUGINS: "[\"apoc\"]"

--- a/stable/neo4j/templates/core-configmap.yaml
+++ b/stable/neo4j/templates/core-configmap.yaml
@@ -10,7 +10,11 @@ data:
   NEO4J_dbms_mode: CORE
   NUMBER_OF_CORES: "{{ .Values.core.numberOfServers }}"
   AUTH_ENABLED: "{{ .Values.authEnabled }}"
+  NEO4J_dbms_default__database: "{{ .Values.defaultDatabase }}"
   NEO4J_causal__clustering_discovery__type: LIST
+  NEO4J_dbms_connector_bolt_listen__address: 0.0.0.0:7687
+  NEO4J_dbms_connector_http_listen__address: 0.0.0.0:7474
+  NEO4J_dbms_connector_https_listen__address: 0.0.0.0:7473
   NEO4J_causal__clustering_initial__discovery__members: "{{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
   NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"
   NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: "2"

--- a/stable/neo4j/templates/core-dns.yaml
+++ b/stable/neo4j/templates/core-dns.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/component: core
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true 
   ports:
     - name: http
       port: 7474
@@ -17,6 +18,9 @@ spec:
     - name: bolt
       port: 7687
       targetPort: 7687
+    - name: https
+      port: 7473
+      targetPort: 7473
   selector:
     app.kubernetes.io/name: {{ template "neo4j.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/stable/neo4j/templates/core-dns.yaml
+++ b/stable/neo4j/templates/core-dns.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: core
 spec:
   clusterIP: None
+  # This next line is critical:  cluster members cannot discover each other without published
+  # addresses, but without this, they can't get addresses unless they're ready (Catch-22)
   publishNotReadyAddresses: true 
   ports:
     - name: http

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: "apps/v1beta2"
+apiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.core.fullname" . }}"

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -24,50 +24,22 @@ spec:
       - name: {{ template "neo4j.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        # Most pod config is factored into a different configMap, which is user overrideable.
+        envFrom:
+          - configMapRef:
+              {{- if .Values.core.configMap }}
+              name: "{{ .Values.core.configMap }}"
+              {{- else }}
+              name: {{ template "neo4j.coreConfig.fullname" . }}
+              {{- end }}          
         env:
-          - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
-            value: "{{ .Values.acceptLicenseAgreement }}"
-          - name: NEO4J_dbms_mode
-            value: CORE
-          - name: NUMBER_OF_CORES
-            value: "{{ .Values.core.numberOfServers }}"
-          - name: AUTH_ENABLED
-            value: "{{ .Values.authEnabled }}"
-          #- name: NEO4J_causal__clustering_discovery__type
-          #  value: DNS
-          #- name: NEO4J_causal__clustering_initial__discovery__members
-          #  value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
-          #- name: NEO4J_causal__clustering_discovery__type
-          #  value: K8S
-          #- name: NEO4J_causal__clustering_kubernetes_label__selector
-          #  value: "app={{ template "neo4j.name" . }},component=core"
-          #- name: NEO4J_causal__clustering_kubernetes_service__port__name
-          #  value: discovery
-          - name: NEO4J_causal__clustering_discovery__type
-            value: LIST
-          - name: NEO4J_causal__clustering_initial__discovery__members
-            value: {{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000
-          - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
-            value: "3"
-          {{- if .Values.useAPOC }}
-          # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
-          - name: NEO4JLABS_PLUGINS
-            value: "[\"apoc\"]"
-          - name: NEO4J_apoc_import_file_use__neo4j__config
-            value: "true"
-          - name: NEO4J_dbms_security_procedures_unrestricted
-            value: "apoc.*"
-          {{- end }}
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ template "neo4j.secrets.fullname" . }}
                 key: neo4j-password
-          {{- end }}
-{{- if .Values.core.extraVars }}
-{{ toYaml .Values.core.extraVars | indent 10 }}
-{{- end }}
+          {{- end }}      
         command:
           - "/bin/bash"
           - "-c"
@@ -83,8 +55,6 @@ spec:
             export NEO4J_causal__clustering_discovery__advertised__address=$(hostname -f):5000
             export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
             export NEO4J_causal__clustering_raft__advertised__address=$(hostname -f):7000
-
-            export NEO4J_dbms_jvm_additional="-XX:+ExitOnOutOfMemoryError"
 
             if [ "${AUTH_ENABLED:-}" == "true" ]; then
               export NEO4J_AUTH="neo4j/${NEO4J_SECRETS_PASSWORD}"

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -32,21 +32,27 @@ spec:
             value: "{{ .Values.core.numberOfServers }}"
           - name: AUTH_ENABLED
             value: "{{ .Values.authEnabled }}"
+          #- name: NEO4J_causal__clustering_discovery__type
+          #  value: DNS
+          #- name: NEO4J_causal__clustering_initial__discovery__members
+          #  value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
           - name: NEO4J_causal__clustering_discovery__type
-            value: DNS
-          - name: NEO4J_causal__clustering_initial__discovery__members
-            value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+            value: K8S
+          - name: NEO4J_causal__clustering_kubernetes_label__selector
+            value: "app={{ template "neo4j.name" . }},component=core"
+          - name: NEO4J_causal__clustering_kubernetes_service__port__name
+            value: discovery
           - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
-            value: 3
+            value: "3"
           {{- if .Values.useAPOC }}
           # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
           - name: NEO4JLABS_PLUGINS
-            value: ["apoc"]
+            value: "[\"apoc\"]"
           - name: NEO4J_apoc_import_file_use__neo4j__config
             value: "true"
           - name: NEO4J_dbms_security_procedures_unrestricted
             value: "apoc.*"
-          {{ -end }}
+          {{- end }}
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:
@@ -97,6 +103,15 @@ spec:
           {{- end }}
         - name: plugins
           mountPath: /plugins
+        readinessProbe:
+          tcpSocket:
+            port: 7687
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 7687
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.core.sidecarContainers }}

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: "apps/v1"
+apiVersion: "apps/v1beta2"
 kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.core.fullname" . }}"
@@ -44,14 +44,17 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            export HOST=$(hostname -f)            
-            export NEO4J_causal__clustering_discovery__advertised__address=$HOST
-            export NEO4J_dbms_default__listen__address=$HOST
-            export NEO4J_dbms_default__advertised__address=$HOST
-            export NEO4J_dbms_connector_bolt_advertised__address=$HOST
-            export NEO4J_dbms_connector_http_advertised__address=$HOST
-            export NEO4J_dbms_connector_https_advertised__address=$HOST
-            export NEO4J_dbms_default__database={{ .Values.defaultDatabase }}
+            # Making this host the default address, so that advertised addresses are over-rideable
+            # by custom configmaps if specified.
+            export HOST=$(hostname -f)
+            export NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causal__clustering_discovery__advertised__address:-$HOST}
+            export NEO4J_dbms_default__advertised__address=${NEO4J_dbms_default__advertised__address:-$HOST}
+            export NEO4J_dbms_connector_bolt_advertised__address=${NEO4J_dbms_connector_bolt_advertised__address:-$HOST}
+            export NEO4J_dbms_connector_http_advertised__address=${NEO4J_dbms_connector_http_advertised__address:-$HOST}
+            export NEO4J_dbms_connector_https_advertised__address=${NEO4J_dbms_connector_https_advertised__address:-$HOST}
+            
+            # These settings are *not* overrideable, because they must match the initial_discovery_members
+            # In the Neo4j node config, otherwise Neo4j's akka layer will reject connections.
             export NEO4J_causal__clustering_discovery__advertised__address=$(hostname -f):5000
             export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
             export NEO4J_causal__clustering_raft__advertised__address=$(hostname -f):7000

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -36,6 +36,17 @@ spec:
             value: DNS
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
+            value: 3
+          {{- if .Values.useAPOC }}
+          # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
+          - name: NEO4JLABS_PLUGINS
+            value: ["apoc"]
+          - name: NEO4J_apoc_import_file_use__neo4j__config
+            value: "true"
+          - name: NEO4J_dbms_security_procedures_unrestricted
+            value: "apoc.*"
+          {{ -end }}
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:
@@ -50,7 +61,12 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            export NEO4J_dbms_connectors_default__advertised__address=$(hostname -f)
+            export NEO4J_dbms_default__listen__address=$(hostname -f)
+            export NEO4J_dbms_default__advertised__address=$(hostname -f)
+            export NEO4J_dbms_connector_bolt__advertised_address=$(hostname -f)
+            export NEO4J_dbms_connector_http_advertised__address=$(hostname -f)
+            export NEO4J_dbms_connector_https_advertised__address=$(hostname -f)
+            export NEO4J_dbms_default__database=neo4j
             export NEO4J_causal__clustering_discovery__advertised__address=$(hostname -f):5000
             export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
             export NEO4J_causal__clustering_raft__advertised__address=$(hostname -f):7000

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -1,8 +1,9 @@
-apiVersion: "apps/v1"
+apiVersion: "apps/v1beta2"
 kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.core.fullname" . }}"
 spec:
+  podManagementPolicy: Parallel
   serviceName: {{ template "neo4j.fullname" . }}
   replicas: {{ .Values.core.numberOfServers }}
   selector:
@@ -36,12 +37,16 @@ spec:
           #  value: DNS
           #- name: NEO4J_causal__clustering_initial__discovery__members
           #  value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          #- name: NEO4J_causal__clustering_discovery__type
+          #  value: K8S
+          #- name: NEO4J_causal__clustering_kubernetes_label__selector
+          #  value: "app={{ template "neo4j.name" . }},component=core"
+          #- name: NEO4J_causal__clustering_kubernetes_service__port__name
+          #  value: discovery
           - name: NEO4J_causal__clustering_discovery__type
-            value: K8S
-          - name: NEO4J_causal__clustering_kubernetes_label__selector
-            value: "app={{ template "neo4j.name" . }},component=core"
-          - name: NEO4J_causal__clustering_kubernetes_service__port__name
-            value: discovery
+            value: LIST
+          - name: NEO4J_causal__clustering_initial__discovery__members
+            value: {{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000
           - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
             value: "3"
           {{- if .Values.useAPOC }}
@@ -67,15 +72,19 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            export NEO4J_dbms_default__listen__address=$(hostname -f)
-            export NEO4J_dbms_default__advertised__address=$(hostname -f)
-            export NEO4J_dbms_connector_bolt__advertised_address=$(hostname -f)
-            export NEO4J_dbms_connector_http_advertised__address=$(hostname -f)
-            export NEO4J_dbms_connector_https_advertised__address=$(hostname -f)
-            export NEO4J_dbms_default__database=neo4j
+            export HOST=$(hostname -f)            
+            export NEO4J_causal__clustering_discovery__advertised__address=$HOST
+            export NEO4J_dbms_default__listen__address=$HOST
+            export NEO4J_dbms_default__advertised__address=$HOST
+            export NEO4J_dbms_connector_bolt_advertised__address=$HOST
+            export NEO4J_dbms_connector_http_advertised__address=$HOST
+            export NEO4J_dbms_connector_https_advertised__address=$HOST
+            export NEO4J_dbms_default__database={{ .Values.defaultDatabase }}
             export NEO4J_causal__clustering_discovery__advertised__address=$(hostname -f):5000
             export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
             export NEO4J_causal__clustering_raft__advertised__address=$(hostname -f):7000
+
+            export NEO4J_dbms_jvm_additional="-XX:+ExitOnOutOfMemoryError"
 
             if [ "${AUTH_ENABLED:-}" == "true" ]; then
               export NEO4J_AUTH="neo4j/${NEO4J_SECRETS_PASSWORD}"
@@ -83,6 +92,7 @@ spec:
               export NEO4J_AUTH="none"
             fi
 
+            echo "Starting Neo4j CORE on $HOST"
             exec /docker-entrypoint.sh "neo4j"
         ports:
         - containerPort: 5000

--- a/stable/neo4j/templates/readreplicas-configmap.yaml
+++ b/stable/neo4j/templates/readreplicas-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "neo4j.replicaConfig.fullname" . }}
 data:
   NEO4J_ACCEPT_LICENSE_AGREEMENT: "{{ .Values.acceptLicenseAgreement }}"
-  NEO4J_dbms_mode: CORE
+  NEO4J_dbms_mode: READ_REPLICA
   NUMBER_OF_CORES: "{{ .Values.core.numberOfServers }}"
   AUTH_ENABLED: "{{ .Values.authEnabled }}"
   NEO4J_causal__clustering_discovery__type: LIST

--- a/stable/neo4j/templates/readreplicas-configmap.yaml
+++ b/stable/neo4j/templates/readreplicas-configmap.yaml
@@ -1,0 +1,21 @@
+# This ConfigMap gets passed to all core cluster members to configure them.
+# Take note that some networking settings like internal hostname still get configured
+# when the pod starts, but most non-networking specific configs can be tailored here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "neo4j.replicaConfig.fullname" . }}
+data:
+  NEO4J_ACCEPT_LICENSE_AGREEMENT: "{{ .Values.acceptLicenseAgreement }}"
+  NEO4J_dbms_mode: CORE
+  NUMBER_OF_CORES: "{{ .Values.core.numberOfServers }}"
+  AUTH_ENABLED: "{{ .Values.authEnabled }}"
+  NEO4J_causal__clustering_discovery__type: LIST
+  NEO4J_causal__clustering_initial__discovery__members: "{{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
+  NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"
+  NEO4J_dbms_jvm_additional: "-XX:+ExitOnOutOfMemoryError"
+  {{- if .Values.useAPOC }}
+  NEO4JLABS_PLUGINS: "[\"apoc\"]"
+  NEO4J_apoc_import_file_use__neo4j__config: "true"
+  NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
+  {{- end }}

--- a/stable/neo4j/templates/readreplicas-configmap.yaml
+++ b/stable/neo4j/templates/readreplicas-configmap.yaml
@@ -13,6 +13,7 @@ data:
   NEO4J_causal__clustering_discovery__type: LIST
   NEO4J_causal__clustering_initial__discovery__members: "{{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
   NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"
+  NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: "2"
   NEO4J_dbms_jvm_additional: "-XX:+ExitOnOutOfMemoryError"
   {{- if .Values.useAPOC }}
   NEO4JLABS_PLUGINS: "[\"apoc\"]"

--- a/stable/neo4j/templates/readreplicas-configmap.yaml
+++ b/stable/neo4j/templates/readreplicas-configmap.yaml
@@ -10,6 +10,10 @@ data:
   NEO4J_dbms_mode: READ_REPLICA
   NUMBER_OF_CORES: "{{ .Values.core.numberOfServers }}"
   AUTH_ENABLED: "{{ .Values.authEnabled }}"
+  NEO4J_dbms_default__database: "{{ .Values.defaultDatabase }}"
+  NEO4J_dbms_connector_bolt_listen__address: 0.0.0.0:7687
+  NEO4J_dbms_connector_http_listen__address: 0.0.0.0:7474
+  NEO4J_dbms_connector_https_listen__address: 0.0.0.0:7473
   NEO4J_causal__clustering_discovery__type: LIST
   NEO4J_causal__clustering_initial__discovery__members: "{{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000"
   NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -39,6 +39,15 @@ spec:
             value: DNS
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          {{- if .Values.useAPOC }}
+          # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
+          - name: NEO4JLABS_PLUGINS
+            value: ["apoc"]
+          - name: NEO4J_apoc_import_file_use__neo4j__config
+            value: "true"
+          - name: NEO4J_dbms_security_procedures_unrestricted
+            value: "apoc.*"
+          {{ -end }}  
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -40,16 +40,16 @@ spec:
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
           - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
-            value: 3
+            value: "3"
           {{- if .Values.useAPOC }}
           # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
           - name: NEO4JLABS_PLUGINS
-            value: ["apoc"]
+            value: "[\"apoc\"]"
           - name: NEO4J_apoc_import_file_use__neo4j__config
             value: "true"
           - name: NEO4J_dbms_security_procedures_unrestricted
             value: "apoc.*"
-          {{ -end }}  
+          {{- end }}  
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -39,6 +39,8 @@ spec:
             value: DNS
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
+            value: 3
           {{- if .Values.useAPOC }}
           # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
           - name: NEO4JLABS_PLUGINS
@@ -62,7 +64,12 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            export NEO4J_dbms_connectors_default__advertised__address=$(hostname -f)
+            export NEO4J_dbms_default__listen__address=$(hostname -f)
+            export NEO4J_dbms_default__advertised__address=$(hostname -f)
+            export NEO4J_dbms_connector_bolt__advertised_address=$(hostname -f)
+            export NEO4J_dbms_connector_http_advertised__address=$(hostname -f)
+            export NEO4J_dbms_connector_https_advertised__address=$(hostname -f)
+            export NEO4J_dbms_default__database=neo4j
             export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
 
             if [ "${AUTH_ENABLED:-}" == "true" ]; then

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: "apps/v1beta2"
+apiVersion: "apps/v1"
 kind: Deployment
 metadata:
   name: "{{ template "neo4j.replica.fullname" . }}"
@@ -48,7 +48,12 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            export HOST=$(hostname -f)            
+            # Replicas advertise by bare IP, not hostname.  This is because deployments in kubernetes
+            # don't provide good FQDNs. (https://github.com/kubernetes/kubernetes/issues/60789)
+            # The FQDN advertisement address is necessary for the akka cluster formation in Neo4j to work,
+            # so if you advertise with a bare local hostname or something invalid, the read replica will be
+            # unable to join the raft group.
+            export HOST=$(hostname -i)
             export NEO4J_causal__clustering_discovery__advertised__address=$HOST
             export NEO4J_dbms_default__listen__address=$HOST
             export NEO4J_dbms_default__advertised__address=$HOST
@@ -56,9 +61,9 @@ spec:
             export NEO4J_dbms_connector_http_advertised__address=$HOST
             export NEO4J_dbms_connector_https_advertised__address=$HOST
             export NEO4J_dbms_default__database={{ .Values.defaultDatabase }}
-            export NEO4J_causal__clustering_discovery__advertised__address=$(hostname -f):5000
-            export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
-            export NEO4J_causal__clustering_raft__advertised__address=$(hostname -f):7000
+            export NEO4J_causal__clustering_discovery__advertised__address=$HOST:5000
+            export NEO4J_causal__clustering_transaction__advertised__address=$HOST:6000
+            export NEO4J_causal__clustering_raft__advertised__address=$HOST:7000
 
             export NEO4J_dbms_jvm_additional="-XX:+ExitOnOutOfMemoryError"
 
@@ -71,12 +76,16 @@ spec:
             echo "Starting Neo4j READ_REPLICA on $HOST"
             exec /docker-entrypoint.sh "neo4j"
         ports:
+        - containerPort: 5000
+          name: discovery
+        - containerPort: 7000
+          name: raft
+        - containerPort: 6000
+          name: tx
         - containerPort: 7474
           name: browser
         - containerPort: 7687
           name: bolt
-        - containerPort: 6000
-          name: tx
         volumeMounts:
         - name: plugins
           mountPath: /plugins

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -28,28 +28,15 @@ spec:
       - name: neo4j
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        # Most pod config is factored into a different configMap, which is user overrideable.
+        envFrom:
+          - configMapRef:
+              {{- if .Values.readReplica.configMap }}
+              name: "{{ .Values.readReplica.configMap }}"
+              {{- else }}
+              name: {{ template "neo4j.replicaConfig.fullname" . }}
+              {{- end }}
         env:
-          - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
-            value: "{{ .Values.acceptLicenseAgreement }}"
-          - name: NEO4J_dbms_mode
-            value: READ_REPLICA
-          - name: NEO4J_dbms_security_auth__enabled
-            value: "{{ .Values.authEnabled }}"
-          - name: NEO4J_causal__clustering_discovery__type
-            value: LIST
-          - name: NEO4J_causal__clustering_initial__discovery__members
-            value: {{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000
-          - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
-            value: "3"
-          {{- if .Values.useAPOC }}
-          # In modern Neo4j docker containers, the following auto-installs APOC and configures it appropriately.
-          - name: NEO4JLABS_PLUGINS
-            value: "[\"apoc\"]"
-          - name: NEO4J_apoc_import_file_use__neo4j__config
-            value: "true"
-          - name: NEO4J_dbms_security_procedures_unrestricted
-            value: "apoc.*"
-          {{- end }}  
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:
@@ -57,9 +44,6 @@ spec:
                 name: {{ template "neo4j.secrets.fullname" . }}
                 key: neo4j-password
           {{- end }}
-{{- if .Values.readReplica.extraVars }}
-{{ toYaml .Values.readReplica.extraVars | indent 10 }}
-{{- end }}
         command:
           - "/bin/bash"
           - "-c"

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: "apps/v1beta2"
 kind: Deployment
 metadata:
   name: "{{ template "neo4j.replica.fullname" . }}"
@@ -36,9 +36,9 @@ spec:
           - name: NEO4J_dbms_security_auth__enabled
             value: "{{ .Values.authEnabled }}"
           - name: NEO4J_causal__clustering_discovery__type
-            value: DNS
+            value: LIST
           - name: NEO4J_causal__clustering_initial__discovery__members
-            value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+            value: {{ template "neo4j.fullname" . }}-core-0.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-1.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000,{{ template "neo4j.fullname" . }}-core-2.{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000
           - name: NEO4J_causal__clustering_minimum__core__cluster__size__at__formation
             value: "3"
           {{- if .Values.useAPOC }}
@@ -64,13 +64,19 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            export NEO4J_dbms_default__listen__address=$(hostname -f)
-            export NEO4J_dbms_default__advertised__address=$(hostname -f)
-            export NEO4J_dbms_connector_bolt__advertised_address=$(hostname -f)
-            export NEO4J_dbms_connector_http_advertised__address=$(hostname -f)
-            export NEO4J_dbms_connector_https_advertised__address=$(hostname -f)
-            export NEO4J_dbms_default__database=neo4j
+            export HOST=$(hostname -f)            
+            export NEO4J_causal__clustering_discovery__advertised__address=$HOST
+            export NEO4J_dbms_default__listen__address=$HOST
+            export NEO4J_dbms_default__advertised__address=$HOST
+            export NEO4J_dbms_connector_bolt_advertised__address=$HOST
+            export NEO4J_dbms_connector_http_advertised__address=$HOST
+            export NEO4J_dbms_connector_https_advertised__address=$HOST
+            export NEO4J_dbms_default__database={{ .Values.defaultDatabase }}
+            export NEO4J_causal__clustering_discovery__advertised__address=$(hostname -f):5000
             export NEO4J_causal__clustering_transaction__advertised__address=$(hostname -f):6000
+            export NEO4J_causal__clustering_raft__advertised__address=$(hostname -f):7000
+
+            export NEO4J_dbms_jvm_additional="-XX:+ExitOnOutOfMemoryError"
 
             if [ "${AUTH_ENABLED:-}" == "true" ]; then
               export NEO4J_AUTH="neo4j/${NEO4J_SECRETS_PASSWORD}"
@@ -78,6 +84,7 @@ spec:
               export NEO4J_AUTH="none"
             fi
 
+            echo "Starting Neo4j READ_REPLICA on $HOST"
             exec /docker-entrypoint.sh "neo4j"
         ports:
         - containerPort: 7474

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -54,18 +54,17 @@ spec:
             # so if you advertise with a bare local hostname or something invalid, the read replica will be
             # unable to join the raft group.
             export HOST=$(hostname -i)
-            export NEO4J_causal__clustering_discovery__advertised__address=$HOST
-            export NEO4J_dbms_default__listen__address=$HOST
-            export NEO4J_dbms_default__advertised__address=$HOST
-            export NEO4J_dbms_connector_bolt_advertised__address=$HOST
-            export NEO4J_dbms_connector_http_advertised__address=$HOST
-            export NEO4J_dbms_connector_https_advertised__address=$HOST
-            export NEO4J_dbms_default__database={{ .Values.defaultDatabase }}
+            export NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causal__clustering_discovery__advertised__address:-$HOST}
+            export NEO4J_dbms_default__advertised__address=${NEO4J_dbms_default__advertised__address:-$HOST}
+            export NEO4J_dbms_connector_bolt_advertised__address=${NEO4J_dbms_connector_bolt_advertised__address:-$HOST}
+            export NEO4J_dbms_connector_http_advertised__address=${NEO4J_dbms_connector_http_advertised__address:-$HOST}
+            export NEO4J_dbms_connector_https_advertised__address=${NEO4J_dbms_connector_https_advertised__address:-$HOST}
+
+            # These settings are *not* overrideable, because they must match the addresses the
+            # core members see to avoid akka rejections.
             export NEO4J_causal__clustering_discovery__advertised__address=$HOST:5000
             export NEO4J_causal__clustering_transaction__advertised__address=$HOST:6000
             export NEO4J_causal__clustering_raft__advertised__address=$HOST:7000
-
-            export NEO4J_dbms_jvm_additional="-XX:+ExitOnOutOfMemoryError"
 
             if [ "${AUTH_ENABLED:-}" == "true" ]; then
               export NEO4J_AUTH="neo4j/${NEO4J_SECRETS_PASSWORD}"

--- a/stable/neo4j/templates/readreplicas-dns.yaml
+++ b/stable/neo4j/templates/readreplicas-dns.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "neo4j.replica.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/name: {{ template "neo4j.replica.fullname" . }}
+    app.kubernetes.io/component: core
+spec:
+  clusterIP: None
+  # This next line is critical:  cluster members cannot discover each other without published
+  # addresses, but without this, they can't get addresses unless they're ready (Catch-22)
+  publishNotReadyAddresses: true 
+  ports:
+    - name: http
+      port: 7474
+      targetPort: 7474
+    - name: bolt
+      port: 7687
+      targetPort: 7687
+    - name: https
+      port: 7473
+      targetPort: 7473
+  selector:
+    app.kubernetes.io/name: {{ template "neo4j.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/component: replica

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -53,7 +53,7 @@ data:
             nc -i 3 ${host} 7474)
           echo "SHOW DATABASES response:"
           echo $SHOW_DATABASES_RESPONSE
-          didItWork=(echo "${SHOW_DATABASES_RESPONSE}" | grep -i online)
+          didItWork=$(echo "${SHOW_DATABASES_RESPONSE}" | grep -i online)
           [ "$?" = 0 ] && break
           [ "${attempt}" -ge "${attempts}" ] && exit 1
           sleep 5

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -42,6 +42,15 @@ data:
         while true; do
           attempt=$[$attempt + 1]
           echo "Try $attempt: Connecting to $url"
+          
+          # Attempt post via netcat since old busybox doesn't support wget --post-data
+          POST_DATA='{"statements":[{"statement":"SHOW DATABASES"}]}'
+          POST_PATH=/db/system/tx/commit
+          HERE_HOST=$(hostname -f)
+          AUTH_TOK=$(echo -n $auth | base64)
+          BODY_LEN=$( echo -n "${POST_DATA}" | wc -c )
+          echo -ne "POST ${POST_PATH} HTTP/1.0\r\nHost: ${HERE_HOST}\r\nAuthorization: Basic $AUTH_TOK\r\nContent-Type: application/json\r\nContent-Length: ${BODY_LEN}\r\n\r\n${POST_DATA}" | \
+            nc -i 3 ${host} 7474
           wget --version
           wget ${url} --post-data '{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1
           response=$(wget ${url} --post-data '{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -49,13 +49,11 @@ data:
           HERE_HOST=$(hostname -f)
           AUTH_TOK=$(echo -n $auth | base64)
           BODY_LEN=$( echo -n "${POST_DATA}" | wc -c )
-          echo -ne "POST ${POST_PATH} HTTP/1.0\r\nHost: ${HERE_HOST}\r\nAuthorization: Basic $AUTH_TOK\r\nContent-Type: application/json\r\nContent-Length: ${BODY_LEN}\r\n\r\n${POST_DATA}" | \
-            nc -i 3 ${host} 7474
-          wget --version
-          wget ${url} --post-data '{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1
-          response=$(wget ${url} --post-data '{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)
+          SHOW_DATABASES_RESPONSE=$(echo -ne "POST ${POST_PATH} HTTP/1.0\r\nHost: ${HERE_HOST}\r\nAuthorization: Basic $AUTH_TOK\r\nContent-Type: application/json\r\nContent-Length: ${BODY_LEN}\r\n\r\n${POST_DATA}" | \
+            nc -i 3 ${host} 7474)
           echo "SHOW DATABASES response:"
-          echo $response
+          echo $SHOW_DATABASES_RESPONSE
+          didItWork=(echo $SHOW_DATABASES_RESPONSE | grep -i online)
           [ "$?" = 0 ] && break
           [ "${attempt}" -ge "${attempts}" ] && exit 1
           sleep 5

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -53,7 +53,7 @@ data:
             nc -i 3 ${host} 7474)
           echo "SHOW DATABASES response:"
           echo $SHOW_DATABASES_RESPONSE
-          didItWork=(echo $SHOW_DATABASES_RESPONSE | grep -i online)
+          didItWork=(echo "${SHOW_DATABASES_RESPONSE}" | grep -i online)
           [ "$?" = 0 ] && break
           [ "${attempt}" -ge "${attempts}" ] && exit 1
           sleep 5

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -42,8 +42,8 @@ data:
         while true; do
           attempt=$[$attempt + 1]
           echo "Try $attempt: Connecting to $url"
-          wget ${url} --post-data='{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1
-          response=$(wget ${url} --post-data='{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)
+          curl ${url} -d '{"statements":[{"statement" : "SHOW DATABASES"}]}' -H 'Content-Type: application/json' 2>&1
+          response=$(curl ${url} -d '{"statements":[{"statement" : "SHOW DATABASES"}]}' -H 'Content-Type: application/json' 2>&1)
           echo "SHOW DATABASES response:"
           echo $response
           [ "$?" = 0 ] && break

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -36,14 +36,15 @@ data:
       for id in $(seq 0 $((CORE_REPLICAS - 1))); do
         host="${STATEFULSET_NAME}-core-$id.${STATEFULSET_NAME}.${NAMESPACE}.svc.cluster.local"
         auth="neo4j:${NEO4J_SECRETS_PASSWORD}"
-        url="http://${auth}@${host}:7474/db/system/tx/"
+        url="http://${auth}@${host}:7474/db/system/tx/commit"
         attempts=10
         attempt=0
         while true; do
           attempt=$[$attempt + 1]
           echo "Try $attempt: Connecting to $url"
-          curl ${url} -d '{"statements":[{"statement" : "SHOW DATABASES"}]}' -H 'Content-Type: application/json' 2>&1
-          response=$(curl ${url} -d '{"statements":[{"statement" : "SHOW DATABASES"}]}' -H 'Content-Type: application/json' 2>&1)
+          wget --version
+          wget ${url} --post-data '{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1
+          response=$(wget ${url} --post-data '{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)
           echo "SHOW DATABASES response:"
           echo $response
           [ "$?" = 0 ] && break

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -42,8 +42,10 @@ data:
         while true; do
           attempt=$[$attempt + 1]
           echo "Try $attempt: Connecting to $url"
-          response=$(wget ${url} --post-data='{"statements":[{"statement" : "SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)
-          echo "SHOW DATABASES response:  $response"
+          wget ${url} --post-data='{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1
+          response=$(wget ${url} --post-data='{"statements":[{"statement":"SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)
+          echo "SHOW DATABASES response:"
+          echo $response
           [ "$?" = 0 ] && break
           [ "${attempt}" -ge "${attempts}" ] && exit 1
           sleep 5

--- a/stable/neo4j/templates/tests/test-config.yaml
+++ b/stable/neo4j/templates/tests/test-config.yaml
@@ -11,16 +11,16 @@ data:
   run.sh: |-
     @test "Testing Neo4j cluster has quorum" {
       echo "checking if the cluster is up"
-      path="data"
+      # path="data"
       for id in $(seq 0 $((CORE_REPLICAS - 1))); do
         host="${STATEFULSET_NAME}-core-$id.${STATEFULSET_NAME}.${NAMESPACE}.svc.cluster.local"
         auth="neo4j:${NEO4J_SECRETS_PASSWORD}"
-        url="http://${auth}@${host}:7474/db/${path}"
+        url="http://${auth}@${host}:7474/"
         attempts=10
         attempt=0
         while true; do
           attempt=$[$attempt + 1]
-          echo "Try $attempt: Connecting to $host:7474/db/${path}"
+          echo "Try $attempt: Connecting to $host:7474/"
           run wget ${url} -qO- 2>&1
           echo "Exit code: $status"
           [ $status -eq 0 ] && break
@@ -36,14 +36,15 @@ data:
       for id in $(seq 0 $((CORE_REPLICAS - 1))); do
         host="${STATEFULSET_NAME}-core-$id.${STATEFULSET_NAME}.${NAMESPACE}.svc.cluster.local"
         auth="neo4j:${NEO4J_SECRETS_PASSWORD}"
-        url="http://${auth}@${host}:7474/db/${path}"
+        url="http://${auth}@${host}:7474/db/system/tx/"
         attempts=10
         attempt=0
         while true; do
           attempt=$[$attempt + 1]
-          echo "Try $attempt: Connecting to $host:7474/db/${path}"
-          response=$(wget ${url} -qO- 2>&1)
-          [ "$response" = "true" ] && break
+          echo "Try $attempt: Connecting to $url"
+          response=$(wget ${url} --post-data='{"statements":[{"statement" : "SHOW DATABASES"}]}' --header 'Content-Type: application/json' -qO- 2>&1)
+          echo "SHOW DATABASES response:  $response"
+          [ "$?" = 0 ] && break
           [ "${attempt}" -ge "${attempts}" ] && exit 1
           sleep 5
         done

--- a/stable/neo4j/test.sh
+++ b/stable/neo4j/test.sh
@@ -9,7 +9,7 @@ echo "Testing we can get the cluster role of each server in statefulset ${STATEF
 
 check_role() {
   name=$1
-  end="$((SECONDS+360))"
+  end="$((SECONDS+600))"
   while true; do
     echo "checking cluster role: ${name} for systemdb"
     # In Neo4j 4.0 members now only have a cluster role with respect to a particular database.

--- a/stable/neo4j/test.sh
+++ b/stable/neo4j/test.sh
@@ -9,10 +9,11 @@ echo "Testing we can get the cluster role of each server in statefulset ${STATEF
 
 check_role() {
   name=$1
-  end="$((SECONDS+120))"
+  end="$((SECONDS+360))"
   while true; do
-    echo "checking cluster role: ${name}"
-    kubectl exec ${name} -n ${NS} -- bin/cypher-shell -u neo4j -p ${NEO4J_SECRETS_PASSWORD} "call dbms.cluster.role()" 2>/dev/null
+    echo "checking cluster role: ${name} for systemdb"
+    # In Neo4j 4.0 members now only have a cluster role with respect to a particular database.
+    kubectl exec ${name} -n ${NS} -- bin/cypher-shell -a ${name} -u neo4j -p ${NEO4J_SECRETS_PASSWORD} "call dbms.cluster.role('system')" 2>/dev/null
     response_code=$?
     [[ "0" = "$response_code" ]] && break
     [[ "${SECONDS}" -ge "${end}" ]] && exit 1
@@ -24,7 +25,7 @@ check_role() {
 for num in $(seq $CORE_REPLICAS); do
   id=$(expr $num - 1)
   name="${STATEFULSET_NAME}-core-$id"
-  echo "checking role of $name"
+  echo "checking role of $name for systemdb"
   check_role $name
 done
 

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -51,6 +51,7 @@ defaultDatabase: "neo4j"
 
 # Cores
 core:
+  # configMap: "my-custom-configmap"
   numberOfServers: 3
   persistentVolume:
     ## whether or not persistence is enabled
@@ -78,14 +79,6 @@ core:
     ##
     ## subPath: ""
 
-  ## Pass extra environment variables to the Neo4j container.
-  ##
-  # extraVars:
-  # - name: EXTRA_VAR_1
-  #   value: extra-var-value-1
-  # - name: EXTRA_VAR_2
-  #   value: extra-var-value-2
-
   sidecarContainers: []
   ## Additional containers to be added to the Neo4j core pod.
   #  - name: my-sidecar
@@ -109,6 +102,7 @@ core:
 
 # Read Replicas
 readReplica:
+  # configMap: "my-custom-configmap"
   resources: {}
   # limits:
   #   cpu: 100m
@@ -123,13 +117,6 @@ readReplica:
     maxReplicas: 3
 
   numberOfServers: 0
-  ## Pass extra environment variables to the Neo4j container.
-  ##
-  # extraVars:
-  # - name: EXTRA_VAR_1
-  #   value: extra-var-value-1
-  # - name: EXTRA_VAR_2
-  #   value: extra-var-value-2
 
   sidecarContainers: []
   ## Additional containers to be added to the Neo4j replica pod.

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -7,7 +7,7 @@ name: "neo4j"
 
 # Specs for the Neo4j docker image
 image: "neo4j"
-imageTag: "3.4.5-enterprise"
+imageTag: "4.0.3-enterprise"
 imagePullPolicy: "IfNotPresent"
 # imagePullSecret: registry-secret
 acceptLicenseAgreement: "no"
@@ -40,6 +40,10 @@ clusterDomain: "cluster.local"
 # Specs for the images used for running tests against the Helm package
 testImage: "markhneedham/k8s-kubectl"
 testImageTag: "master"
+
+# Whether or not to use APOC: https://neo4j.com/labs/apoc/
+# Comment out if you do not want to use it.
+useAPOC: "true"
 
 # Cores
 core:
@@ -85,7 +89,7 @@ core:
 
   initContainers: []
   ## init containers to run before the Neo4j core pod e.g. to install plugins
-
+  ## Note that this is specifically *not* needed for APOC, which is included by default.
   # - name: init-plugins
   #   image: "appropriate/curl:latest"
   #   imagePullPolicy: "IfNotPresent"
@@ -96,8 +100,8 @@ core:
   #     - "/bin/sh"
   #     - "-c"
   #     - |
-  #       curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.2.0.3/apoc-3.2.0.3-all.jar -O
-  #       cp apoc-3.2.0.3-all.jar /plugins/
+  #       curl -L https://somesite.com/path/to/plugin.jar -O
+  #       cp plugin.jar /plugins/
 
 # Read Replicas
 readReplica:
@@ -129,8 +133,8 @@ readReplica:
   #    image: nginx:latest
 
   initContainers: []
-  ## init containers to run before the Neo4j replica pod e.g. to install plugins
-
+  ## init containers to run before the Neo4j replica pod e.g. to install custom plugins
+  ## Note that this is specifically *not* needed for APOC, which is included by default.
   # - name: init-plugins
   #   image: "appropriate/curl:latest"
   #   imagePullPolicy: "IfNotPresent"
@@ -141,8 +145,8 @@ readReplica:
   #     - "/bin/sh"
   #     - "-c"
   #     - |
-  #       curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.2.0.3/apoc-3.2.0.3-all.jar -O
-  #       cp apoc-3.2.0.3-all.jar /plugins/
+  #       curl -L https://somesite.com/path/to/plugin.jar -O
+  #       cp plugin.jar /plugins/
 
 resources: {}
 # limits:

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -86,6 +86,8 @@ core:
 
   initContainers: []
   ## init containers to run before the Neo4j core pod e.g. to install plugins
+  ## They can also be used to restore from last available backup, to ensure that newly joining
+  ## core members have less TX history to catch up on before joining the cluster.
   ## Note that this is specifically *not* needed for APOC, which is included by default.
   # - name: init-plugins
   #   image: "appropriate/curl:latest"
@@ -125,6 +127,8 @@ readReplica:
 
   initContainers: []
   ## init containers to run before the Neo4j replica pod e.g. to install custom plugins
+  ## They can also be used to restore from last available backup, to ensure that newly joining
+  ## core members have less TX history to catch up on before joining the cluster.
   ## Note that this is specifically *not* needed for APOC, which is included by default.
   # - name: init-plugins
   #   image: "appropriate/curl:latest"

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -38,6 +38,7 @@ authEnabled: true
 clusterDomain: "cluster.local"
 
 # Specs for the images used for running tests against the Helm package
+# https://github.com/mneedham/k8s-kubectl this is a general kubectl docker image
 testImage: "markhneedham/k8s-kubectl"
 testImageTag: "master"
 

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -45,6 +45,10 @@ testImageTag: "master"
 # Comment out if you do not want to use it.
 useAPOC: "true"
 
+# The default name of the Neo4j database to use.
+# See https://neo4j.com/docs/operations-manual/current/manage-databases/introduction/#manage-databases-default
+defaultDatabase: "neo4j"
+
 # Cores
 core:
   numberOfServers: 3


### PR DESCRIPTION
#### What this PR does / why we need it:

- Neo4j [released a major new version (4.0)](https://neo4j.com/press-releases/announcing-neo4j-4-0/) which has a bunch of substantial new features:  multi-database, fine-grained security, fabric queries, and others.  This version has some substantial differences/incompatibilities from the old series (3.5) that the old chart is based on
- Fixes #21439 by enabling custom configuration to be passed to all pods with a simple configmap name.
- Adds simple readiness and liveness probes, for indications of when cluster formation has been successful.
- Adds APOC installed by default.  Most users want APOC in, so this has been done by default with a toggle (useAPOC) which can be trivially set to false if APOC is not wanted.  This saves users from setting up initContainers themselves each time.
- Adds a service for contacting read replicas.  This is useful when read-only analytic workloads need to be pointed to an auto-scaling subset of cluster members.
- Adds a lot of useful Links, References, and additional documentation for people who use the chart with information on techniques like backup & recovery for Neo4j in Kubernetes

So this PR enables a major new set of features with Neo4j 4.0.  As such, and because the underlying product versions were revised by a major version, the chart version is going up a major version as well.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
