### PR TITLE
[stable/prometheus-adapter] fix ClusterRole permissions

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.3.0
+version: 2.3.1
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
@@ -19,4 +19,5 @@ rules:
   verbs:
   - get
   - list
+  - watch
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Fixes ClusterRole permissions for prometheus-adapter custom-metrics resource-reader

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/274

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
