### PR TITLE
[stable/prometheus-blackbox-exporter] prometheusrule additionalLabels have too many indents/spaces

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 3.4.0
+version: 3.4.1
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" $ }}
     {{- with .Values.prometheusRule.additionalLabels }}
-    {{- toYaml . | indent 4 }}
+{{- toYaml . | indent 4 }}
     {{- end }}
 spec:
   {{- with .Values.prometheusRule.rules }}


### PR DESCRIPTION
### Is this a new chart
No

### What this PR does / why we need it:
Too may spaces before the label value is causing this error:
```
Error: UPGRADE FAILED: YAML parse error on prometheus-blackbox-exporter/templates/prometheusrule.yaml: error converting YAML to JSON: yaml: line 9: mapping values are not allowed in this context
```

Because of this error I can't add labels to integrate with prometheus-operator.

### Special notes for your reviewer:
Checking a similar template for another project, moving the templated values four spaces to the left should solve it. See:

https://github.com/helm/charts/blob/master/stable/airflow/templates/prometheus-rule.yaml

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
