### PR TITLE
stable/stolon: fix clustername usage

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.5.11
+version: 1.6.0
 appVersion: 0.16.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -65,7 +65,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: STKEEPER_CLUSTER_NAME
-              value: {{ template "stolon.fullname" . }}
+              value: {{ template "stolon.clusterName" . }}
             - name: STKEEPER_STORE_BACKEND
               value: {{ .Values.store.backend | quote }}
             {{- if eq .Values.store.backend "kubernetes" }}

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -49,7 +49,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: STPROXY_CLUSTER_NAME
-              value: {{ template "stolon.fullname" . }}
+              value: {{ template "stolon.clusterName" . }}
             - name: STPROXY_STORE_BACKEND
               value: {{ .Values.store.backend | quote}}
             {{- if eq .Values.store.backend "kubernetes" }}

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: STSENTINEL_CLUSTER_NAME
-              value: {{ template "stolon.fullname" . }}
+              value: {{ template "stolon.clusterName" . }}
             - name: STSENTINEL_STORE_BACKEND
               value: {{ .Values.store.backend | quote}}
             {{- if eq .Values.store.backend "kubernetes" }}


### PR DESCRIPTION
### What this PR does / why we need it:
Changed from using fullname to clustername in the *_CLUSTER_NAME env vars for each of the deployments/statefuslets. The switch to using clusterName was made for the init of the cluster but not for these env vars so a cluster with a custom clusterName which did not match the fullName would fail to init.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
- [ x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
