### PR TITLE
[stable/prometheus-operator] fix coreDNS chart to have a dynamic datasource #22024

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.0
+version: 8.13.1
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-coredns.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-coredns.yaml
@@ -15,33 +15,32 @@ metadata:
 data:
   k8s-coredns.json: |-
     {
+        "__inputs": [
+
+        ],
+        "__requires": [
+
+        ],
         "annotations": {
             "list": [
-                {
-                    "builtIn": 1,
-                    "datasource": "-- Grafana --",
-                    "enable": true,
-                    "hide": true,
-                    "iconColor": "rgba(0, 211, 255, 1)",
-                    "name": "Annotations & Alerts",
-                    "type": "dashboard"
-                }
+
             ]
         },
-        "description": "A dashboard for the CoreDNS DNS server.",
-        "editable": true,
-        "gnetId": 5926,
+        "editable": false,
+        "gnetId": null,
         "graphTooltip": 0,
-        "id": 9,
-        "iteration": 1539947521873,
-        "links": [],
+        "hideControls": false,
+        "id": null,
+        "links": [
+
+        ],
         "panels": [
             {
                 "aliasColors": {},
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -140,7 +139,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -234,7 +233,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -331,7 +330,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -428,7 +427,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -540,7 +539,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -652,7 +651,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -737,7 +736,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -839,7 +838,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -956,7 +955,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -1076,7 +1075,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -1161,7 +1160,7 @@ data:
                 "bars": false,
                 "dashLength": 10,
                 "dashes": false,
-                "datasource": "Prometheus",
+                "datasource": "$datasource",
                 "editable": true,
                 "error": false,
                 "fill": 1,
@@ -1260,6 +1259,22 @@ data:
         "templating": {
             "list": [
                 {
+                    "current": {
+                        "text": "default",
+                        "value": "default"
+                    },
+                    "hide": 0,
+                    "label": null,
+                    "name": "datasource",
+                    "options": [
+
+                    ],
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "datasource"
+                },
+                {
                     "allValue": ".*",
                     "current": {
                         "selected": true,
@@ -1267,7 +1282,7 @@ data:
                         "text": "172.16.1.8:9153",
                         "value": "172.16.1.8:9153"
                     },
-                    "datasource": "Prometheus",
+                    "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": true,
                     "label": "Instance",


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fixes CoreDNS chart to work without having to name the datsource `Prometheus`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #22024


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
