### PR TITLE
[stable/prometheus-operator] Use new API version for ingress

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.1
+version: 8.13.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -3,7 +3,11 @@
 {{- $servicePort := .Values.alertmanager.service.port -}}
 {{- $routePrefix := list .Values.alertmanager.alertmanagerSpec.routePrefix }}
 {{- $paths := .Values.alertmanager.ingress.paths | default $routePrefix -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ $serviceName }}

--- a/stable/prometheus-operator/templates/alertmanager/ingressperreplica.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingressperreplica.yaml
@@ -9,8 +9,12 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 items:
 {{ range $i, $e := until $count }}
-  - apiVersion: extensions/v1beta1
-    kind: Ingress
+  - kind: Ingress
+    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    apiVersion: networking.k8s.io/v1beta1
+    {{ else }}
+    apiVersion: extensions/v1beta1
+    {{ end -}}
     metadata:
       name: {{ include "prometheus-operator.fullname" $ }}-alertmanager-{{ $i }}
       namespace: {{ $.Release.Namespace }}

--- a/stable/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingress.yaml
@@ -3,7 +3,11 @@
 {{- $servicePort := .Values.prometheus.service.port -}}
 {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix }}
 {{- $paths := .Values.prometheus.ingress.paths | default $routePrefix -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
 {{- if .Values.prometheus.ingress.annotations }}

--- a/stable/prometheus-operator/templates/prometheus/ingressperreplica.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingressperreplica.yaml
@@ -9,8 +9,12 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 items:
 {{ range $i, $e := until $count }}
-  - apiVersion: extensions/v1beta1
-    kind: Ingress
+  - kind: Ingress
+    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    apiVersion: networking.k8s.io/v1beta1
+    {{ else }}
+    apiVersion: extensions/v1beta1
+    {{ end -}}
     metadata:
       name: {{ include "prometheus-operator.fullname" $ }}-prometheus-{{ $i }}
       namespace: {{ $.Release.Namespace }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Use new API for ingress if it is available
