### PR TITLE
[stable/jenkins] Render agent.volumes in kubernetes pod template JCasC

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.17.0
+
+Render `agent.volumes` in kubernetes pod template JCasC
+
 ## 1.16.2
 
 Reverts 1.16.1 as it introduced an error #22047
@@ -42,7 +46,7 @@ Add support for custom ClusterIP
 
 ## 1.13.1
 
-Fix yaml template rendering in kubernetes pod template JCasC
+Fix `agent.yamlTemplate` rendering in kubernetes pod template JCasC
 
 ## 1.13.0
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.16.2
+version: 1.17.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/ci/other-values.yaml
+++ b/stable/jenkins/ci/other-values.yaml
@@ -39,3 +39,7 @@ agent:
             resourceRequestMemory: "512Mi"
             resourceLimitCpu: "1"
             resourceLimitMemory: "1024Mi"
+  volumes:
+    - type: EmptyDir
+      mountPath: /var/myapp/myemptydir
+      memory: false

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -178,6 +178,23 @@ Returns kubernetes pod template configuration as code
   showRawYaml: true
   serviceAccount: "{{ include "jenkins.serviceAccountAgentName" . }}"
   slaveConnectTimeoutStr: "{{ .Values.agent.slaveConnectTimeout }}"
+{{- if .Values.agent.volumes }}
+  volumes:
+  {{- range $index, $volume := .Values.agent.volumes }}
+    -{{- if (eq $volume.type "ConfigMap") }} configMapVolume:
+     {{- else if (eq $volume.type "EmptyDir") }} emptyDirVolume:
+     {{- else if (eq $volume.type "HostPath") }} hostPathVolume:
+     {{- else if (eq $volume.type "Nfs") }} nfsVolume:
+     {{- else if (eq $volume.type "Secret") }} secretVolume:
+     {{- else }} {{ $volume.type }}:
+     {{- end }}
+    {{- range $key, $value := $volume }}
+      {{- if not (eq $key "type") }}
+        {{ $key }}: {{ if kindIs "string" $value }}{{ tpl $value $ | quote }}{{ else }}{{ $value }}{{ end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
   {{- if .Values.agent.yamlTemplate }}
   yaml: |-
   {{- tpl ( trim .Values.agent.yamlTemplate ) . | nindent 4 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -439,17 +439,29 @@ agent:
   # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type
   # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
+  volumes: []
+  # - type: ConfigMap
+  #   configMapName: myconfigmap
+  #   mountPath: /var/myapp/myconfigmap
+  # - type: EmptyDir
+  #   mountPath: /var/myapp/myemptydir
+  #   memory: false
+  # - type: HostPath
+  #   hostPath: /var/lib/containers
+  #   mountPath: /var/myapp/myhostpath
+  # - type: Nfs
+  #   mountPath: /var/myapp/mynfs
+  #   readOnly: false
+  #   serverAddress: "192.0.2.0"
+  #   serverPath: /var/lib/containers
+  # - type: Secret
+  #   defaultMode: "600"
+  #   mountPath: /var/myapp/mysecret
+  #   secretName: mysecret
   # Pod-wide ennvironment, these vars are visible to any container in the agent pod
   envVars: []
   # - name: PATH
   #   value: /usr/local/bin
-  volumes: []
-  # - type: Secret
-  #   secretName: mysecret
-  #   mountPath: /var/myapp/mysecret
-  # - type: EmptyDir
-  #   mountPath: "/var/lib/containers"
-  #   memory: false
   nodeSelector: {}
   # Key Value selectors. Ex:
   # jenkins-agent: v1


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Render `agent.volumes` in the kubernetes pod template JCasC as it is currently only rendered in the XML configuration.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I placed the following in stable/jenkins/agent-values.yaml
```yaml
agent:
  volumes:
    - type: ConfigMap
      configMapName: myconfigmap
      mountPath: /var/myapp/myconfigmap
    - type: EmptyDir
      mountPath: /var/myapp/myemptydir
      memory: true
    - type: HostPath
      hostPath: /var/lib/containers
      mountPath: /var/myapp/myhostpath
    - type: Nfs
      mountPath: /var/myapp/mynfs
      readOnly: true
      serverAddress: "192.0.2.0"
      serverPath: /var/lib/containers
    - type: Secret
      defaultMode: "600" 
      mountPath: /var/myapp/mysecret
      secretName: mysecret
```
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--values stable/jenkins/agent-values.yaml
```
rendering of `agent.volumes` in kubernetes pod template volumes
```yaml
    jenkins:
      clouds:
      - kubernetes:
          templates:
            - name: "default"
              volumes:
                - configMapVolume:
                    configMapName: "myconfigmap"
                    mountPath: "/var/myapp/myconfigmap"
                - emptyDirVolume:
                    memory: true
                    mountPath: "/var/myapp/myemptydir"
                - hostPathVolume:
                    hostPath: "/var/lib/containers"
                    mountPath: "/var/myapp/myhostpath"
                - nfsVolume:
                    mountPath: "/var/myapp/mynfs"
                    readOnly: true
                    serverAddress: "192.0.2.0"
                    serverPath: "/var/lib/containers"
                - secretVolume:
                    defaultMode: "600"
                    mountPath: "/var/myapp/mysecret"
                    secretName: "mysecret"
```
Jenkins screenshots
![Screenshot_2020-04-21 Configure Clouds  Jenkins](https://user-images.githubusercontent.com/7925481/79828653-27c43500-836f-11ea-9d8b-bce38df04c14.png)
![Screenshot_2020-04-21 Configure Clouds  Jenkins (2)](https://user-images.githubusercontent.com/7925481/79829030-116aa900-8370-11ea-8447-e61b536d8ba1.png)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
