### PR TITLE
[stable/neo4j] Remove doubled -- for -a

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
 version: 2.0.0
-appVersion: 3.4.5
+appVersion: 3.4.6
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png
 sources:

--- a/stable/neo4j/templates/NOTES.txt
+++ b/stable/neo4j/templates/NOTES.txt
@@ -18,7 +18,7 @@ kubectl run -it --rm cypher-shell \
     --image=neo4j:3.2.3-enterprise \
     --restart=Never \
     --namespace {{ .Release.Namespace }} \
-    --command -- ./bin/cypher-shell -u neo4j -p <password> --a {{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
+    --command -- ./bin/cypher-shell -u neo4j -p <password> -a {{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
 
 This will print out the addresses of the members of the cluster.
 


### PR DESCRIPTION
@mneedham

#### What this PR does / why we need it:

`--a` works because the full flag is `--address` and any substring of that works, but the proper short flag is `-a`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)