### PR TITLE
[stable/datadog-agent] Mount system-probe socket in agent container

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Datadog changelog
 
+## 2.2.8
+
+* Mount `system-probe` socket in `agent` container when system-probe is enabled
+
+## 2.2.7
+
+* Add "Cluster-Agent" `Event` `create` RBAC permission
+
 ## 2.2.6
 
 * Ensure the `trace-agent` computes the same hostname as the core `agent`.

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.2.7
+version: 2.2.8
 appVersion: "7"
 description: Datadog Agent
 keywords:
@@ -13,19 +13,19 @@ sources:
 - https://app.datadoghq.com/account/settings#agent/kubernetes
 - https://github.com/DataDog/datadog-agent
 maintainers:
-- name: hkaj
-  email: haissam@datadoghq.com
-- name: irabinovitch
-  email: ilan@datadoghq.com
-- name: charlyf
-  email: charly@datadoghq.com
-- name: mfpierre
-  email: pierre.margueritte@datadoghq.com
-- name: clamoriniere
-  email: cedric.lamoriniere@datadoghq.com
-- name: xlucas
-  email: xavier.lucas@datadoghq.com
-- name: L3n41c
-  email: lenaic.huard@datadoghq.com
+- name: ahmed-mez
+  email: ahmed.mezghani@datadoghq.com
 - name: celenechang
   email: celene@datadoghq.com
+- name: charlyf
+  email: charly@datadoghq.com
+- name: clamoriniere
+  email: cedric.lamoriniere@datadoghq.com
+- name: irabinovitch
+  email: ilan@datadoghq.com
+- name: L3n41c
+  email: lenaic.huard@datadoghq.com
+- name: vboulineau
+  email: vincent.boulineau@datadoghq.com
+- name: xornivore
+  email: ivan.ilichev@datadoghq.com

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -104,6 +104,11 @@
     - name: dsdsocket
       mountPath: "/var/run/datadog"
     {{- end }}
+    {{- if .Values.datadog.systemProbe.enabled }}
+    - name: sysprobe-socket-dir
+      mountPath: /opt/datadog-agent/run
+      readOnly: true
+    {{- end }}
     - name: procdir
       mountPath: /host/proc
       readOnly: true


### PR DESCRIPTION
#### What this PR does / why we need it:

mount `system-probe` socket in the `agent` container when system-probe is enabled

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
