### PR TITLE
[stable/datadog]: disable trace-agent internal CPU/RAM limits

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.8
+version: 2.0.9
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -20,6 +20,10 @@
       value: "true"
     - name: DD_APM_RECEIVER_PORT
       value: {{ .Values.datadog.apm.port | quote }}
+    - name: DD_APM_MAX_MEMORY
+      value: 0
+    - name: DD_APM_MAX_CPU_PERCENT
+      value: 0
 {{- if .Values.agents.containers.traceAgent.env }}
 {{ toYaml .Values.agents.containers.traceAgent.env | indent 4 }}
 {{- end }}


### PR DESCRIPTION
This change disables the rate limiter's CPU and memory limits. They are
not necessary in containerized environments and were a continuous source
of confusion for customers in situations like: "We have increased the
resource limits for the trace-agent pod, yet things are still not
working".

These "safety" mechanisms should arguably be dropped in modern
architectures.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
