### PR TITLE
[incubator/solr] Fix messed up configuration option table

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.5.0"
+version: "1.5.1"
 appVersion: "8.4.0"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/README.md
+++ b/incubator/solr/README.md
@@ -32,7 +32,6 @@ The following table shows the configuration options for the Solr helm chart:
 | `resources`                                   | Resource limits and requests to set on the solr pods | `{}` |
 | `extraEnvVars`                                | Additional environment variables to set on the solr pods (in yaml syntax) | `[]` |
 | `initScript`                                | The file name of the custom script to be run before starting Solr | `""` |
-
 | `terminationGracePeriodSeconds`               | The termination grace period of the Solr pods | `180`|
 | `image.repository`                            | The repository to pull the docker image from| `solr`                                                                |
 | `image.tag`                                   | The tag on the repository to pull | `7.7.2`                                                               |


### PR DESCRIPTION
The configuration option table in README was messed up with an extra space

#### Is this a new chart
No

#### What this PR does / why we need it:
Fix the messed up configuration option table in README

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
Fix a type by my [previous commit](https://github.com/helm/charts/pull/21598)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
