### PR TITLE
[stable/gitlab-ee] GitLab: mark very old stable/gitlab-* deprecated

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,8 +1,9 @@
 name: gitlab-ce
 deprecated: true
-version: 0.2.2
+version: 0.2.3
 appVersion: 9.4.1
-description: GitLab Community Edition
+deprecated: true
+description: DEPRECATED GitLab Community Edition
 keywords:
 - git
 - ci

--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,8 +1,9 @@
 name: gitlab-ee
 deprecated: true
-version: 0.2.2
+version: 0.2.3
 appVersion: 9.4.1
-description: GitLab Enterprise Edition
+deprecated: true
+description: DEPRECATED GitLab Enterprise Edition
 keywords:
 - git
 - ci


### PR DESCRIPTION
GitLab: mark very old stable/gitlab-* deprecated

#### Is this a new chart

No.

#### What this PR does / why we need it:

Very old, long deprecated Omnibus GitLab charts are deprecated.
Mark as so with `deprecated: true`. READMEs were updated long ago.

- stable/gitlab-ee
- stable/gitlab-ce

Replaced with charts.gitlab.io, gitlab/gitlab

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
