### PR TITLE
[incubator/kafka] fix commands documentation in NOTES.txt

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.21.0
+version: 0.21.1
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -19,20 +19,20 @@ You can connect to Kafka by running a simple pod in the K8s cluster like this wi
 Once you have the testclient pod above running, you can list all kafka
 topics with:
 
-  kubectl -n {{ .Release.Namespace }} exec testclient -- kafka-topics --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
+  kubectl -n {{ .Release.Namespace }} exec testclient -- ./bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
 
 To create a new topic:
 
-  kubectl -n {{ .Release.Namespace }} exec testclient -- kafka-topics --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1
+  kubectl -n {{ .Release.Namespace }} exec testclient -- ./bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1
 
 To listen for messages on a topic:
 
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- kafka-console-consumer --bootstrap-server {{ include "kafka.fullname" . }}:9092 --topic test1 --from-beginning
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- ./bin/kafka-console-consumer.sh --bootstrap-server {{ include "kafka.fullname" . }}:9092 --topic test1 --from-beginning
 
 To stop the listener session above press: Ctrl+C
 
 To start an interactive message producer session:
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- kafka-console-producer --broker-list {{ include "kafka.fullname" . }}-headless:9092 --topic test1
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- ./bin/kafka-console-producer.sh --broker-list {{ include "kafka.fullname" . }}-headless:9092 --topic test1
 
 To create a message in the above session, simply type the message and press "enter"
 To end the producer session try: Ctrl+C


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
The existing Kafka chart's NOTES.txt has incorrect instructions. 

Here's a short snippet of the post-install rendered notes
```
$ helm install my-kafka --namespace kafka incubator/kafka
NAME: my-kafka
LAST DEPLOYED: Tue Apr 28 12:18:59 2020
NAMESPACE: kafka
STATUS: deployed
REVISION: 1
NOTES:
### Connecting to Kafka from inside Kubernetes
...

Once you have the testclient pod above running, you can list all kafka
topics with:

  kubectl -n kafka exec testclient -- kafka-topics --zookeeper my-kafka-zookeeper:2181 --list

...
```
I copy/pasted the command provided to list kafka topics and this was the output
```
$ kubectl -n kafka exec testclient -- kafka-topics --zookeeper my-kafka-zookeeper:2181 --list
OCI runtime exec failed: exec failed: container_linux.go:346: starting container process caused "exec: \"kafka-topics\": executable file not found in $PATH": unknown
command terminated with exit code 126
```
Because the Kafka docker image's workdir is /opt/kafka and the binaries are in /opt/kafka/bin, the relative path './bin/' needs to be prepended to the binary calls in the `kubectl exec` commands

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
  - Should the version be incremented for a doc change like this?
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
