### PR TITLE
[stable/airflow] add LoadBalancer IP/SourceRanges config

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.7.3
+version: 6.8.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -424,6 +424,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.service.type`                   | service type for Airflow UI                             | `ClusterIP`               |
 | `airflow.service.annotations`            | (optional) service annotations for Airflow UI           | `{}`                      |
 | `airflow.service.externalPort`           | (optional) external port for Airflow UI                 | `8080`                    |
+| `airflow.service.loadBalancerIP`         | (optional) for service.type == LoadBalancer, the loadBalancerIP | `` |
+| `airflow.service.loadBalancerSourceRanges` | (optional) for service.type == LoadBalancer, the loadBalancerSourceRanges | `[]` |
 | `airflow.service.nodePort.http`          | (optional) when using service.type == NodePort, an optional NodePort to request | ``|
 | `airflow.service.sessionAffinity`        | The session affinity for the airflow UI                 | `None`                    |
 | `airflow.service.sessionAffinityConfig`  | The session affinity config for the airflow UI          | `None`                    |
@@ -457,6 +459,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `flower.service.type`                    | service type for Flower UI                              | `ClusterIP`               |
 | `flower.service.annotations`             | (optional) service annotations for Flower UI            | `{}`                      |
 | `flower.service.externalPort`            | (optional) external port for Flower UI                  | `5555`                    |
+| `flower.service.loadBalancerIP`          | (optional) for service.type == LoadBalancer, the loadBalancerIP | `` |
+| `flower.service.loadBalancerSourceRanges` | (optional) for service.type == LoadBalancer, the loadBalancerSourceRanges | `[]` |
 | `flower.securityContext`                 | (optional) security context for the flower deployment   | `{}`                      |
 | `web.baseUrl`                            | webserver UI URL                                        | `http://localhost:8080`   |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |

--- a/stable/airflow/templates/service-flower.yaml
+++ b/stable/airflow/templates/service-flower.yaml
@@ -24,4 +24,13 @@ spec:
       protocol: TCP
       port: {{ .Values.flower.service.externalPort | default 5555 }}
       targetPort: 5555
+{{- if eq .Values.flower.service.type "LoadBalancer" }}
+{{- if .Values.flower.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.flower.service.loadBalancerIP | quote }}
+{{- end }}
+{{- if .Values.flower.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.flower.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -31,3 +31,12 @@ spec:
       nodePort: {{ .Values.airflow.service.nodePort.http }}
       {{- end }}
       targetPort: 8080
+{{- if eq .Values.airflow.service.type "LoadBalancer" }}
+{{- if .Values.airflow.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.airflow.service.loadBalancerIP | quote }}
+{{- end }}
+{{- if .Values.airflow.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.airflow.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -44,6 +44,8 @@ airflow:
     sessionAffinityConfig: {}
     type: ClusterIP
     externalPort: 8080
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
     nodePort:
       http:
   ##
@@ -235,6 +237,8 @@ flower:
     annotations: {}
     type: ClusterIP
     externalPort: 5555
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
 
   ## Support Node, affinity and tolerations for flower pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector


### PR DESCRIPTION
Adds the following Service configs:
* `airflow.service.loadBalancerIP`
* `airflow.service.loadBalancerSourceRanges`
* `flower.service.loadBalancerIP`
* `flower.service.loadBalancerSourceRanges`
