### PR TITLE
Fix/empty mount dir datadog chart

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.2.2
+version: 2.2.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -76,13 +76,7 @@ Return the container runtime socket
 */}}
 {{- define "datadog.dockerOrCriSocketPath" -}}
 {{- if eq .Values.targetSystem "linux" -}}
-{{- if .Values.datadog.dockerSocketPath -}}
-{{- .Values.dockerSocketPath -}}
-{{- else if .Values.datadog.criSocketPath -}}
-{{- .Values.datadog.criSocketPath -}}
-{{- else -}}
-/var/run/docker.sock
-{{- end -}}
+{{- .Values.datadog.dockerSocketPath | default .Values.datadog.criSocketPath | default "/var/run/docker.sock" -}}
 {{- end -}}
 {{- if eq .Values.targetSystem "windows" -}}
 \\.\pipe\docker_engine


### PR DESCRIPTION
…include

Signed-off-by: Javier Toledo <javiertoledos@gmail.com>

#### Which issue this PR fixes
  - fixes #21992

#### Special notes for your reviewer:
It seems that the go templating engine doesn't play nice with the nested ifs in the datadog.dockerOrCriSocketPath helper

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
