### PR TITLE
stable/opa Adding newer cert-manager apis

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.13.4
+version: 1.13.5
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/_helpers.tpl
+++ b/stable/opa/templates/_helpers.tpl
@@ -77,3 +77,19 @@ Create the name of the service account to use
 {{- define "opa.servingCertificate" -}}
 {{ printf "%s-webhook-tls" (include "opa.fullname" .) }}
 {{- end -}}
+
+{{/*
+Detect the version of cert manager crd that is installed
+Error if CRD is not available
+*/}}
+{{- define "opa.certManagerApiVersion" -}}
+{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha3") -}}
+cert-manager.io/v1alpha3
+{{- else if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") -}}
+cert-manager.io/v1alpha2
+{{- else if (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") -}}
+certmanager.k8s.io/v1alpha1
+{{- else  -}}
+{{- fail "cert-manager CRD does not appear to be installed" }}
+{{- end -}}
+{{- end -}}

--- a/stable/opa/templates/webhookconfiguration.yaml
+++ b/stable/opa/templates/webhookconfiguration.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
 {{- if .Values.certManager.enabled }}
     certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
 {{- end }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
@@ -40,7 +41,7 @@ webhooks:
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Issuer
 metadata:
   name: {{ include "opa.selfSignedIssuer" . }}
@@ -51,7 +52,7 @@ spec:
 
 ---
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Certificate
 metadata:
   name: {{ include "opa.rootCACertificate" . }}
@@ -67,7 +68,7 @@ spec:
 
 ---
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Issuer
 metadata:
   name: {{ include "opa.rootCAIssuer" . }}
@@ -80,7 +81,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: {{ include "opa.certManagerApiVersion" . }}
 kind: Certificate
 metadata:
   name: {{ include "opa.servingCertificate" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
@tsandall 
#### What this PR does / why we need it:
Adding support for newer versions of the cert-manager CRD.

#### Special notes for your reviewer:
Helm is not happy if you run a helm update and current version of the cert-manager CRD is not around.  I actually had the 0.6 and 0.14 CRD installed at the same time even though I was running the 0.14 cert-manager.  After the updated version of OPA was installed I was able to remove the 0.6 CRD.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
