### PR TITLE
[stable/eventrouter] add bclermont to OWNERS

### DIFF
--- a/stable/eventrouter/OWNERS
+++ b/stable/eventrouter/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - gianrubio
+- bclermont
 reviewers:
 - gianrubio
+- bclermont


### PR DESCRIPTION
As @gianrubio don't actively maintains `stable/eventrouter` anymore, I propose myself.

Please @gianrubio review #21522 first and if you accept to merge this PR I will review #21709

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped **NOT -  WAITING FOR #21522**
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
