### PR TITLE
[stable/k8s-spot-termination-handler] allow config of pod securityContext

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.7-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.4.8
+version: 1.5.0
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -50,3 +50,4 @@ Parameter | Description | Default
 `hostNetwork` | controls whether the pod may use the node network namespace | `true`
 `podAnnotations` | annotations to be added to pods | `{}`
 `updateStrategy` | can be either `RollingUpdate` or `OnDelete` | `RollingUpdate`
+`securityContext` | pod security context | `{}`

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -89,6 +89,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -86,3 +86,6 @@ podAnnotations: {}
 # Default value for Kubernetes v1.5 and before was "OnDelete".
 updateStrategy: RollingUpdate
 maxUnavailable: 1
+
+# SecurityContext to be set on the pod
+securityContext: {}


### PR DESCRIPTION

#### What this PR does / why we need it:
Allow users to set the securityContext of the pods in the stable/k8s-spot-termination-handler chart.
This is usefull when running this component in combination with podsecuritypolicies

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
