### PR TITLE
[stable/prometheus-adapter] Defining a variable for listen port

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.2.1
+version: 2.3.0
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.2.0
+version: 2.2.1
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -116,6 +116,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
 | `image.pullSecrets`             | Image pull secrets                                                              | `{}`                                        |
 | `logLevel`                      | Log level                                                                       | `4`                                         |
+| `listenPort`                    | Port that application would listen on in the container                          | `6443`                                      |
 | `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `1m`                                        |
 | `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
 | `podLabels`                     | Labels to add to the pod                                                        | `{}`                                        |

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - /adapter
-        - --secure-port=6443
+        - --secure-port={{ .Values.listenPort }}
         {{- if .Values.tls.enable }}
         - --tls-cert-file=/var/run/serving-cert/tls.crt
         - --tls-private-key-file=/var/run/serving-cert/tls.key
@@ -52,7 +52,7 @@ spec:
         - --v={{ .Values.logLevel }}
         - --config=/etc/adapter/config.yaml
         ports:
-        - containerPort: 6443
+        - containerPort: {{ .Values.listenPort }}
           name: https
         livenessProbe:
           httpGet:

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -10,6 +10,8 @@ logLevel: 4
 
 metricsRelistInterval: 1m
 
+listenPort: 6443
+
 nodeSelector: {}
 
 priorityClassName: ""


### PR DESCRIPTION
## What this PR does / why we need it:

Defines a variable for listen port of the application so it can be changed to the purpose.

#### Which issue this PR fixes
- addresses https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/134#issuecomment-439904042
- addresses https://github.com/kubernetes-sigs/metrics-server/issues/45#issuecomment-541110986

#### Special notes for your reviewer:

Changing the port for GKE deployment is the easiest approach since the firewall rules in GCP can't be easily updated through IaC and require [extra software](https://cloud.google.com/config-connector/docs/overview) to be deployed.


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
