### PR TITLE
[stable/selenium] Add configurable securityContext in all selenium deployments

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.0.11
+version: 1.0.12
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `hub.servicePort` | The port the hub Service listens on | `4444` |
 | `hub.nodePort` | The port the hub is exposed when Nodeport mode is selected | `nil` |
 | `hub.podAnnotations` | Annotations on the hub pod | `{}` |
+| `hub.securityContext` |	SecurityContext on the hub pod |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `hub.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `hub.javaOpts` | The java options for the selenium hub JVM, default sets the maximum heap size to 400 mb | `-Xmx400m` |
 | `hub.resources` | The resources for the hub container, defaults to minimum half a cpu and maximum 512 mb RAM | `{"limits":{"cpu":".5", "memory":"512Mi"}}` |
@@ -90,6 +91,7 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `chrome.pullPolicy` | The pull policy for the node chrome image | `IfNotPresent` |
 | `chrome.replicas` | The number of selenium node chrome pods | `1` |
 | `chrome.podAnnotations` | Annotations on the chrome pods | `{}` |
+| `chrome.securityContext` |	SecurityContext on the chrome pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `chrome.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `chrome.javaOpts` | The java options for the selenium node chrome JVM, default sets the maximum heap size to 900 mb | `-Xmx900m` |
 | `chrome.volumeMounts` | Additional volumes to mount, the default provides a larger shared memory | `[{"mountPath":"/dev/shm", "name":"dshm"}]` |
@@ -116,6 +118,7 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `chromeDebug.pullPolicy` | The selenium node chrome debug pull policy | `IfNotPresent` |
 | `chromeDebug.replicas` | The number of selenium node chrome debug pods | `1` |
 | `chromeDebug.podAnnotations` | Annotations on the Chrome debug pod | `{}` |
+| `chromeDebug.securityContext` |	SecurityContext on the Chrome debug pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `chromeDebug.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `chromeDebug.javaOpts` | The java options for a selenium node chrome debug JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
 | `chromeDebug.volumeMounts` | Additional volumes to mount, the default provides a larger shared | `[{"mountPath":"/dev/shm", "name":"dshm"}]` |
@@ -142,6 +145,7 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `firefox.pullPolicy` | The selenium node firefox pull policy | `IfNotPresent` |
 | `firefox.replicas` | The number of selenium node firefox pods | `1` |
 | `firefox.podAnnotations` | Annotations on the firefox pods | `{}` |
+| `firefox.securityContext` |	SecurityContext on the firefox pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `firefox.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `firefox.javaOpts` | The java options for a selenium node firefox JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
 | `firefox.resources` | The resources for the hub container, defaults to minimum half a cpu and maximum 1,000 mb | `{"limits":{"cpu":".5", "memory":"1000Mi"}}` |
@@ -166,6 +170,7 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `firefoxDebug.pullPolicy` | The selenium node firefox debug pull policy | `IfNotPresent` |
 | `firefoxDebug.replicas` | The number of selenium node firefox debug pods | `1` |
 | `firefoxDebug.podAnnotations` | Annotations on the firefox debug pods | `{}` |
+| `firefoxDebug.securityContext` |	SecurityContext on the firefox debug pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `firefoxDebug.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `firefoxDebug.javaOpts` | The java options for a selenium node firefox debug JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
 | `firefoxDebug.resources` | The resources for the selenium node firefox debug container, defaults to minimum half a cpu and maximum 1,000 mb | `{"limits":{"cpu":".5", "memory":"1000Mi"}}` |

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.chrome.podAnnotations | indent 8 }}
       {{- end}}
     spec:
+      {{- if .Values.chrome.securityContext }}
+      securityContext:
+{{ toYaml .Values.chrome.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.chrome.image }}:{{ .Values.chrome.tag }}"

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.chromeDebug.podAnnotations | indent 8 }}
       {{- end}}
     spec:
+      {{- if .Values.chromeDebug.securityContext }}
+      securityContext:
+{{ toYaml .Values.chromeDebug.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.chromeDebug.image }}:{{ .Values.chromeDebug.tag }}"

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.firefox.podAnnotations | indent 8 }}
       {{- end}}
     spec:
+      {{- if .Values.firefox.securityContext }}
+      securityContext:
+{{ toYaml .Values.firefox.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.firefox.image }}:{{ .Values.firefox.tag }}"

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.firefoxDebug.podAnnotations | indent 8 }}
       {{- end}}
     spec:
+      {{- if .Values.firefoxDebug.securityContext }}
+      securityContext:
+{{ toYaml .Values.firefoxDebug.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.firefoxDebug.image }}:{{ .Values.firefoxDebug.tag }}"

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -22,6 +22,10 @@ spec:
 {{ toYaml .Values.hub.podAnnotations | indent 8 }}
       {{- end}}
     spec:
+      {{- if .Values.hub.securityContext }}
+      securityContext:
+{{ toYaml .Values.hub.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.hub.image }}:{{ .Values.hub.tag }}"

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -53,6 +53,11 @@ hub:
   ## Path for checking readiness and liveness via HTTP Request
   probePath: "/wd/hub/status"
 
+  # Configure security context on the hub pod
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+
   ## Additional environment variables to set
   extraEnvs: []
   # extraEnvs:
@@ -168,6 +173,11 @@ chrome:
   ## Configure annotations on the chrome pods
   podAnnotations: {}
 
+  # Configure security context on the chrome pods
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+
   ## Additional environment variables to set
   extraEnvs: []
   # extraEnvs:
@@ -259,6 +269,11 @@ chromeDebug:
   ## Configure annotations on the chrome debug pods
   podAnnotations: {}
 
+  # Configure security context on the chrome debug pods
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+
   ## Additional environment variables to set
   extraEnvs: []
   # extraEnvs:
@@ -349,6 +364,11 @@ firefox:
   ## Configure annotations on the firefox pods
   podAnnotations: {}
 
+  # Configure security context on the firefox pods
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+
   ## Additional environment variables to set
   extraEnvs: []
   # extraEnvs:
@@ -425,6 +445,11 @@ firefoxDebug:
 
   ## Configure annotations on the firefox debug pods
   podAnnotations: {}
+
+  # Configure security context on the firefox debug pods
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
 
   ## Additional environment variables to set
   extraEnvs: []

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -54,9 +54,9 @@ hub:
   probePath: "/wd/hub/status"
 
   # Configure security context on the hub pod
-  securityContext:
-    fsGroup: 1000
-    runAsUser: 1000
+  # securityContext:
+  #   fsGroup: 1000
+  #   runAsUser: 1000
 
   ## Additional environment variables to set
   extraEnvs: []
@@ -174,9 +174,9 @@ chrome:
   podAnnotations: {}
 
   # Configure security context on the chrome pods
-  securityContext:
-    fsGroup: 1000
-    runAsUser: 1000
+  # securityContext:
+  #   fsGroup: 1000
+  #   runAsUser: 1000
 
   ## Additional environment variables to set
   extraEnvs: []
@@ -270,9 +270,9 @@ chromeDebug:
   podAnnotations: {}
 
   # Configure security context on the chrome debug pods
-  securityContext:
-    fsGroup: 1000
-    runAsUser: 1000
+  # securityContext:
+  #   fsGroup: 1000
+  #   runAsUser: 1000
 
   ## Additional environment variables to set
   extraEnvs: []
@@ -365,9 +365,9 @@ firefox:
   podAnnotations: {}
 
   # Configure security context on the firefox pods
-  securityContext:
-    fsGroup: 1000
-    runAsUser: 1000
+  # securityContext:
+  #   fsGroup: 1000
+  #   runAsUser: 1000
 
   ## Additional environment variables to set
   extraEnvs: []
@@ -447,9 +447,9 @@ firefoxDebug:
   podAnnotations: {}
 
   # Configure security context on the firefox debug pods
-  securityContext:
-    fsGroup: 1000
-    runAsUser: 1000
+  # securityContext:
+  #   fsGroup: 1000
+  #   runAsUser: 1000
 
   ## Additional environment variables to set
   extraEnvs: []


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
This adds the possibility to configure the security context in the Selenium deployments. I set the default user to 1000 as it's what is being used by the underlying image: https://github.com/SeleniumHQ/docker-selenium/blob/master/Base/Dockerfile. Not sure if this should be considered a breaking change or not. I hope a "patch" version bump is ok

#### Which issue this PR fixes
I didn't open an issue

#### Special notes for your reviewer:
This is my first PR to a public repo of this size. Please be patient if you find I made some mistakes.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)