### PR TITLE
[stable/kube-state-metrics] Change name of container argument from namespace to namespaces

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.2
+version: 2.8.3
 appVersion: 1.9.5
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -73,3 +73,4 @@ $ helm install stable/kube-state-metrics
 | `prometheus.monitor.namespace`               | Namespace where servicemonitor resource should be created                             | `the same namespace as kube-state-metrics` |
 | `prometheus.monitor.honorLabels`             | Honor metric labels                                                                   | `false`                                    |
 | `namespaceOverride`                          | Override the deployment namespace                                                     | `""` (`Release.Namespace`)                 |
+| `namespaces`                                 | Comma-separated list of namespaces to be enabled.                                     | `""` (`All namespaces`)                    |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -145,8 +145,8 @@ spec:
 {{  if .Values.collectors.volumeattachments  }}
         - --collectors=volumeattachments
 {{  end  }}
-{{ if .Values.namespace }}
-        - --namespace={{ .Values.namespace }}
+{{ if .Values.namespaces }}
+        - --namespaces={{ .Values.namespaces }}
 {{ end }}
 {{ if .Values.autosharding.enabled }}
         - --pod=$(POD_NAME)

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -121,8 +121,8 @@ collectors:
   verticalpodautoscalers: true
   volumeattachments: true
 
-# Namespace to be enabled for collecting resources. By default all namespaces are collected.
-# namespace: ""
+# Comma-separated list of namespaces to be enabled. Defaults to "" (all namespaces)
+# namespaces: ""
 
 ## Override the deployment namespace
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

1. Change container argument from 'namespace' to 'namespaces' to align official documentation:
https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md#available-options
2. Change value in Values.yaml for defining namespaces from 'namespace' to 'namespaces'.

@fiunchinho
@tariq1890
@mrueg

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
