### PR TITLE
[stable/home-assistant] fix port for VSCode extension

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.107.7
 description: Home Assistant
 name: home-assistant
-version: 0.12.7
+version: 0.12.8
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/templates/service.yaml
+++ b/stable/home-assistant/templates/service.yaml
@@ -58,7 +58,7 @@ spec:
     - name: vscode
       port: {{ .Values.vscode.service.port }}
       protocol: TCP
-      targetPort: 80
+      targetPort: {{ .Values.vscode.service.port }}
 {{ if (and (eq .Values.vscode.service.type "NodePort") (not (empty .Values.vscode.service.nodePort))) }}
       nodePort: {{.Values.vscode.service.nodePort}}
 {{ end }}


### PR DESCRIPTION
#### Is this a new chart
no
#### What this PR does / why we need it:
When we specify vscode.service.port the port gets adjusted
everywhere but in the targetPort definition of the home-assistant
service. This PR fixes that.

#### Which issue this PR fixes
none

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
