### PR TITLE
[stable/home-assistant] Fix default values for git.user

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.107.7
 description: Home Assistant
 name: home-assistant
-version: 0.13.0
+version: 0.13.1
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -130,9 +130,9 @@ git:
   # command: []
 
   # Committer settings
-  # user:
-  #   name: ""
-  #   email: ""
+  user:
+    name: ""
+    email: ""
 
   # repo:
   secret: git-creds


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
In version 0.13.0 a bug was introduced that prevented upgrading when no values were given for `git.user.name` or `git.user.email`. This fix uncomments the default values.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: bjws <bernd@bjws.nl>