### PR TITLE
[stable/prometheus-mongodb-exporter] Provide the possibility for referring to an existing secret to use the MongoDB URI from

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.4.0
+version: 2.5.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -15,7 +15,8 @@ This command deploys the MongoDB Exporter with the default configuration. The [c
 
 ## Using the Chart
 
-To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string).
+To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string)
+or an existing secret (in the releases namespace) containing the key `mongodb-uri` with the URI is referred via `existingSecret.name`.
 If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports
 connecting to either a MongoDB replica set member, shard, or standalone instance.
 
@@ -35,13 +36,14 @@ podAnnotations:
 |-----------|-------------|---------|
 | `affinity` | Node/pod affinities | `{}` |
 | `annotations` | Annotations to be added to the pods | `{}` |
+| `existingSecret.name` | Refer to an existing secret instead of using `mongodb.uri` | `` |
 | `extraArgs` | The extra command line arguments to pass to the MongoDB Exporter  | See values.yaml |
 | `fullnameOverride` | Override the full chart name | `` |
 | `image.pullPolicy` | MongoDB Exporter image pull policy | `IfNotPresent` |
 | `image.repository` | MongoDB Exporter image name | `ssheehy/mongodb-exporter` |
 | `image.tag` | MongoDB Exporter image tag | `0.10.0` |
 | `imagePullSecrets` | List of container registry secrets | `[]` |
-| `mongodb.uri` | The required [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
+| `mongodb.uri` | The [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
 | `nameOverride` | Override the application name  | `` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `podAnnotations` | Annotations to be added to all pods | `{}` |
@@ -62,8 +64,3 @@ podAnnotations:
 | `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | `` |
 | `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}` |
 | `tolerations` | List of node taints to tolerate  | `[]` |
-
-## Limitations
-
-Connecting to MongoDB via TLS is currently not supported.
-

--- a/stable/prometheus-mongodb-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-mongodb-exporter/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Determine secret name, can either be the self-created of an existing one
+*/}}
+{{- define "prometheus-mongodb-exporter.secretName" -}}
+{{- if .Values.existingSecret.name -}}
+    {{- .Values.existingSecret.name -}}
+{{- else -}}
+    {{ include "prometheus-mongodb-exporter.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           - name: MONGODB_URI
             valueFrom:
               secretKeyRef:
-                name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+                name: {{ include "prometheus-mongodb-exporter.secretName" . }}
                 key: mongodb-uri
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}

--- a/stable/prometheus-mongodb-exporter/templates/secret.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.existingSecret.name -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+  name: {{ include "prometheus-mongodb-exporter.secretName" . }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:
   mongodb-uri: {{ required "A MongoDB URI is required" .Values.mongodb.uri | b64enc }}
+{{- end -}}

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -24,9 +24,14 @@ livenessProbe:
     port: metrics
   initialDelaySeconds: 10
 
-# [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]
+# [mongodb[+srv]://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]
 mongodb:
-  uri:
+  uri: ""
+
+# Name of an externally managed secret (in the same namespace) containing the connection uri as key `mongodb-uri`.
+# If this is provided, the value mongodb.uri is ignored.
+existingSecret:
+  name: ""
 
 nameOverride: ""
 


### PR DESCRIPTION
For use with a GitOps approach utilizing Weaveworks Flux & HelmOperator as well as Bitnamis Sealed-Secrets controller it is necessary to externalize the MongoDB connection URI since the charts values are checked in as plain text.
