### PR TITLE
[stable/sentry] Pull S3 secrets from Secret rather than ConfigMap

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 4.1.1
+version: 4.2.0
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -168,6 +168,7 @@ Parameter                                            | Description              
 `filestore.gcs.bucketName`                           | The name of the GCS bucket                                                                                 | `nil`
 `filestore.s3.accessKey`                             | S3 access key                                                                                              | `nil`
 `filestore.s3.secretKey`                             | S3 secret key                                                                                              | `nil`
+`filestore.s3.existingSecret`                        | Name of existing secret to use for the S3 keys                                                             | `nil`
 `filestore.s3.bucketName`                            | The name of the S3 bucket                                                                                  | `nil`
 `filestore.s3.endpointUrl`                           | The endpoint url of the S3 (using for "MinIO S3 Backend")                                                  | `nil`
 `filestore.s3.signature_version`                     | S3 signature version (optional)                                                                            | `nil`

--- a/stable/sentry/templates/configmap.yaml
+++ b/stable/sentry/templates/configmap.yaml
@@ -76,12 +76,6 @@ data:
     {{ end }}
     {{- if eq .Values.filestore.backend "s3" }}
     filestore.options:
-      {{- if .Values.filestore.s3.accessKey }}
-      access_key: '{{ .Values.filestore.s3.accessKey }}'
-      {{- end }}
-      {{- if .Values.filestore.s3.secretKey }}
-      secret_key: '{{ .Values.filestore.s3.secretKey }}'
-      {{- end }}
       {{- if .Values.filestore.s3.bucketName }}
       bucket_name: '{{ .Values.filestore.s3.bucketName }}'
       {{- end }}

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -28,3 +28,7 @@ data:
   {{ if and (not .Values.redis.enabled) (.Values.redis.password) }}
   redis-password: {{ .Values.redis.password | default "" | b64enc | quote }}
   {{ end }}
+  {{- if and (eq .Values.filestore.backend "s3") (not .Values.filestore.s3.existingSecret) }}
+  AWS_ACCESS_KEY_ID: {{ .Values.filestore.s3.accessKey | default "" | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.filestore.s3.secretKey | default "" | b64enc | quote }}
+  {{- end }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -119,6 +119,26 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
+        {{- if eq .Values.filestore.backend "s3" }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.filestore.s3.existingSecret }}
+              name: {{ .Values.filestore.s3.existingSecret }}
+            {{- else }}
+              name: {{ template "sentry.fullname" . }}
+            {{- end }}
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.filestore.s3.existingSecret }}
+              name: {{ .Values.filestore.s3.existingSecret }}
+            {{- else }}
+              name: {{ template "sentry.fullname" . }}
+            {{- end }}
+              key: AWS_SECRET_ACCESS_KEY
+        {{- end }}
 {{- if .Values.web.env }}
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -129,6 +129,26 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/google/{{ .Values.filestore.gcs.credentialsFile }}
         {{ end }}
+        {{- if eq .Values.filestore.backend "s3" }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.filestore.s3.existingSecret }}
+              name: {{ .Values.filestore.s3.existingSecret }}
+            {{- else }}
+              name: {{ template "sentry.fullname" . }}
+            {{- end }}
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.filestore.s3.existingSecret }}
+              name: {{ .Values.filestore.s3.existingSecret }}
+            {{- else }}
+              name: {{ template "sentry.fullname" . }}
+            {{- end }}
+              key: AWS_SECRET_ACCESS_KEY
+        {{- end }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 8 }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR aims to provide a better way to supply S3 credentials for the filestore in Sentry. Previously this was done by injecting the secrets into the ConfigMap, which one major issue: keys have to be provided manually in the values.yaml file and can not be shared with other resources in the cluster (i.e. a Minio instance).

This PR solves the problem in two ways:
1. Pull the S3 credentials from the env vars rather than the ConfigMap. This is a poorly documented feature, but can be found [here](https://github.com/getsentry/sentry/blob/master/src/sentry/filestore/s3.py#L260).
2. Implement the `existingSecret` idiom commonly used in Helm chart. 

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
