### PR TITLE
[stable/rabbitmq-ha] Allow configuration of headless service

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.0
-version: 1.44.2
+version: 1.44.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -17,9 +17,7 @@ metadata:
 {{- end }}
 spec:
 {{- if ne .Values.service.type "NodePort" }}
-{{- if and (eq .Values.service.type "LoadBalancer") (ne .Values.service.clusterIP "None") }}
   clusterIP: "{{ .Values.service.clusterIP }}"
-{{- end }}
 {{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:


### PR DESCRIPTION
#### What this PR does / why we need it:

A Kubernetes headless service is configured by explicitly specifying the
clusterIP to have the value "None". This configuration has been made impossible
by the changes introduced in #18503. 

#### Which issue this PR fixes
  - fixes #20510 and #19560

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
