### PR TITLE
[stable/jenkins] fix yaml template rendering in kubernetes pod template JCasC

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.13.1
+
+Fix yaml template rendering in kubernetes pod template JCasC
+
 ## 1.13.0
 
 Add `master.networkPolicy.internalAgents` and `master.networkPolicy.externalAgents` stanzas to fine grained controls over where internal/external agents can connect from. Internal ones are allowed based on pod labels and (optionally) namespaces, and external ones are allowed based on IP ranges.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
 
-version: 1.13.0
+version: 1.13.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -178,8 +178,10 @@ Returns kubernetes pod template configuration as code
   showRawYaml: true
   serviceAccount: "{{ include "jenkins.serviceAccountAgentName" . }}"
   slaveConnectTimeoutStr: "{{ .Values.agent.slaveConnectTimeout }}"
+  {{- if .Values.agent.yamlTemplate }}
   yaml: |-
-    {{ tpl .Values.agent.yamlTemplate . | nindent 10 | trim }}
+  {{- tpl ( trim .Values.agent.yamlTemplate ) . | nindent 4 }}
+  {{- end }}
   yamlMergeStrategy: "override"
 {{- end -}}
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
fix yaml template rendering in kubernetes pod template JCasC

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

## helm template tests
### default values
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true
```
#### original formatting
```yaml
{{ tpl .Values.agent.yamlTemplate . | nindent 10 | trim }}
```
```yaml
              slaveConnectTimeoutStr: "100"
              yaml: |-
                
              yamlMergeStrategy: "override"
```
#### proposed formatting
```yaml
  {{- if .Values.agent.yamlTemplate }}
  yaml: |-
  {{- tpl ( trim .Values.agent.yamlTemplate ) . | nindent 4 }}
  {{- end }}
```
```yaml
              slaveConnectTimeoutStr: "100"
              yamlMergeStrategy: "override"
```
### agent-values.yaml
I placed the following in stable/jenkins/agent-values.yaml
```yaml
agent:
  # includes trailing whitespace to test trim
  yamlTemplate: |-
    apiVersion: v1
    kind: Pod
    spec:
      tolerations:
      - key: "key"
        operator: "Equal"
        value: {{ .Values.tolerations }}
        
tolerations: 10
```
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--values stable/jenkins/agent-values.yaml
```
#### original formatting
```yaml
{{ tpl .Values.agent.yamlTemplate . | nindent 10 | trim }}
```
```yaml
              slaveConnectTimeoutStr: "100"
              yaml: |-
                apiVersion: v1
                      kind: Pod
                      spec:
                        tolerations:
                        - key: "key"
                          operator: "Equal"
                          value: 10
              yamlMergeStrategy: "override"
```
#### proposed formatting
```yaml
  {{- if .Values.agent.yamlTemplate }}
  yaml: |-
  {{- tpl ( trim .Values.agent.yamlTemplate ) . | nindent 4 }}
  {{- end }}
```
```yaml
              slaveConnectTimeoutStr: "100"
              yaml: |-
                apiVersion: v1
                kind: Pod
                spec:
                  tolerations:
                  - key: "key"
                    operator: "Equal"
                    value: 10
              yamlMergeStrategy: "override"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
