### PR TITLE
[stable/kube-state-metrics] Allow specification of additional volume types in podSecurityPolicy of kube-state-metrics

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.6
+version: 2.8.7
 appVersion: 1.9.6
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -30,6 +30,7 @@ $ helm install stable/kube-state-metrics
 | `serviceAccount.imagePullSecrets`            | Specify image pull secrets field                                                      | `[]`                                       |
 | `podSecurityPolicy.enabled`                  | If true, create & use PodSecurityPolicy resources. Note that related RBACs are created only if `rbac.enabled` is `true. | `false`  |
 | `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                                    | {}                                         |
+| `podSecurityPolicy.additionalVolumes`        | Specify allowed volumes in the pod security policy (`secret` is always allowed)       | []                                         |
 | `securityContext.enabled`                    | Enable security context                                                               | `true`                                     |
 | `securityContext.fsGroup`                    | Group ID for the container                                                            | `65534`                                    |
 | `securityContext.runAsUser`                  | User ID for the container                                                             | `65534`                                    |

--- a/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -16,6 +16,9 @@ spec:
   privileged: false
   volumes:
     - 'secret'
+{{- if .Values.podSecurityPolicy.additionalVolumes }}
+{{ toYaml .Values.podSecurityPolicy.additionalVolumes | indent 4 }}
+{{- end }}
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -62,6 +62,7 @@ podSecurityPolicy:
     # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
     # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
+  additionalVolumes: []
 
 securityContext:
   enabled: true


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Allow to specify allowed volumes other than secret in values for `PodSecurityPolicy` which is helpful on GKE >= 1.16.x with pod security policy enabled which has `projected` volumes by default.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
Follow-up of #21563

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
