### PR TITLE
[stable/locust] Changed tolerations to be arrays

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
 description: A modern load testing framework
-version: 1.1.3
+version: 1.1.4
 appVersion: 0.9.0
 maintainers:
   - name: haugene

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -40,12 +40,12 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `extraEnvs`                  | List of extra Environment Variables     | `[]`                                                  |
 | `master.config.target-host`  | locust target host                      | `http://site.example.com`                             |
 | `master.nodeSelector`        | k8s nodeselector                        | `{}`                                                  |
-| `master.tolerations`         | k8s tolerance                           | `{}`                                                  |
+| `master.tolerations`         | k8s tolerations                         | `[]`                                                  |
 | `worker.config.locust-script`| locust script to run                    | `/locust-tasks/tasks.py`                              |
 | `worker.config.configmapName`| configmap to mount locust scripts from  | `empty, configmap is created from tasks folder in Chart` |
 | `worker.replicaCount`        | Number of workers to run                | `2`                                                   |
 | `worker.nodeSelector`        | k8s nodeselector                        | `{}`                                                  |
-| `worker.tolerations`         | k8s tolerance                           | `{}`                                                  |
+| `worker.tolerations`         | k8s tolerations                         | `[]`                                                  |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -50,7 +50,7 @@ master:
       memory: 128Mi
   nodeSelector: {}
     # kops.k8s.io/instancegroup: master
-  tolerations: {}
+  tolerations: []
   # - key: "application"
   #   operator: "Equal"
   #   value: "api"
@@ -73,7 +73,7 @@ worker:
       memory: 128Mi
   nodeSelector: {}
     # kops.k8s.io/instancegroup: worker
-  tolerations: {}
+  tolerations: []
   # - key: "application"
   #   operator: "Equal"
   #   value: "api"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

Fixes the format of the tolerations parameter. It was mistakenly set as a map, while Kubernetes expects an array.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
