### PR TITLE
[stable/grafana] Ability to give a subpath for an extra secret

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.16
+version: 5.0.18
 appVersion: 6.7.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -202,6 +202,7 @@ containers:
       - name: {{ .name }}
         mountPath: {{ .mountPath }}
         readOnly: {{ .readOnly }}
+        subPath: {{ .subPath | default "" }}
     {{- end }}
     {{- range .Values.extraVolumeMounts }}
       - name: {{ .name }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -281,6 +281,7 @@ extraSecretMounts: []
   #   mountPath: /etc/secrets
   #   secretName: grafana-secret-files
   #   readOnly: true
+  #   subPath: ""
 
 ## Additional grafana server volume mounts
 # Defines additional volume mounts.


### PR DESCRIPTION
@zanhsieh @rtluckie @maorfr

What this PR does / why we need it:
Add the ability to give a subpath for an extra secret.
Use case:
We use a secret with multiple data and we don't want to override the directory /etc/ssl/certs/ but just add a file. SubPath in volumeMount help to achive this.

Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

[x ] DCO signed
[x ] Chart Version bumped
[x ] Variables are documented in the README.md
[x ] Title of the PR starts with chart name (e.g. [stable/mychartname])