### PR TITLE
[stable/newrelic-infrastructure] Explicitly define the namespace in manifests.

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.13.29
+version: 0.13.30
 appVersion: 1.18.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/stable/newrelic-infrastructure/templates/configmap.yaml
+++ b/stable/newrelic-infrastructure/templates/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic.labels" . | indent 4 }}
   name: {{ template "newrelic.fullname" . }}
 data:
@@ -13,8 +14,9 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic.labels" . | indent 4 }}
-  name: {{ template "newrelic.fullname" . }}-integrations-cfg 
+  name: {{ template "newrelic.fullname" . }}-integrations-cfg
 data:
 {{ range .Values.integrations_config -}}
 {{ .name | indent 2 }}: |

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic.labels" . | indent 4 }}
   name: {{ template "newrelic.fullname" . }}
 spec:

--- a/stable/newrelic-infrastructure/templates/secret.yaml
+++ b/stable/newrelic-infrastructure/templates/secret.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "newrelic.labels" . | indent 4 }}
   name: {{ template "newrelic.fullname" . }}-config
 type: Opaque

--- a/stable/newrelic-infrastructure/templates/serviceaccount.yaml
+++ b/stable/newrelic-infrastructure/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "newrelic.name" . }}
     chart: {{ template "newrelic.chart" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This is needed in order to render the templates with the correct
namespace when passed the --namespace flag. This is required for tools
like Spinnaker.

This doesn't affect installing directly from helm since helm adds the
value directly from the --namespace flag.

For reference https://github.com/helm/helm/issues/5465

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
