### PR TITLE
[stable/prometheus] Fix prometheus service selector with statefulset

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.1.2
+version: 11.1.3
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end }}
   selector:
   {{- if and .Values.server.statefulSet.enabled .Values.server.service.statefulsetReplica.enabled }}
-    statefulset.kubernetes.io/pod-name: {{ .Release.Name }}-{{ .Values.server.name }}-{{ .Values.server.service.statefulsetReplica.replica }}
+    statefulset.kubernetes.io/pod-name: {{ template "prometheus.server.fullname" . }}-{{ .Values.server.service.statefulsetReplica.replica }}
   {{- else -}}
     {{- include "prometheus.server.matchLabels" . | nindent 4 }}
 {{- if .Values.server.service.sessionAffinity }}


### PR DESCRIPTION
#### What this PR does / why we need it:
In Stable/Prometheus chart, when deploying prometheus server using statefulset, the selector of `prometheus-server` service is incorrect.

Before this PR, selector is defined as `statefulset.kubernetes.io/pod-name: {{ .Release.Name }}-{{ .Values.server.name }}-{{ .Values.server.service.statefulsetReplica.replica }}`.

`server.name` defaults to `prometheus-server`, `server.service.statefulsetReplica.replica` defaults to 0 (first pod of the statefulset) so label's value defaults to `$(release name)-prometheus-server-0`

Based on [Statefulset documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id), a pod created by a statefulset have a label `statefulset.kubernetes.io/pod-name: $(statefulset name)-$(ordinal)`.

Name of the server statefulset name is defined in this chart as `{{ template "prometheus.server.fullname" . }}`.

This PR fixes the service selector's value.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
