### PR TITLE
[stable/rabbitmq-ha] 🔨 Fix definitions.json path reference in README.md

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.0
-version: 1.44.2
+version: 1.44.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -216,7 +216,7 @@ $ helm install --name my-release -f values.yaml stable/rabbitmq-ha
 When creating a new chart with this chart as a dependency, `existingConfigMap`
 can be used to override the default [configmap.yaml](templates/configmap.yaml)
 provided. It also allows for providing additional configuration files that will
-be mounted into `/etc/rabbitmq`. In the parent chart's values.yaml, set the
+be mounted into `/etc/definitions`. In the parent chart's values.yaml, set the
 value to true and provide the file [templates/configmap.yaml][] for your use
 case.
 
@@ -240,7 +240,7 @@ data:
     ].
   rabbitmq.conf: |
     # ....
-    management.load_definitions = /etc/rabbitmq/definitions.json
+    management.load_definitions = /etc/definitions/definitions.json
   definitions.json: |
     {
       "permissions": [],


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
_Fixes wrong path reference in `README.md`._

Actually, the chart puts `definitions.json` in `/etc/definitions` not `/etc/rabbitmq`, so the example in the `README.md` was somehow misleading. You can verify this [here](https://github.com/babakks/charts/blob/158169b6b5c1296b063b8db1bb65c8ac0b71f470/stable/rabbitmq-ha/templates/statefulset.yaml#L220).

#### Which issue this PR fixes
None.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
