### PR TITLE
[stable/jenkins] revert runAsUser comparison

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.16.2
+
+Reverts 1.16.1 as it introduced an error #22047
+
 ## 1.16.1
 
 Fixed a bug with master.runAsUser variable due to use wrong type for comparison.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.16.1
+version: 1.16.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/ci/other-values.yaml
+++ b/stable/jenkins/ci/other-values.yaml
@@ -1,5 +1,7 @@
 master:
   overwritePluginsFromImage: false
+  runAsUser: 0
+  fsGroup: 1000
 agent:
   resources:
     limits:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -73,7 +73,7 @@ spec:
       securityContext:
         runAsUser: {{ default 0 .Values.master.runAsUser }}
 {{- if and (.Values.master.runAsUser) (.Values.master.fsGroup) }}
-{{- if not (eq .Values.master.runAsUser 0.0) }}
+{{- if not (eq (int .Values.master.runAsUser) 0) }}
         fsGroup: {{ .Values.master.fsGroup }}
 {{- end }}
 {{- end }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -73,7 +73,7 @@ spec:
       securityContext:
         runAsUser: {{ default 0 .Values.master.runAsUser }}
 {{- if and (.Values.master.runAsUser) (.Values.master.fsGroup) }}
-{{- if not (eq .Values.master.runAsUser 0) }}
+{{- if not (eq .Values.master.runAsUser 0.0) }}
         fsGroup: {{ .Values.master.fsGroup }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

PR #21864 chnaged the way we compare `runAsuser`.  We got a report that it breaks rendering so I revert it back with this PR. So the template code is once again:

```
{{- if .Values.master.usePodSecurityContext }}
      securityContext:
        runAsUser: {{ default 0 .Values.master.runAsUser }}
{{- if and (.Values.master.runAsUser) (.Values.master.fsGroup) }}
{{- if not (eq .Values.master.runAsUser 0.0) }}
        fsGroup: {{ .Values.master.fsGroup }}
{{- end }}
{{- end }}
{{- end }}
```

With this code my expectation it that if you run it with the values below than both `runAsUser` and `fsGroup` would be set:

```
master:
  runAsUser: 1000
  fsGroup: 1000
```

helm 3:

```
helm3 template jenkins . --values ci/other-values.yaml|grep -C 1 runAsUser
      securityContext:
        runAsUser: 1000
        fsGroup: 1000
```

helm 2:

```
helm2 template . --values ci/other-values.yaml|grep -C 1 runAsUser
      securityContext:
        runAsUser: 1000
        fsGroup: 1000
```

With values like this one, where the runAsUser is 0 only `runAsUser` should be set and not `fsGroup`

```
master:
  runAsUser: 0
  fsGroup: 1000
```

```
helm2 template . --values ci/other-values.yaml|grep -C 1 runAsUser
      securityContext:
        runAsUser: 0
      serviceAccountName: "release-name-jenkins"
```

helm 3:

```
helm3 template jenkins . --values ci/other-values.yaml|grep -C 1 runAsUser
      securityContext:
        runAsUser: 0
      serviceAccountName: "jenkins"
```


used helm version:

```
helm2 version
Client: &version.Version{SemVer:"v2.15.2", GitCommit:"8dce272473e5f2a7bf58ce79bb5c3691db54c96b", GitTreeState:"clean"}
```

```
helm3 version
version.BuildInfo{Version:"v3.1.1", GitCommit:"afe70585407b420d0097d07b21c47dc511525ac8", GitTreeState:"clean", GoVersion:"go1.13.8"}
```


So I've been asking myself what issue has been resolved with #21864. Thanks to @chrisLeeTW who mentioned how to reproduce it:

```
helm3 template  . --set master.runAsUser=1000 --set master.fsGroup=1000 |grep -C 1 runAsUser
Error: template: jenkins/templates/jenkins-master-deployment.yaml:76:12: executing "jenkins/templates/jenkins-master-deployment.yaml" at <eq .Values.master.runAsUser 0.0>: error calling eq: incompatible types for comparison
```
No we see an error. interestingly this works with helm 2

```
helm2 template  . --set master.runAsUser=1000 --set master.fsGroup=1000 |grep -C 1 runAsUser
      securityContext:
        runAsUser: 1000
        fsGroup: 1000
```

It looks as if helm 3 interprets values passed at the command line as string and not as numeric values. That's the reason for the comparison error!


I've been able to solve this by converting `runAsUser` to an int:

`{{- if not (eq (int .Values.master.runAsUser) 0) }}`
 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #22047

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
