### PR TITLE
[stable/datadog] incorrect indentation in cluster-agent-deployment.yaml #21921

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Datadog changelog
+## 2.2.1
+
+* Fix indentation for `clusterAgent.volumes`.
+
 
 ## 2.2.1
 

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.2.1
+version: 2.2.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -182,7 +182,7 @@ spec:
 {{- end}}
 
 {{- if .Values.clusterAgent.volumes }}
-{{ toYaml .Values.clusterAgent.volumes | indent 10 }}
+{{ toYaml .Values.clusterAgent.volumes | indent 8 }}
 {{- end }}
       {{- if .Values.clusterAgent.tolerations }}
       tolerations:


### PR DESCRIPTION
#### Is this a new chart
No.
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #21921

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
