### PR TITLE
[stable/prometheus] fix remoteRead/Write defaults

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.1.4
+version: 11.1.5
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -286,8 +286,8 @@ Parameter | Description | Default
 `server.global.scrape_interval` | How frequently to scrape targets by default | `1m`
 `server.global.scrape_timeout` | How long until a scrape request times out | `10s`
 `server.global.evaluation_interval` | How frequently to evaluate rules | `1m`
-`server.remoteWrite` | The remote write feature of Prometheus allow transparently sending samples. | `{}`
-`server.remoteRead` | The remote read feature of Prometheus allow transparently receiving samples. | `{}`
+`server.remoteWrite` | The remote write feature of Prometheus allow transparently sending samples. | `[]`
+`server.remoteRead` | The remote read feature of Prometheus allow transparently receiving samples. | `[]`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.extraFlags` | Additional Prometheus server container flags | `["web.enable-lifecycle"]`
 `server.extraInitContainers` | Init containers to launch alongside the server | `[]`

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -605,10 +605,10 @@ server:
     evaluation_interval: 1m
   ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
   ##
-  remoteWrite: {}
+  remoteWrite: []
   ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read
   ##
-  remoteRead: {}
+  remoteRead: []
 
   ## Additional Prometheus server container arguments
   ##


### PR DESCRIPTION


<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
#20056 has added the options to set `remote_read` and `remote_write` configs but ueses a wrong standard value.
Using this value as list works but shows this warning:

```
Warning: Merging destination map for chart 'prometheus'. Cannot overwrite table item 'remoteRead', with non table value: map[]
```

The config is a list of objects not an object:

https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file
```
# Settings related to the remote write feature.
remote_write:
  [ - <remote_write> ... ]

# Settings related to the remote read feature.
remote_read:
  [ - <remote_read> ... ]
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped]
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
