### PR TITLE
[stable/jenkins] Fixing wrong indent in tolerations key.

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.13.3
+
+Fix wrong indent in tolerations
+
 ## 1.13.2
 
 Add support for custom ClusterIP

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
 
-version: 1.13.2
+version: 1.13.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -114,7 +114,7 @@ spec:
                       values:
                       - {{ .Release.Name }}
       {{- with .Values.tolerations }}
-        tolerations:
+          tolerations:
 {{ toYaml . | indent 10 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Andres Pozo <andpozo@gmail.com>

#### Which issue this PR fixes
  - fixes error when try to install this chart with tolerations key in `values.yaml`
