### PR TITLE
[stable/home-assistant] Small fix and enhancements

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.107.7
 description: Home Assistant
 name: home-assistant
-version: 0.12.8
+version: 0.13.0
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -82,8 +82,8 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `git.secret`                   | Git secret to use for git-sync | `git-creds` |
 | `git.syncPath`                 | Git sync path | `/config` |
 | `git.keyPath`                  | Git ssh key path | `/root/.ssh` |
-| `git.user.name`                | Human-readable name in the “committer” field. | `` |
-| `git.user.email`               | Email address for the “committer” field | `` |
+| `git.user.name`                | Human-readable name in the “committer” and “author” fields | `` |
+| `git.user.email`               | Email address for the “committer” and “author” fields | `` |
 | `zwave.enabled`                  | Enable zwave host device passthrough. Also enables privileged container mode. | `false` |
 | `zwave.device`                  | Device to passthrough to guest | `ttyACM0` |
 | `hostMounts`        | Array of host directories to mount; can be used for devices | [] |

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -82,6 +82,8 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `git.secret`                   | Git secret to use for git-sync | `git-creds` |
 | `git.syncPath`                 | Git sync path | `/config` |
 | `git.keyPath`                  | Git ssh key path | `/root/.ssh` |
+| `git.authorName`               | Human-readable name in the “author” field. | `` |
+| `git.authorEmail`              | Email address for the “author” field | `` |
 | `zwave.enabled`                  | Enable zwave host device passthrough. Also enables privileged container mode. | `false` |
 | `zwave.device`                  | Device to passthrough to guest | `ttyACM0` |
 | `hostMounts`        | Array of host directories to mount; can be used for devices | [] |

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -82,8 +82,8 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `git.secret`                   | Git secret to use for git-sync | `git-creds` |
 | `git.syncPath`                 | Git sync path | `/config` |
 | `git.keyPath`                  | Git ssh key path | `/root/.ssh` |
-| `git.authorName`               | Human-readable name in the “author” field. | `` |
-| `git.authorEmail`              | Email address for the “author” field | `` |
+| `git.user.name`                | Human-readable name in the “committer” field. | `` |
+| `git.user.email`               | Email address for the “committer” field | `` |
 | `zwave.enabled`                  | Enable zwave host device passthrough. Also enables privileged container mode. | `false` |
 | `zwave.device`                  | Device to passthrough to guest | `ttyACM0` |
 | `hostMounts`        | Array of host directories to mount; can be used for devices | [] |

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -64,6 +64,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `service.loadBalancerIP`   | Loadbalancer IP for the home-assistant GUI | `` |
 | `service.loadBalancerSourceRanges`   | Loadbalancer client IP restriction range for the home-assistant GUI | `[]` |
 | `service.publishNotReadyAddresses`   | Set to true if the editors (vscode or configurator) should be reachable when home assistant does not run | `false` |
+| `service.externalTrafficPolicy`   | Loadbalancer externalTrafficPolicy | `` |
 | `hostNetwork`              | Enable hostNetwork - might be needed for discovery to work | `false` |
 | `service.nodePort`   | nodePort to listen on for the home-assistant GUI | `` |
 | `ingress.enabled`              | Enables Ingress | `false` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -287,11 +287,9 @@ spec:
           - mountPath: /config
             name: config
           {{- if .Values.git.enabled }}
-          - name: git-secret
-            secret:
-              defaultMode: 256
-              secretName: {{ .Values.git.secret }}
-          {{ end }}
+          - mountPath: {{ .Values.git.keyPath }}
+            name: git-secret
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           securityContext:

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -119,6 +119,11 @@ spec:
                   name: {{ $opts.secret }}
                   key: {{ $opts.key }}
             {{- end }}
+          envFrom:
+          {{- range .Values.extraSecretNamesForEnvFrom }}
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
           volumeMounts:
           - mountPath: /config
             name: config

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -202,6 +202,14 @@ spec:
             - name: HC_ENFORCE_BASEPATH
               value: "{{ .Values.configurator.enforceBasepath }}"
             {{- end }}
+            {{- if and (.Values.git.enabled) (.Values.git.authorName) }}
+            - name: GIT_AUTHOR_NAME
+              value: {{ .Values.git.authorName }}
+            {{ end }}
+            {{- if and (.Values.git.enabled) (.Values.git.authorEmail) }}
+            - name: GIT_AUTHOR_EMAIL
+              value: {{ .Values.git.authorEmail }}
+            {{ end }}
             {{- range $key, $value := .Values.configurator.extraEnv }}
             - name: {{ $key }}
               value: {{ $value }}
@@ -255,6 +263,14 @@ spec:
                   name: {{ template "home-assistant.fullname" . }}-vscode
                   key: password
             {{- end }}
+            {{- if and (.Values.git.enabled) (.Values.git.authorName) }}
+            - name: GIT_AUTHOR_NAME
+              value: {{ .Values.git.authorName }}
+            {{ end }}
+            {{- if and (.Values.git.enabled) (.Values.git.authorEmail) }}
+            - name: GIT_AUTHOR_EMAIL
+              value: {{ .Values.git.authorEmail }}
+            {{ end }}
             {{- range $key, $value := .Values.vscode.extraEnv }}
             - name: {{ $key }}
               value: {{ $value }}
@@ -298,6 +314,14 @@ spec:
                   name: {{ template "home-assistant.fullname" . }}-appdaemon
                   key: token
             {{- end }}
+            {{- if and (.Values.git.enabled) (.Values.git.authorName) }}
+            - name: GIT_AUTHOR_NAME
+              value: {{ .Values.git.authorName }}
+            {{ end }}
+            {{- if and (.Values.git.enabled) (.Values.git.authorEmail) }}
+            - name: GIT_AUTHOR_EMAIL
+              value: {{ .Values.git.authorEmail }}
+            {{ end }}
             {{- range $key, $value := .Values.vscode.extraEnv }}
             - name: {{ $key }}
               value: {{ $value }}

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -286,6 +286,12 @@ spec:
           volumeMounts:
           - mountPath: /config
             name: config
+          {{- if .Values.git.enabled }}
+          - name: git-secret
+            secret:
+              defaultMode: 256
+              secretName: {{ .Values.git.secret }}
+          {{ end }}
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
           {{- if .Values.usePodSecurityContext }}
           securityContext:

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -203,10 +203,14 @@ spec:
               value: "{{ .Values.configurator.enforceBasepath }}"
             {{- end }}
             {{- if and (.Values.git.enabled) (.Values.git.user.name) }}
+            - name: GIT_AUTHOR_NAME
+              value: {{ .Values.git.user.name }}
             - name: GIT_COMMITTER_NAME
               value: {{ .Values.git.user.name }}
             {{ end }}
             {{- if and (.Values.git.enabled) (.Values.git.user.email) }}
+            - name: GIT_AUTHOR_EMAIL
+              value: {{ .Values.git.user.email }}
             - name: GIT_COMMITTER_EMAIL
               value: {{ .Values.git.user.email }}
             {{ end }}
@@ -264,10 +268,14 @@ spec:
                   key: password
             {{- end }}
             {{- if and (.Values.git.enabled) (.Values.git.user.name) }}
+            - name: GIT_AUTHOR_NAME
+              value: {{ .Values.git.user.name }}
             - name: GIT_COMMITTER_NAME
               value: {{ .Values.git.user.name }}
             {{ end }}
             {{- if and (.Values.git.enabled) (.Values.git.user.email) }}
+            - name: GIT_AUTHOR_EMAIL
+              value: {{ .Values.git.user.email }}
             - name: GIT_COMMITTER_EMAIL
               value: {{ .Values.git.user.email }}
             {{ end }}
@@ -315,10 +323,14 @@ spec:
                   key: token
             {{- end }}
             {{- if and (.Values.git.enabled) (.Values.git.user.name) }}
+            - name: GIT_AUTHOR_NAME
+              value: {{ .Values.git.user.name }}
             - name: GIT_COMMITTER_NAME
               value: {{ .Values.git.user.name }}
             {{ end }}
             {{- if and (.Values.git.enabled) (.Values.git.user.email) }}
+            - name: GIT_AUTHOR_EMAIL
+              value: {{ .Values.git.user.email }}
             - name: GIT_COMMITTER_EMAIL
               value: {{ .Values.git.user.email }}
             {{ end }}

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -202,13 +202,13 @@ spec:
             - name: HC_ENFORCE_BASEPATH
               value: "{{ .Values.configurator.enforceBasepath }}"
             {{- end }}
-            {{- if and (.Values.git.enabled) (.Values.git.authorName) }}
-            - name: GIT_AUTHOR_NAME
-              value: {{ .Values.git.authorName }}
+            {{- if and (.Values.git.enabled) (.Values.git.user.name) }}
+            - name: GIT_COMMITTER_NAME
+              value: {{ .Values.git.user.name }}
             {{ end }}
-            {{- if and (.Values.git.enabled) (.Values.git.authorEmail) }}
-            - name: GIT_AUTHOR_EMAIL
-              value: {{ .Values.git.authorEmail }}
+            {{- if and (.Values.git.enabled) (.Values.git.user.email) }}
+            - name: GIT_COMMITTER_EMAIL
+              value: {{ .Values.git.user.email }}
             {{ end }}
             {{- range $key, $value := .Values.configurator.extraEnv }}
             - name: {{ $key }}
@@ -263,13 +263,13 @@ spec:
                   name: {{ template "home-assistant.fullname" . }}-vscode
                   key: password
             {{- end }}
-            {{- if and (.Values.git.enabled) (.Values.git.authorName) }}
-            - name: GIT_AUTHOR_NAME
-              value: {{ .Values.git.authorName }}
+            {{- if and (.Values.git.enabled) (.Values.git.user.name) }}
+            - name: GIT_COMMITTER_NAME
+              value: {{ .Values.git.user.name }}
             {{ end }}
-            {{- if and (.Values.git.enabled) (.Values.git.authorEmail) }}
-            - name: GIT_AUTHOR_EMAIL
-              value: {{ .Values.git.authorEmail }}
+            {{- if and (.Values.git.enabled) (.Values.git.user.email) }}
+            - name: GIT_COMMITTER_EMAIL
+              value: {{ .Values.git.user.email }}
             {{ end }}
             {{- range $key, $value := .Values.vscode.extraEnv }}
             - name: {{ $key }}
@@ -314,13 +314,13 @@ spec:
                   name: {{ template "home-assistant.fullname" . }}-appdaemon
                   key: token
             {{- end }}
-            {{- if and (.Values.git.enabled) (.Values.git.authorName) }}
-            - name: GIT_AUTHOR_NAME
-              value: {{ .Values.git.authorName }}
+            {{- if and (.Values.git.enabled) (.Values.git.user.name) }}
+            - name: GIT_COMMITTER_NAME
+              value: {{ .Values.git.user.name }}
             {{ end }}
-            {{- if and (.Values.git.enabled) (.Values.git.authorEmail) }}
-            - name: GIT_AUTHOR_EMAIL
-              value: {{ .Values.git.authorEmail }}
+            {{- if and (.Values.git.enabled) (.Values.git.user.email) }}
+            - name: GIT_COMMITTER_EMAIL
+              value: {{ .Values.git.user.email }}
             {{ end }}
             {{- range $key, $value := .Values.vscode.extraEnv }}
             - name: {{ $key }}

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
                   key: {{ $opts.key }}
             {{- end }}
           envFrom:
-          {{- range .Values.extraSecretNamesForEnvFrom }}
+          {{- range .Values.extraSecretForEnvFrom }}
             - secretRef:
                 name: {{ . }}
           {{- end }}

--- a/stable/home-assistant/templates/service.yaml
+++ b/stable/home-assistant/templates/service.yaml
@@ -25,6 +25,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -130,9 +130,9 @@ git:
   # command: []
 
   # Committer settings
-  user:
-    name: ""
-    email: ""
+  # user:
+  #   name: ""
+  #   email: ""
 
   # repo:
   secret: git-creds

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -102,7 +102,7 @@ extraEnvSecrets:
 
 ## If you'd like to provide your own Kubernetes Secret object instead of passing your values
 ## individually, pass in the name of a created + populated Secret.
-## All secrets will be mounted as environment variables, with each key/value mapping to a 
+## All secrets will be mounted as environment variables, with each key/value mapping to a
 ## corresponding environment variable.
 ##
 extraSecretForEnvFrom: []

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -129,9 +129,10 @@ git:
   ## Specify the command that runs in the git-sync container to pull in configuration.
   # command: []
 
-  # Author settings
-  authorName: ""
-  authorEmail: ""
+  # Committer settings
+  user:
+    name: ""
+    email: ""
 
   # repo:
   secret: git-creds

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -198,6 +198,7 @@ configurator:
     externalIPs: []
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Local
     # nodePort: 30000
 
 ## Add support for Prometheus

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -129,6 +129,10 @@ git:
   ## Specify the command that runs in the git-sync container to pull in configuration.
   # command: []
 
+  # Author settings
+  authorName: ""
+  authorEmail: ""
+
   # repo:
   secret: git-creds
   syncPath: /config

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -100,6 +100,14 @@ extraEnvSecrets:
   #   secret: mqtt
   #   key: password
 
+## If you'd like to provide your own Kubernetes Secret object instead of passing your values
+## individually, pass in the name of a created + populated Secret.
+## All secrets will be mounted as environment variables, with each key/value mapping to a 
+## corresponding environment variable.
+##
+extraSecretNamesForEnvFrom: []
+# - home-assistant-secrets
+
 # Enable pod security context (must be `true` if runAsUser or fsGroup are set)
 usePodSecurityContext: true
 # Set runAsUser to 1000 to let home-assistant run as non-root user 'hass' which exists in 'runningman84/alpine-homeassistant' docker image.

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -105,7 +105,7 @@ extraEnvSecrets:
 ## All secrets will be mounted as environment variables, with each key/value mapping to a 
 ## corresponding environment variable.
 ##
-extraSecretNamesForEnvFrom: []
+extraSecretForEnvFrom: []
 # - home-assistant-secrets
 
 # Enable pod security context (must be `true` if runAsUser or fsGroup are set)


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR fixes / enhances a few aspects of the _stable/home-assistant_ chart:
- It is now possible to define the `externalTrafficPolicy` field for services with type `LoadBalancer`. This is required to let Home Assistant know the "real" IP address when using something like [MetalLB](https://metallb.universe.tf/usage/).
- The `git-secret` Secret was only mounted for the `configurator` and `appdaemon` containers, but not for `vscode`. This has been added to allow git commits from that container as well.
- It is now possible to set the author and email used for Git commits through the `git.user` variables.
- In the previous version it was only possible to specify a list of single secret keys to be used as environment variables. It is now possible to specify an entire secret through the `extraSecretForEnvFrom` variable.

#### Special notes for your reviewer:
@billimek @runningman84

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Bernd Schorgers <bernd@bjws.nl>