### PR TITLE
[stable/jenkins] Cleanup agent.yamlTemplate rendering in XML config

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.21.2
+
+Cleanup `agent.yamlTemplate` rendering in kubernetes pod template XML configuration
+
 ## 1.21.1
 
 Render `agent.nodeSelector` in the kubernetes pod template JCasC

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.21.1
+version: 1.21.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -220,10 +220,10 @@ Returns kubernetes pod template configuration as code
     {{- end }}
   {{- end }}
 {{- end }}
-  {{- if .Values.agent.yamlTemplate }}
+{{- if .Values.agent.yamlTemplate }}
   yaml: |-
-  {{- tpl ( trim .Values.agent.yamlTemplate ) . | nindent 4 }}
-  {{- end }}
+    {{- tpl (trim .Values.agent.yamlTemplate) . | nindent 4 }}
+{{- end }}
   yamlMergeStrategy: "override"
 {{- end -}}
 
@@ -322,7 +322,9 @@ Returns kubernetes pod template xml configuration
 {{- end }}
   <nodeProperties/>
 {{- if .Values.agent.yamlTemplate }}
-  <yaml>{{ tpl .Values.agent.yamlTemplate . | html | indent 4 | trim }}</yaml>
+  <yaml>
+    {{- tpl (trim .Values.agent.yamlTemplate) . | html | nindent 4 }}
+  </yaml>
 {{- end }}
   <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
 </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Cleanup `agent.yamlTemplate` rendering in kubernetes pod template XML configuration.

This is a cosmetic change to render valid looking yaml. Technically, nothing was broken as the kubernetes plugin was able to parse the yaml despite the misalignment. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Given the following in stable/jenkins/agent-values.yaml
```yaml
agent:
  yamlTemplate: |-
    apiVersion: v1
    kind: Pod
    spec:
      tolerations:
      - key: "key"
        operator: "Equal"
        value: "value"
        effect: "NoSchedule"
```
#### original formatting
config.yaml
```yaml
<yaml>{{ tpl .Values.agent.yamlTemplate . | html | indent 4 | trim }}</yaml>
```
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--values stable/jenkins/agent-values.yaml
```
```xml
              <yaml>apiVersion: v1
                kind: Pod
                spec:
                  tolerations:
                  - key: &#34;key&#34;
                    operator: &#34;Equal&#34;
                    value: &#34;value&#34;
                    effect: &#34;NoSchedule&#34;</yaml>
```
Jenkins screenshot
![image](https://user-images.githubusercontent.com/7925481/80271680-666c2f00-8690-11ea-96c3-6dbbbe77dd39.png)

Pod YAML at runtime
```yaml
apiVersion: v1
kind: Podspec:
  tolerations:
  - effect: "NoSchedule"
    key: "key"
    operator: "Equal"
    value: "value"
```
#### proposed formatting
config.yaml
```yaml
  <yaml>
    {{- tpl (trim .Values.agent.yamlTemplate) . | html | nindent 4 }}
  </yaml>
```
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--values stable/jenkins/agent-values.yaml
```
```xml
              <yaml>
                apiVersion: v1
                kind: Pod
                spec:
                  tolerations:
                  - key: &#34;key&#34;
                    operator: &#34;Equal&#34;
                    value: &#34;value&#34;
                    effect: &#34;NoSchedule&#34;
              </yaml>
```
Jenkins screenshot
![image](https://user-images.githubusercontent.com/7925481/80271740-41c48700-8691-11ea-9df9-69b354fa3f80.png)

Pod YAML at runtime
```yaml
apiVersion: v1
kind: Podspec:
  tolerations:
  - effect: "NoSchedule"
    key: "key"
    operator: "Equal"
    value: "value"
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
