### PR TITLE
[stable/k8s-spot-rescheduler] Include non-truthy cmdOption values to the deployment 

### DIFF
--- a/stable/k8s-spot-rescheduler/Chart.yaml
+++ b/stable/k8s-spot-rescheduler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.3.0"
 description: A k8s-spot-rescheduler Helm chart for Kubernetes
 name: k8s-spot-rescheduler
-version: 0.4.4
+version: 0.4.5
 keywords:
   - spot
   - rescheduler

--- a/stable/k8s-spot-rescheduler/templates/deployment.yaml
+++ b/stable/k8s-spot-rescheduler/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - k8s-spot-rescheduler
             - --namespace={{ .Release.Namespace }}
           {{- range $key, $value := .Values.cmdOptions }}
-            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+            - --{{ $key }}={{ $value }}
           {{- end }}
           ports:
           - name: http


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Which issue this PR fixes
  - fixes #21975 

#### Special notes for your reviewer:
There is probably a more nuanced approach to check if a value is explicitly`null` but in the interest of simplicity and expediency removing the conditional fixes the issue without creating another one (all cmdOptions require a value).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
