### PR TITLE
[stable/nextcloud] Allow to use a existing database secret

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.9.2
+version: 1.9.3
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nginx.image.repository`                                     | nginx Image name                                        | `nginx`                                                 |
 | `nginx.image.tag`                                            | nginx Image tag                                         | `alpine`                                                |
 | `nginx.image.pullPolicy`                                     | nginx Image pull policy                                 | `IfNotPresent`                                          |
-| `nginx.config.default`                                       | Whether to use nextclouds recomended nginx config       | `true`                                                  |
+| `nginx.config.default`                                       | Whether to use nextclouds recommended nginx config      | `true`                                                  |
 | `nginx.config.custom`                                        | Specify a custom config for nginx                       | `{}`                                                    |
 | `nginx.resources`                                            | nginx resources                                         | `{}`                                                    |
 | `lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand      | `nil`                                                   |
@@ -99,6 +99,10 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `externalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                             |
 | `externalDatabase.user`                                      | Existing username in the external db                    | `nextcloud`                                             |
 | `externalDatabase.password`                                  | Password for the above username                         | `nil`                                                   |
+| `externalDatabase.existingSecret.enabled`                    | Whether to use a existing secret or not                 | `false`                                                 |
+| `externalDatabase.existingSecret.secretName`                 | Name of the existing secret                             | `nil`                                                   |
+| `externalDatabase.existingSecret.usernameKey`                | Name of the key that contains the username              | `nil`                                                   |
+| `externalDatabase.existingSecret.passwordKey`                | Name of the key that contains the password              | `nil`                                                   |
 | `mariadb.enabled`                                            | Whether to use the MariaDB chart                        | `false`                                                 |
 | `mariadb.db.name`                                            | Database name to create                                 | `nextcloud`                                             |
 | `mariadb.db.password`                                        | Password for the database                               | `changeme`                                              |

--- a/stable/nextcloud/templates/db-secret.yaml
+++ b/stable/nextcloud/templates/db-secret.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.enabled }}
+{{- if not .Values.externalDatabase.existingSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,4 +18,5 @@ data:
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
   db-username: {{ default "" .Values.externalDatabase.user | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -69,13 +69,13 @@ spec:
         - name: MYSQL_USER
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "db"  }}
-              key: db-username
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "db"  }}
-              key: db-password
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
         {{- else }}
           {{- if eq .Values.externalDatabase.type "postgresql" }}
         - name: POSTGRES_HOST
@@ -85,13 +85,13 @@ spec:
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "db" }}
-              key: db-username
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "db" }}
-              key: db-password
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
           {{- else }}
         - name: MYSQL_HOST
           value: {{ .Values.externalDatabase.host | quote }}
@@ -100,13 +100,13 @@ spec:
         - name: MYSQL_USER
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "db" }}
-              key: db-username
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.usernameKey | default "db-username" }}
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "db" }}
-              key: db-password
+              name: {{ .Values.externalDatabase.existingSecret.secretName | default (printf "%s-%s" .Release.Name "db") }}
+              key: {{ .Values.externalDatabase.existingSecret.passwordKey | default "db-password" }}
           {{- end }}
         {{- end }}
         - name: NEXTCLOUD_ADMIN_USER

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -180,6 +180,13 @@ externalDatabase:
   ## Database name
   database: nextcloud
 
+  ## Use a existing secret
+  existingSecret:
+    enabled: false
+    # secretName: nameofsecret
+    # usernameKey: username
+    # passwordKey: password
+
 ##
 ## MariaDB chart configuration
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
I'm deploying a Postgres cluster using [Zalando Postgres Operator](https://github.com/zalando/postgres-operator) for Nextcloud. The operator creates a database secret on provisioning of the cluster before Nextcloud is being deployed.

I want to re-use the secret already in there rather than create a new one using this chart.
As `key` names in secrets might vary I made them configurable.

This allows us to use a existing secret like one created from a Postgres operator.

Without this addition the chart creates a new secret based on the username/password provided in values and you can't use a existing secret.

#### Which issue this PR fixes
  - Fixes #20292

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@chrisingenhaag @billimek 
