### PR TITLE
[stable/fluent-bit] tail input docker mode

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.15
+version: 2.8.16
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -134,6 +134,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
 | `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |
 | `input.tail.ignore_older`          | Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax.        | ``                                             |
+| `input.tail.dockerMode`            | Recombine split Docker log lines before passing them to the parser.        | `false`                                             |
+| `input.tail.dockerModeFlush`       | Wait period time in seconds to flush queued unfinished split lines in docker mode.        | `4`                                             |
 | `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -26,19 +26,23 @@ data:
 
   fluent-bit-input.conf: |
     [INPUT]
-        Name             tail
-        Path             {{ .Values.input.tail.path }}
-        Parser           {{ .Values.input.tail.parser }}
-        Tag              {{ .Values.filter.kubeTag }}.*
-        Refresh_Interval 5
-        Mem_Buf_Limit    {{ .Values.input.tail.memBufLimit }}
-        Skip_Long_Lines  On
+        Name              tail
+        Path              {{ .Values.input.tail.path }}
+        Parser            {{ .Values.input.tail.parser }}
+        Tag               {{ .Values.filter.kubeTag }}.*
+        Refresh_Interval  5
+        Mem_Buf_Limit     {{ .Values.input.tail.memBufLimit }}
+        Skip_Long_Lines   On
 {{- if .Values.input.tail.ignore_older }}
-        Ignore_Older    {{ .Values.input.tail.ignore_older }}
+        Ignore_Older      {{ .Values.input.tail.ignore_older }}
 {{- end }}
 {{- if .Values.trackOffsets }}
-        DB               /tail-db/tail-containers-state.db
-        DB.Sync          Normal
+        DB                /tail-db/tail-containers-state.db
+        DB.Sync           Normal
+{{- end }}
+{{- if .Values.input.tail.dockerMode }}
+        Docker_Mode       On
+        Docker_Mode_Flush {{ .Values.input.tail.dockerModeFlush }}
 {{- end }}
 {{- if .Values.input.systemd.enabled }}
     [INPUT]

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -246,6 +246,8 @@ input:
     parser: docker
     path: /var/log/containers/*.log
     ignore_older: ""
+    dockerMode: false
+    dockerModeFlush: 4
   systemd:
     enabled: false
     filters:


### PR DESCRIPTION
Signed-off-by: Or Sela <orsela1@gmail.com>

#### What this PR does / why we need it:

Adds docker_mode support for tail input plugin (https://docs.fluentbit.io/manual/v/1.3/input/tail#docker_mode)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
