### PR TITLE
[stable/datadog] Ensure the trace-agent computes the same hostname as the core agent

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Datadog changelog
 
+## 2.2.6
+
+* Ensure the `trace-agent` computes the same hostname as the core `agent`.
+  by giving it access to all the elements that might be used to compute the hostname:
+  the `DD_CLUSTER_NAME` environment variable and the docker socket.
+
+## 2.2.5
+
+* Fix RBAC
+
 ## 2.2.4
 
 * Move several EnvVars to `common-env-vars` to be accessible by the `trace-agent` #21991.

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.2.5
+version: 2.2.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -14,13 +14,6 @@
     protocol: UDP
   env:
     {{- include "containers-common-env" . | nindent 4 }}
-    {{- if .Values.datadog.clusterName }}
-    {{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
-    {{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
-    {{- end}}
-    - name: DD_CLUSTER_NAME
-      value: {{ .Values.datadog.clusterName | quote }}
-    {{- end }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
@@ -77,19 +70,6 @@
       value: {{  (default false (or .Values.datadog.logs.containerCollectAll .Values.datadog.logsConfigContainerCollectAll)) | quote}}
     - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
       value: {{ .Values.datadog.logs.containerCollectUsingFiles | quote }}
-    {{- if .Values.datadog.dockerSocketPath }}
-    - name: DOCKER_HOST
-    {{- if eq .Values.targetSystem "linux" }}
-      value: unix://{{ .Values.datadog.dockerSocketPath }}
-    {{- end }}
-    {{- if eq .Values.targetSystem "windows" }}
-      value: npipe://{{ .Values.datadog.dockerSocketPath | replace "\\" "/" }}
-    {{- end }}
-    {{- end }}
-    {{- if .Values.datadog.criSocketPath }}
-    - name: DD_CRI_SOCKET_PATH
-      value: {{ .Values.datadog.criSocketPath }}
-    {{- end }}
     {{- if not .Values.datadog.livenessProbe }}
     - name: DD_HEALTH_PORT
       value: "5555"

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -37,6 +37,11 @@
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
     {{- end }}
+    - name: runtimesocket
+      mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
+      {{- if eq .Values.targetSystem "linux" }}
+      readOnly: true
+      {{- end }}
   livenessProbe:
 {{ toYaml .Values.agents.containers.traceAgent.livenessProbe | indent 4 }}
 {{- end -}}

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -16,6 +16,13 @@
 - name: DD_HOSTNAME
   value: {{ .Values.datadog.hostname | quote }}
 {{- end }}
+{{- if .Values.datadog.clusterName }}
+{{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
+{{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
+{{- end}}
+- name: DD_CLUSTER_NAME
+  value: {{ .Values.datadog.clusterName | quote }}
+{{- end }}
 {{- if .Values.datadog.tags }}
 - name: DD_TAGS
   value: {{ .Values.datadog.tags | join " " | quote }}
@@ -45,5 +52,18 @@
 {{- range $value := .Values.datadog.env }}
 - name: {{ $value.name }}
   value: {{ $value.value | quote }}
+{{- end }}
+{{- if .Values.datadog.dockerSocketPath }}
+- name: DOCKER_HOST
+{{- if eq .Values.targetSystem "linux" }}
+  value: unix://{{ .Values.datadog.dockerSocketPath }}
+{{- end }}
+{{- if eq .Values.targetSystem "windows" }}
+  value: npipe://{{ .Values.datadog.dockerSocketPath | replace "\\" "/" }}
+{{- end }}
+{{- end }}
+{{- if .Values.datadog.criSocketPath }}
+- name: DD_CRI_SOCKET_PATH
+  value: {{ .Values.datadog.criSocketPath }}
 {{- end }}
 {{- end -}}

--- a/stable/datadog/templates/containers-init-linux.yaml
+++ b/stable/datadog/templates/containers-init-linux.yaml
@@ -43,14 +43,6 @@
       value: {{ .Values.datadog.leaderElection | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.datadog.dockerSocketPath }}
-    - name: DOCKER_HOST
-      value: unix://{{ .Values.datadog.dockerSocketPath }}
-    {{- end }}
-    {{- if .Values.datadog.criSocketPath }}
-    - name: DD_CRI_SOCKET_PATH
-      value: {{ .Values.datadog.criSocketPath }}
-    {{- end }}
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 {{- end -}}

--- a/stable/datadog/templates/containers-init-windows.yaml
+++ b/stable/datadog/templates/containers-init-windows.yaml
@@ -33,14 +33,6 @@
       mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
-    {{- if .Values.datadog.dockerSocketPath }}
-    - name: DOCKER_HOST
-      value: npipe://{{ .Values.datadog.dockerSocketPath | replace "\\" "/" }}
-    {{- end }}
-    {{- if .Values.datadog.criSocketPath }}
-    - name: DD_CRI_SOCKET_PATH
-      value: {{ .Values.datadog.criSocketPath }}
-    {{- end }}
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Ensure the trace-agent computes the same hostname as the core agent by giving it access to all the elements that might be used to compute the hostname:
* the `DD_CLUSTER_NAME` environment variable and
* the docker socket.

#### Which issue this PR fixes

The `trace-agent` computes its hostname by invoking `agent hostname` from its container. But this `agent hostname` command doesn’t communicate with the real agent. Instead, it’s redoing the same process.
So, if we want to get the same result in the end, it’s important that both containers have a similar environment concerning everything which is involved in hostname discovery.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
