### PR TITLE
[stable/elasticsearch-exporter] add extraEnvSecrets

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 3.0.0
+version: 3.1.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -72,6 +72,7 @@ Parameter | Description | Default
 `service.annotations` | Annotations on the http service | `{}`
 `service.labels` | Additional labels for the service definition | `{}`
 `env` | Extra environment variables passed to pod | `{}`
+`extraEnvSecrets` | Extra environment variables passed to the pod from k8s secrets - see `values.yaml` for an example | `{}` |
 `envFromSecret` | The name of an existing secret in the same kubernetes namespace which contains values to be added to the environment | `nil`
 `secretMounts` |  list of secrets and their paths to mount inside the pod | `[]`
 `affinity` | Affinity rules | `{}`

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -48,13 +48,18 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.env }}
           env:
-          {{- range $key, $value := .Values.env }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-          {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            {{- range $key, $value := .Values.extraEnvSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "Must specify secret!" $value.secret }}
+                  key: {{ required "Must specify key!" $value.key }}
+            {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:
           - secretRef:
@@ -63,7 +68,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["elasticsearch_exporter",
-                    {{- if .Values.es.uri }}                    
+                    {{- if .Values.es.uri }}
                     "--es.uri={{ .Values.es.uri }}",
                     {{- end }}
                     {{- if .Values.es.all }}

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -57,6 +57,15 @@ env: {}
 ## This can be useful for auth tokens, etc
 envFromSecret: ""
 
+## A list of environment variables from secret refs that will be passed into the exporter pod
+## example:
+## This will set ${ES_PASSWORD} to the 'password' key from the 'my-secret' secret
+## extraEnvSecrets:
+##   ES_PASSWORD:
+##     secret: my-secret
+##     key: password
+extraEnvSecrets: {}
+
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security
 secretMounts: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds ability to set environment variables with k8s secret information to support referencing already existing sensitive parameters. For example, the [ECK Operator](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html) will provide a secret where the keys are user names and the values are the passwords for elasticsearch. With the current chart, it is not easy to expose this value to the pod.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I moved the conditional for Values.env to reduce the logic necessary to template the deployment. This means that if there are no values passed for `env` or `extraEnvSecrets`, there will be an empty `env:` in the deployment. This seems to be valid (tested with kubectl --validate) and is what other charts have done. 

I used `extraEnvSecrets` as this was what other charts seemed to use (home-assitant, cluster-autoscaler) but if this should be something else, I would be happy to change it. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
