### PR TITLE
[stable/kube2iam] add podsecuritypolicy object to the chart

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.2.0
+version: 2.3.0
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -71,6 +71,8 @@ Parameter | Description | Default
 `aws.access_key` | The value to use for AWS_ACCESS_KEY_ID | `""`
 `aws.region` | The AWS region to use | `""`
 `existingSecret` | Set the AWS credentials using an existing secret | `""`
+`podSecurityPolicy.enabled` | If true, create a podSecurityPolicy object. For the pods to use the psp, rbac.create should also be set to true | `false`
+`podSecurityPolicy.annotations` | The annotations to add to the podSecurityPolicy object | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/templates/clusterrole.yaml
+++ b/stable/kube2iam/templates/clusterrole.yaml
@@ -18,4 +18,15 @@ rules:
       - list
       - watch
       - get
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - {{ template "kube2iam.fullname" . }}
+{{- end }}
+
 {{- end -}}

--- a/stable/kube2iam/templates/podsecuritypolicy.yaml
+++ b/stable/kube2iam/templates/podsecuritypolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "kube2iam.name" . }}
+    helm.sh/chart: {{ template "kube2iam.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ template "kube2iam.fullname" . }}
+{{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: true
+  hostPorts:
+  - max: {{ .Values.host.port }}
+    min: {{ .Values.host.port }}
+{{- if .Values.prometheus.metricsPort }}
+  - max: {{ .Values.prometheus.metricsPort }}
+    min: {{ .Values.prometheus.metricsPort }}
+{{- end }}
+  hostIPC: false
+  hostPID: false
+  volumes:
+  - 'configMap'
+  - 'secret'
+  - 'downwardAPI'
+  runAsUser:
+    rule: 'RunAsAny'    
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -97,3 +97,10 @@ updateStrategy: OnDelete
 verbose: false
 
 tolerations: []
+
+podSecurityPolicy:
+  ## if true, a podSecurityPolicy object will be created. rbac.create has to be set to true to also create RBAC roles and bindings for the podSecurityPolicy.
+  enabled: false
+
+  ## annotations to add to the podSecurityPolicy object
+  annotations: {}


### PR DESCRIPTION
Signed-off-by: Yannick Kint <yannick.kint@gmail.com>

#### What this PR does / why we need it:
Add the possibility to configure podSecurityPolicies for kube2iam. podsecuritypolicies are an important security feature of k8s, policies are needed to let kube2iam function properly when the default psp is restricted.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
