### PR TITLE
[stable/jenkins] Allow templating of ServiceAccount annotations

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.17.2
+
+Allow templating of `serviceAccount.annotations` and `serviceAccountAgent.annotations` by rendering them with the `tpl` function
+
 ## 1.17.1
 
 Add support for Persistent Volume Claim (PVC) in `agent.volumes`

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -22,4 +22,6 @@ maintainers:
   email: mail@torstenwalter.de
 - name: mogaal
   email: garridomota@gmail.com
+- name: wmcdona89
+  email: wmcdona89@gmail.com
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.17.1
+version: 1.17.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/OWNERS
+++ b/stable/jenkins/OWNERS
@@ -4,9 +4,11 @@ approvers:
 - maorfr
 - torstenwalter
 - mogaal
+- wmcdona89
 reviewers:
 - lachie83
 - viglesiasce
 - maorfr
 - torstenwalter
 - mogaal
+- wmcdona89

--- a/stable/jenkins/ci/other-values.yaml
+++ b/stable/jenkins/ci/other-values.yaml
@@ -43,3 +43,10 @@ agent:
     - type: EmptyDir
       mountPath: /var/myapp/myemptydir
       memory: false
+serviceAccount:
+  annotations:
+    description: "Used by release {{ .Release.Name }} for role-based access control"
+serviceAccountAgent:
+  create: true
+  annotations:
+    description: "Used by release {{ .Release.Name }} for role-based access control"

--- a/stable/jenkins/templates/service-account-agent.yaml
+++ b/stable/jenkins/templates/service-account-agent.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ template "jenkins.master.slaveKubernetesNamespace" . }}
 {{- if .Values.serviceAccountAgent.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccountAgent.annotations | indent 4 }}
-{{ end }}
+{{ tpl (toYaml .Values.serviceAccountAgent.annotations) . | indent 4 }}
+{{- end }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/service-account.yaml
+++ b/stable/jenkins/templates/service-account.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ template "jenkins.namespace" . }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-{{ end }}
+{{ tpl (toYaml .Values.serviceAccount.annotations) . | indent 4 }}
+{{- end }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Allow templating of `serviceAccount.annotations` and `serviceAccountAgent.annotations` by rendering them with the `tpl` function

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
A use case for templating ServiceAccount annotations is the use of a [ServiceAccount as an OAuth client in OpenShift](https://docs.openshift.com/container-platform/4.3/authentication/using-service-accounts-as-oauth-client.html#redirect-uris-for-service-accounts_using-service-accounts-as-oauth-client). 

In this example, the Route name is templated so the OAuth redirect can point to a Route in the release rather than being pinned to a hardcoded Route.
```yaml
serviceAccount:
  annotations:
    serviceaccounts.openshift.io/oauth-redirectreference.jenkins: |-
      {
        "kind": "OAuthRedirectReference",
        "apiVersion": "v1",
        "reference": {
          "kind": "Route",
          "name": "{{ template "jenkins.fullname" . }}"
        }
      }
```
### helm template test
Given the above yaml in stable/jenkins/sa-values.yaml
```
helm template stable/jenkins \
--show-only templates/service-account.yaml \
--values stable/jenkins/sa-values.yaml
```
```yaml
# Source: jenkins/templates/service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: RELEASE-NAME-jenkins
  namespace: default
  annotations:
    serviceaccounts.openshift.io/oauth-redirectreference.jenkins: |-
      {
        "kind": "OAuthRedirectReference",
        "apiVersion": "v1",
        "reference": {
          "kind": "Route",
          "name": "RELEASE-NAME-jenkins"
        }
      }
  labels:
    "app.kubernetes.io/name": 'jenkins'
    "helm.sh/chart": "jenkins-1.17.2"
    "app.kubernetes.io/managed-by": "Helm"
    "app.kubernetes.io/instance": "RELEASE-NAME"
    "app.kubernetes.io/component": "jenkins-master"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
