### PR TITLE
[stable/prometheus-blackbox-exporter] Add vars for liveness and readyness

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.0.0
+version: 4.1.0
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -69,6 +69,8 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `allowIcmp`                               | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
 | `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
 | `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
+| `livenessProbe`                           | Container liveness probe                                                         | See values.yaml                                                              |
+| `readinessProbe`                          | Container readiness probe                                                        | See values.yaml                                                              |
 | `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
 | `service.labels`                          | additional labels for the service                                                | None                                                                         |
 | `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |

--- a/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -77,13 +77,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               name: http
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           volumeMounts:
             - mountPath: /config
               name: config

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -82,13 +82,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               name: http
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           volumeMounts:
             - mountPath: /config
               name: config

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -31,6 +31,16 @@ runAsUser: 1000
 readOnlyRootFilesystem: true
 runAsNonRoot: true
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add vars for liveness and readyness and use them

If we set:
```yaml 
extraArgs:
  - "--web.route-prefix=/blackbox
```
Health url move from `/health` to `/blackbox/health`. Liveness and readyness fail because they are set in the code and are not configurable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
