### PR TITLE
[stable/jenkins] Add support for PVC in agent.volumes

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.17.1
+
+Add support for Persistent Volume Claim (PVC) in `agent.volumes`
+
 ## 1.17.0
 
 Render `agent.volumes` in kubernetes pod template JCasC

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.17.0
+version: 1.17.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -248,7 +248,7 @@ agent:
     mountPath: /var/run/secrets/jenkins-mysecrets
 ```
 
-The supported volume types are: `ConfigMap`, `EmptyDir`, `HostPath`, `Nfs`, `Pod`, `Secret`. Each type supports a different set of configurable attributes, defined by [the corresponding Java class](https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes).
+The supported volume types are: `ConfigMap`, `EmptyDir`, `HostPath`, `Nfs`, `PVC`, `Secret`. Each type supports a different set of configurable attributes, defined by [the corresponding Java class](https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes).
 
 ## NetworkPolicy
 

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -185,6 +185,7 @@ Returns kubernetes pod template configuration as code
      {{- else if (eq $volume.type "EmptyDir") }} emptyDirVolume:
      {{- else if (eq $volume.type "HostPath") }} hostPathVolume:
      {{- else if (eq $volume.type "Nfs") }} nfsVolume:
+     {{- else if (eq $volume.type "PVC") }} persistentVolumeClaim:
      {{- else if (eq $volume.type "Secret") }} secretVolume:
      {{- else }} {{ $volume.type }}:
      {{- end }}
@@ -225,11 +226,19 @@ Returns kubernetes pod template xml configuration
     <nodeUsageMode>NORMAL</nodeUsageMode>
   <volumes>
 {{- range $index, $volume := .Values.agent.volumes }}
+  {{- if (eq $volume.type "PVC") }}
+    <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+  {{- else }}
     <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
-{{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
+  {{- end }}
+  {{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
       <{{ $key }}>{{ $value }}</{{ $key }}>
-{{- end }}{{- end }}
+  {{- end }}{{- end }}
+  {{- if (eq $volume.type "PVC") }}
+    </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
+  {{- else }}
     </org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+  {{- end }}
 {{- end }}
   </volumes>
   <containers>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -61,7 +61,7 @@ data:
     {{- /* restore .Values.agent */}}
     {{- $_ := set .Values "agent" $agent }}
   {{- end }}
-{{- end -}}
+{{- end }}
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>
           <skipTlsVerify>false</skipTlsVerify>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -436,7 +436,7 @@ agent:
   # Possible values: Always, Never, OnFailure
   podRetention: "Never"
   # You can define the volumes that you want to mount for this container
-  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
+  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, PVC, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type
   # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
   volumes: []
@@ -454,6 +454,10 @@ agent:
   #   readOnly: false
   #   serverAddress: "192.0.2.0"
   #   serverPath: /var/lib/containers
+  # - type: PVC
+  #   claimName: mypvc
+  #   mountPath: /var/myapp/mypvc
+  #   readOnly: false
   # - type: Secret
   #   defaultMode: "600"
   #   mountPath: /var/myapp/mysecret


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
`agent.volumes` currently lacks support for Persistent Volume Claim

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
### helm template tests
Given the following in stable/jenkins/agent-values.yaml
```yaml
agent:
  volumes:
    - type: PVC
      claimName: mypvc
      mountPath: /var/myapp/mypvc
      readOnly: true
```
#### default JCasC with auto-reload (jcasc-config.yaml)
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--values stable/jenkins/agent-values.yaml
```
rendering of `agent.volumes` in kubernetes pod template volumes
```yaml
    jenkins:
      clouds:
      - kubernetes:
          templates:
            - name: "default"
              volumes:
                - persistentVolumeClaim:
                    claimName: "mypvc"
                    mountPath: "/var/myapp/mypvc"
                    readOnly: true
```
Jenkins screenshot
![image](https://user-images.githubusercontent.com/7925481/79906700-4a456500-83e6-11ea-8a94-96d060551cfa.png)

#### XML configuration (config.yaml)
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--values stable/jenkins/agent-values.yaml
```
rendering of `agent.volumes` in kubernetes pod template volumes
```xml
    <hudson>
      <clouds>
        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@1.25.3">
          <templates>
            <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
              <volumes>
                <org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
                  <claimName>mypvc</claimName>
                  <mountPath>/var/myapp/mypvc</mountPath>
                  <readOnly>true</readOnly>
                </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>
              </volumes>
            </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
          </templates>
        </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
      </clouds>
    </hudson>
```
Jenkins screenshot
![image](https://user-images.githubusercontent.com/7925481/79910079-0bb2a900-83ec-11ea-985b-279803475a7b.png)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
