### PR TITLE
[stable/prometheus-pushgateway] added relabelconfig to serviceMonitor

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `serviceMonitor.scrapeTimeout`    | How long to scrape metrics before timing out. (use by default, falling back to Prometheus' default)                           | `nil`                             |
 | `serviceMonitor.additionalLables` | Used to pass Labels that are required by the Installed Prometheus Operator                                                    | `{}`                              |
 | `serviceMonitor.honorLabels`      | if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
+| `serviceMonitor.relabelings`      | Array of RelabelConfigs to apply to samples before scraping                                                                   | `true`                            |
 | `podDisruptionBudget`             | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
 | `networkPolicy.allowAll`          | Allow connectivity from all pods in the cluster                                                                               | ``                                |
 | `networkPolicy.customSelectors`   | Allow connectivity from pods that match a list of podSelectors and namespaceSelectors                                         | ``                                |

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `serviceMonitor.scrapeTimeout`    | How long to scrape metrics before timing out. (use by default, falling back to Prometheus' default)                           | `nil`                             |
 | `serviceMonitor.additionalLables` | Used to pass Labels that are required by the Installed Prometheus Operator                                                    | `{}`                              |
 | `serviceMonitor.honorLabels`      | if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
-| `serviceMonitor.relabelings`      | Array of RelabelConfigs to apply to samples before scraping                                                                   | `true`                            |
+| `serviceMonitor.relabelings`      | Array of RelabelConfigs to apply to samples before scraping                                                                   | `[]`                              |
 | `podDisruptionBudget`             | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
 | `networkPolicy.allowAll`          | Allow connectivity from all pods in the cluster                                                                               | ``                                |
 | `networkPolicy.customSelectors`   | Allow connectivity from pods that match a list of podSelectors and namespaceSelectors                                         | ``                                |

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -25,9 +25,9 @@ spec:
     {{- end }}
     path: /metrics
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-    {{- if .Values.serviceMonitor.relabelConfig }}
+    {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
-{{ toYaml .Values.serviceMonitor.relabelConfig | indent 6 }}
+{{ toYaml .Values.serviceMonitor.relabelings | indent 6 }}
     {{- end }}
   namespaceSelector:
     matchNames:

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -25,6 +25,10 @@ spec:
     {{- end }}
     path: /metrics
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+    {{- if .Values.serviceMonitor.relabelConfig }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelConfig | indent 6 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds the possibility to add relabelConfig (prometheus-operator.relabelings) via prometheus-pushgateway serviceMonitor as described in  #22040

#### Which issue this PR fixes
  - fixes #22040

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)