### PR TITLE
[stable/home-assistant] Bump home-assistant and code-server image versions

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.107.7
+appVersion: 0.108.7
 description: Home Assistant
 name: home-assistant
-version: 0.13.1
+version: 0.13.2
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -36,7 +36,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `homeassistant/home-assistant` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.106.6`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.108.7`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
 | `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
@@ -126,7 +126,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `configurator.service.loadBalancerSourceRanges`   | Loadbalancer client IP restriction range for the configurator UI | `[]` |
 | `vscode.enabled`                  | Enable the optional [VS Code Server Sidecar](https://github.com/cdr/code-server) | `false` |
 | `vscode.image.repository`         | Image repository | `codercom/code-server` |
-| `vscode.image.tag`                | Image tag | `2.1665-vsc1.39.2`|
+| `vscode.image.tag`                | Image tag | `3.1.1`|
 | `vscode.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `vscode.hassConfig`               | Base path of the home assistant configuration files | `/config` |
 | `vscode.vscodePath`               | Base path of the VS Code configuration files | `/config/.vscode` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -245,9 +245,7 @@ spec:
           workingDir: {{ .Values.vscode.hassConfig }}
           args:
             - --port={{ .Values.vscode.service.port }}
-            {{- if (.Values.vscode.password) }}
-            - --allow-http #Not supported without password
-            {{- else }}
+            {{- if not (.Values.vscode.password) }}
             - --auth=none
             {{- end }}
             {{- if .Values.vscode.vscodePath }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.107.7
+  tag: 0.108.7
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -233,7 +233,7 @@ vscode:
   ##
   image:
     repository: codercom/code-server
-    tag: 2.1665-vsc1.39.2
+    tag: 3.1.1
     pullPolicy: IfNotPresent
 
   ## VSCode password


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates to the latest home-assistant container version
* Updates the optional VSCode server to version 3.1.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
