### PR TITLE
[stable/fluentd] Fix statefulset manifest without autoscaling

### DIFF
--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -13,17 +13,17 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-{{- if not .Values.autoscaling.enabled }}
+{{- if not $statefulSet }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
-{{- if .Values.autoscaling.enabled }}
+{{- if $statefulSet }}
   serviceName: {{ template "fluentd.name" . }}
 {{- end }}
   selector:
     matchLabels:
       app: {{ template "fluentd.name" . }}
       release: {{ .Release.Name }}
-  {{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) }}
+  {{- if and .Values.persistence.enabled (not $statefulSet) }}
   strategy:
     type: Recreate
   {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:

When applying the chart with `useStatefulset: true` but without `autoscaling.enabled` I get the following error:

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec
```

#### Which issue this PR fixes

I don't know if an issue exists.

#### Special notes for your reviewer:

I have not tested this at all. See this as an issue ticket with a quick suggestion if you like. Sorry.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
