### PR TITLE
[stable/jenkins]: make changes from 1.16.1 to has backward compatibility with helm v2

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.16.3
+
+Make changes from 1.16.1 to has backward compatibility with helm v2.
+
 ## 1.16.2
 
 Reverts 1.16.1 as it introduced an error #22047

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,25 +1,26 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.16.2
+version: 1.16.3
 appVersion: lts
-description: Open source continuous integration server. It supports multiple SCM tools
+description:
+  Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.
 sources:
-- https://github.com/jenkinsci/jenkins
-- https://github.com/jenkinsci/docker-jnlp-slave
-- https://github.com/maorfr/kube-tasks
-- https://github.com/jenkinsci/configuration-as-code-plugin
+  - https://github.com/jenkinsci/jenkins
+  - https://github.com/jenkinsci/docker-jnlp-slave
+  - https://github.com/maorfr/kube-tasks
+  - https://github.com/jenkinsci/configuration-as-code-plugin
 maintainers:
-- name: lachie83
-  email: lachlan.evenson@microsoft.com
-- name: viglesiasce
-  email: viglesias@google.com
-- name: maorfr
-  email: maor.friedman@redhat.com
-- name: torstenwalter
-  email: mail@torstenwalter.de
-- name: mogaal
-  email: garridomota@gmail.com
+  - name: lachie83
+    email: lachlan.evenson@microsoft.com
+  - name: viglesiasce
+    email: viglesias@google.com
+  - name: maorfr
+    email: maor.friedman@redhat.com
+  - name: torstenwalter
+    email: mail@torstenwalter.de
+  - name: mogaal
+    email: garridomota@gmail.com
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -73,7 +73,11 @@ spec:
       securityContext:
         runAsUser: {{ default 0 .Values.master.runAsUser }}
 {{- if and (.Values.master.runAsUser) (.Values.master.fsGroup) }}
-{{- if not (eq (int .Values.master.runAsUser) 0) }}
+{{- if kindIs "float64" .Values.master.runAsUser }}
+{{- if not (eq .Values.master.runAsUser 0.0) }}
+        fsGroup: {{ .Values.master.fsGroup }}
+{{- end }}
+{{- else if not (eq .Values.master.runAsUser 0) }}
         fsGroup: {{ .Values.master.fsGroup }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
make changes from 1.16.1 to also has backward compatibility with helm v2

#### Which issue this PR fixes
fixes #21358 (#21358) and #22047 (#22047)

#### Special notes for your reviewer:
No

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
