### PR TITLE
[incubator/haproxy-ingress] Wrong `app` label generated in manifests

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.25
+version: 0.0.26
 appVersion: 0.7.2
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/templates/_helpers.tpl
+++ b/incubator/haproxy-ingress/templates/_helpers.tpl
@@ -10,14 +10,14 @@ Expand the name of the chart.
 Create the app label for controller
 */}}
 {{- define "haproxy-ingress.labels.app.controller" -}}
-{{ default "haproxy-ingress.name" }}-controller
+{{ default "haproxy-ingress-controller" }}
 {{- end -}}
 
 {{/*
 Create the app label for default backend
 */}}
 {{- define "haproxy-ingress.labels.app.default-backend" -}}
-{{ default "haproxy-ingress.name" }}-default-backend
+{{ default "haproxy-ingress-default-backend" }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
NO

#### What this PR does / why we need it:
This PR fixes the wrong value in `app` label introduced with https://github.com/helm/charts/pull/22076
#### Which issue this PR fixes

  - fixes #22116

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X ] Chart Version bumped
- [ X] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
