### PR TITLE
[stable/spinnaker] Fix incorrect dockerRegistry password-command quoting

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc2
+version: 2.0.0-rc3
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -104,9 +104,9 @@ dockerRegistries:
 #   password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
 #   email: 1234@5678.com
 # - name: ecr
-#   address: https://<AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
+#   address: <AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
 #   username: AWS
-#   passwordCommand: "aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'"
+#   passwordCommand: aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'
 ```
 
 You can provide passwords as a Helm value, or you can use a pre-created secret containing your registry passwords.  The secret should have an item per Registry in the format: `<registry name>: <password>`. In which case you'll specify the secret to use in `dockerRegistryAccountSecret` like so:

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -99,21 +99,11 @@ data:
       PROVIDER_COMMAND='add'
     fi
 
-    CREDS=""
-    {{ if $registry.username -}}
-    CREDS+="--username {{ $registry.username }}"
-    {{ if $registry.passwordCommand -}}
-    CREDS+=" --password-command {{ $registry.passwordCommand | quote }}"
-    {{- else -}}
-    CREDS+=" --password-file /opt/registry/passwords/{{ $registry.name }}"
-    {{- end -}}
-    {{ if $registry.email }}
-    CREDS+=" --email {{ $registry.email }}"
-    {{- end -}}
-    {{- end }}
-
     $HAL_COMMAND config provider docker-registry account $PROVIDER_COMMAND {{ $registry.name }} --address {{ $registry.address }} \
-        ${CREDS} {{ if $registry.repositories }} --repositories {{ range $index, $repository := $registry.repositories }}{{if $index}},{{end}}{{- $repository }}{{- end }}{{- end }}
+      {{ if $registry.username -}} --username {{ $registry.username }} \
+      {{ if $registry.passwordCommand -}} --password-command "{{ $registry.passwordCommand }}"{{ else -}} --password-file /opt/registry/passwords/{{ $registry.name }}{{- end }} \
+      {{ if $registry.email -}} --email {{ $registry.email }}{{- end -}}{{- end }} \
+      {{ if $registry.repositories -}} --repositories {{ range $index, $repository := $registry.repositories }}{{if $index}},{{end}}{{- $repository }}{{- end }}{{- end }}
 
     {{- end }}
 

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -150,7 +150,7 @@ dockerRegistries:
 # - name: ecr
 #   address: <AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
 #   username: AWS
-#   passwordCommand: "aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'"
+#   passwordCommand: aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'
 
 # If you don't want to put your passwords into a values file
 # you can use a pre-created secret instead of putting passwords

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -1,8 +1,8 @@
 halyard:
-  spinnakerVersion: 1.16.7
+  spinnakerVersion: 1.19.4
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
-    tag: 1.31.1
+    tag: 1.32.0
     pullSecrets: []
   # Set to false to disable persistence data volume for halyard
   persistence:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The current version of the `password-command` is being incorrectly quoted / string-escaped for use with Halyard.
As the linked issue states, it wraps the passed in `password-command` in double-quotes - this immediately ends the `CRED` string, so password-commands will never be passed to the provider.
Using single quotes or your own `\` also doesn't work as the string-escaping occurs in the wrong places - when passed to Halyard, it will swap the double-quotes for single-quotes and do it's own escaping, so it is safe to wrap it once in double-quotes, rather than do string-concatenation. 
This new format follows the `kubernetes` provider format below

This is especially noticeable when trying to log into AWS ECR repos. 

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/21947

#### Special notes for your reviewer:
This change has been tested in our own clusters and we have been using it - it replicates the way we have been adding ECR repos via `additional_scripts`

Passing in the raw password-command when on the Halyard pod works, so it is not an issue with that

#####Mentions
@dwardu89 
@ezimanyi 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
