### PR TITLE
[stable/gocd] - GH-22120 - fix the permission of files in ~/.ssh/

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.26.1
+* [7a9cd1bb4](https://github.com/kubernetes/charts/commit/7a9cd1bb4): Updated permissions of files in ~/.ssh directory
+
 ### 1.26.0
 * [ec6b96f](https://github.com/kubernetes/charts/commit/ec6b96f): Bump up GoCD Version to 20.3.0
 ### 1.25.1
@@ -266,7 +269,7 @@
 
 ### 1.4.0
 
-* [f5249551](https://github.com/kubernetes/charts/commit/f5249551):  
+* [f5249551](https://github.com/kubernetes/charts/commit/f5249551):
   - Bump up GoCD app version to 18.8.0
   - Updated kubernetes elastic agent plugin version to 1.0.2
   - Updated post install script

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.26.0
+version: 1.26.1
 appVersion: 20.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -54,6 +54,7 @@ spec:
         - name: ssh-secrets
           secret:
             secretName: {{ .Values.agent.security.ssh.secretName }}
+            defaultMode: {{ .Values.agent.security.ssh.defaultMode | default 256 }}
       {{- end }}
       {{- if .Values.agent.initContainers }}
       initContainers:

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -58,6 +58,7 @@ spec:
         - name: ssh-secrets
           secret:
             secretName: {{ .Values.server.security.ssh.secretName }}
+            defaultMode: {{ .Values.server.security.ssh.defaultMode | default 256 }}
       {{- end }}
       {{- if .Values.server.initContainers }}
       initContainers:

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -222,6 +222,8 @@ server:
       enabled: false
       # server.security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
       secretName: gocd-server-ssh
+      # server.security.ssh.defaultMode specifies the permission of the files in ~/.ssh directory
+      defaultMode:
 
 agent:
   # specifies overrides for agent specific service account creation
@@ -371,6 +373,8 @@ agent:
       enabled: false
       # agent.security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
       secretName: gocd-agent-ssh
+      # agent.security.ssh.defaultMode specifies the permission of the files in ~/.ssh directory
+      defaultMode:
 
   ## Configure GoCD agent resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Permissions of files in directory `~/.ssh`  are not correct in the `gocd-server` and `go-agent` pods. This PR fixes the permissions and thus allows private git repositories to work correctly.

#### Which issue this PR fixes
  - fixes #22120

#### Special notes for your reviewer:
@arvindsv  - Please have a look
After the change, I can test my connection successfully
![2020-04-25_22-43-47](https://user-images.githubusercontent.com/6998650/80280261-52830480-8746-11ea-8f06-826831a7a627.png)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
