### PR TITLE
[stable/prometheus] Fix rollingUpdate: null indentation Recreate fix for helm3

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.1.1
+version: 11.1.2
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -12,9 +12,9 @@ spec:
   replicas: {{ .Values.alertmanager.replicaCount }}
   {{- if .Values.alertmanager.strategy }}
   strategy:
-{{ toYaml .Values.alertmanager.strategy | indent 4 }}
-  {{- if eq .Values.alertmanager.strategy.type "Recreate" }}rollingUpdate: null{{- end }}
-  {{- end }}
+{{ toYaml .Values.alertmanager.strategy | trim | indent 4 }}
+    {{ if eq .Values.alertmanager.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
+{{- end }}
   template:
     metadata:
     {{- if .Values.alertmanager.podAnnotations }}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -15,9 +15,9 @@ spec:
   replicas: {{ .Values.pushgateway.replicaCount }}
   {{- if .Values.pushgateway.strategy }}
   strategy:
-{{ toYaml .Values.pushgateway.strategy | indent 4 }}
-  {{- if eq .Values.pushgatway.strategy.type "Recreate" }}rollingUpdate: null{{- end }}
-  {{- end }}
+{{ toYaml .Values.pushgateway.strategy | trim | indent 4 }}
+    {{ if eq .Values.pushgateway.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
+{{- end }}
   template:
     metadata:
     {{- if .Values.pushgateway.podAnnotations }}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -17,9 +17,9 @@ spec:
   replicas: {{ .Values.server.replicaCount }}
   {{- if .Values.server.strategy }}
   strategy:
-{{ toYaml .Values.server.strategy | indent 4 }}
-  {{- if eq .Values.server.strategy.type "Recreate" }}rollingUpdate: null{{- end }}
-  {{- end }}
+{{ toYaml .Values.server.strategy | trim | indent 4 }}
+    {{ if eq .Values.server.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
+{{- end }}
   template:
     metadata:
     {{- if .Values.server.podAnnotations }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The change in https://github.com/helm/charts/pull/21976 was not compatible in helm 3.

#### Special notes for your reviewer:
I have tested this against helm ( `v2.16.2`, `v2.13.1`, `v3.1.1`)

The change in  https://github.com/helm/charts/pull/21976 worked in helm2, but failed in helm3. This was noted in https://github.com/helm/charts/pull/21976#issuecomment-615262475

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
