### PR TITLE
Buzzfeed sso/fix default allowed email domains

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -81,6 +81,7 @@ Parameter | Description | Default
 `proxy.service.port` | port for the http proxy service | `80`
 `proxy.secret` | secrets to be generated randomly with `openssl rand -base64 32 | head -c 32 | base64`. | REQUIRED if `proxy.customSecret` is not set
 `proxy.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `proxy.secret` is not set
+`proxy.defaultAllowedEmailDomains` | the default allowed domains for upstreams | ``
 `provider.google` | the Oauth provider to use (only Google support for now) | REQUIRED
 `provider.google.adminEmail` | the Google admin email | `undefined`
 `provider.google.slug` | the Google provider slug | `oauth2`

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -61,13 +61,13 @@ spec:
                 secretKeyRef:
                   name: {{ $proxySecret }}
                   key: proxy-cookie-secret
-            {{- if .Values.defaultAllowedEmailDomains }}
-            {{- if (eq "-" .Values.defaultAllowedEmailDomains) }}
+            {{- if .Values.proxy.defaultAllowedEmailDomains }}
+            {{- if (eq "-" .Values.proxy.defaultAllowedEmailDomains) }}
             - name: DEFAULT_ALLOWED_EMAIL_DOMAINS
               value: ""
             {{- else }}
             - name: DEFAULT_ALLOWED_EMAIL_DOMAINS
-              value: {{ .Values.defaultAllowedEmailDomains | quote }}
+              value: {{ .Values.proxy.defaultAllowedEmailDomains | quote }}
             {{- end }}
             {{- else }}
             - name: DEFAULT_ALLOWED_EMAIL_DOMAINS

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -61,8 +61,18 @@ spec:
                 secretKeyRef:
                   name: {{ $proxySecret }}
                   key: proxy-cookie-secret
+            {{- if .Values.defaultAllowedEmailDomains }}
+            {{- if (eq "-" .Values.defaultAllowedEmailDomains) }}
+            - name: DEFAULT_ALLOWED_EMAIL_DOMAINS
+              value: ""
+            {{- else }}
+            - name: DEFAULT_ALLOWED_EMAIL_DOMAINS
+              value: {{ .Values.defaultAllowedEmailDomains | quote }}
+            {{- end }}
+            {{- else }}
             - name: DEFAULT_ALLOWED_EMAIL_DOMAINS
               value: {{ .Values.emailDomain | quote }}
+            {{- end }}
             {{- if .Values.whitelistedEmails }}
             - name: DEFAULT_ALLOWED_EMAIL_ADDRESSES
               value: {{ .Values.whitelistedEmails }}

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -84,7 +84,7 @@ provider:
 
 image:
   repository: buzzfeed/sso
-  tag: v2.0.0
+  tag: v2.1.0
   pullPolicy: IfNotPresent
 
 ingress:

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -1,5 +1,11 @@
 # Default values for buzzfeed-sso.
 
+# not required by default. If you are using_allowed groups, DEFAULT_ALLOWED_EMAIL_DOMAINS needs to be en empty string
+# this is explained in this pr https://github.com/buzzfeed/sso/pull/280#issuecomment-584088825
+# to get an empty value, set the below to -, as per this issue https://github.com/helm/helm/issues/2600#issuecomment-310108850
+# otherwise populate it with your defauly allowed email domains
+defaultAllowedEmailDomains: ""
+
 emailDomain: "<your_email_domain>"  # Required. e.g "email.mydomain.foo"
 rootDomain: "<your_root_domain>"  # Required. e.g "mydomain.foo"
 # whitelistedEmails: "<whitelisted_addresses>" # Optional. e.g. "userA.nameA@mydomain.foo,userB.nameB@mydomain.foo"
@@ -78,7 +84,7 @@ provider:
 
 image:
   repository: buzzfeed/sso
-  tag: v2.1.0
+  tag: v2.0.0
   pullPolicy: IfNotPresent
 
 ingress:

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -1,11 +1,5 @@
 # Default values for buzzfeed-sso.
 
-# not required by default. If you are using_allowed groups, DEFAULT_ALLOWED_EMAIL_DOMAINS needs to be en empty string
-# this is explained in this pr https://github.com/buzzfeed/sso/pull/280#issuecomment-584088825
-# to get an empty value, set the below to -, as per this issue https://github.com/helm/helm/issues/2600#issuecomment-310108850
-# otherwise populate it with your defauly allowed email domains
-defaultAllowedEmailDomains: ""
-
 emailDomain: "<your_email_domain>"  # Required. e.g "email.mydomain.foo"
 rootDomain: "<your_root_domain>"  # Required. e.g "mydomain.foo"
 # whitelistedEmails: "<whitelisted_addresses>" # Optional. e.g. "userA.nameA@mydomain.foo,userB.nameB@mydomain.foo"
@@ -67,6 +61,12 @@ proxy:
     # cookieSecret: ''
   # # Or if you do not want to create the secret via helm
   # customSecret: my-sso-proxy-secret
+
+  # If you are using_allowed groups in upstreams, DEFAULT_ALLOWED_EMAIL_DOMAINS needs to be en empty string
+  # this is explained in this pr https://github.com/buzzfeed/sso/pull/280#issuecomment-584088825
+  # to get an empty value, set the below to -, as per this issue https://github.com/helm/helm/issues/2600#issuecomment-310108850
+  # otherwise populate it with your default allowed email domains
+  defaultAllowedEmailDomains: ""
 
 provider:
   google: {}  # Required.

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -62,9 +62,9 @@ proxy:
   # # Or if you do not want to create the secret via helm
   # customSecret: my-sso-proxy-secret
 
-  # If you are using_allowed groups in upstreams, DEFAULT_ALLOWED_EMAIL_DOMAINS needs to be en empty string
+  # If you are using_allowed groups in upstreams, DEFAULT_ALLOWED_EMAIL_DOMAINS needs to be an empty string
   # this is explained in this pr https://github.com/buzzfeed/sso/pull/280#issuecomment-584088825
-  # to get an empty value, set the below to -, as per this issue https://github.com/helm/helm/issues/2600#issuecomment-310108850
+  # to get an empty value, set the string below to -, as per this issue https://github.com/helm/helm/issues/2600#issuecomment-310108850
   # otherwise populate it with your default allowed email domains
   defaultAllowedEmailDomains: ""
 


### PR DESCRIPTION
## Is this a new chart
No

#### What this PR does / why we need it:

Currently the chart sets the env var `DEFAULT_ALLOWED_EMAIL_DOMAINS` to emailDomain by default. This is fine if you want to just whitelist a domain. However, when you set allowed_groups in upstream, the default is still present as it has enabled the domains backend. This isn't quite right. It should be set to an empty string, as per this issue https://github.com/buzzfeed/sso/pull/280#issuecomment-584088825.
This change is a bit messy as noted in the values file, but it maintains backwards capability with the previous chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
