### PR TITLE
[stable/instana-agent] Chart version 1.0.28

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: instana-agent
 sources:
 - https://github.com/instana/instana-agent-docker
-version: 1.0.27
+version: 1.0.28

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -8,7 +8,7 @@ This chart adds the Instana Agent to all schedulable nodes in your cluster via a
 
 ## Prerequisites
 
-Kubernetes 1.9.x - 1.16.x
+Kubernetes 1.9.x - 1.18.x
 
 #### Helm 3 prerequisites
 
@@ -113,7 +113,7 @@ The following table lists the configurable parameters of the Instana chart and t
 |------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | `agent.configuration_yaml`         | Custom content for the agent configuration.yaml file                    | `nil` See [below](#agent) for more details                                                                  |
 | `agent.downloadKey`                | Your Instana Download key                                               | `nil` Usually not required                                                                                  |
-| `agent.endpointHost`               | Instana Agent backend endpoint host                                     | `saas-us-west-2.instana.io`                                                                                 |
+| `agent.endpointHost`               | Instana Agent backend endpoint host                                     | `ingress-red-saas.instana.io` (US and ROW). If in Europe, please override with `ingress-blue-saas.instana.io`                   |
 | `agent.endpointPort`               | Instana Agent backend endpoint port                                     | `443`                                                                                                       |
 | `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                                                                                             |
 | `agent.image.tag`                  | The image tag to pull                                                   | `latest`                                                                                                    |

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
 - apiGroups: ["batch"]
   resources:
     - "jobs"
+    - 'cronjobs'
   verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -96,7 +96,7 @@ spec:
               value: {{ .Values.agent.redactKubernetesSecrets | quote }}
             {{- end }}
             - name: JAVA_OPTS
-              # Approximately 1/3 of container memory limits to allow for direct-buffer memory usage and JVM overhead
+              # Approximately 1/3 of container memory requests to allow for direct-buffer memory usage and JVM overhead
               value: "-Xmx{{ div (default 512 .Values.agent.pod.requests.memory) 3 }}M -XX:+ExitOnOutOfMemoryError"
             - name: INSTANA_AGENT_POD_NAME
               valueFrom:

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -18,7 +18,7 @@ agent:
   leaderElectorPort: 42655
 
   # agent.endpointHost is the hostname of the Instana server your agents will connect to.
-  endpointHost: saas-us-west-2.instana.io
+  endpointHost: ingress-red-saas.instana.io # This is for US and ROW. If in Europe, please override with ingress-blue-saas.instana.io.
   # agent.endpointPort is the port number (as a String) of the Instana server your agents will connect to.
   endpointPort: 443
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- Add `cronjobs` ClusterRole permission
- Update default agent endpointHost value to `ingress-red-saas.instana.io` (US & ROW) and include `ingress-blue-saas.instana.io` (Europe) in comments as an option


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
