### PR TITLE
[stable/selenium] Add liveness probes and preStop hooks on browsers

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.1.0
+version: 1.1.1
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -91,6 +91,8 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `chrome.imagePullSecrets` | The secret to use for pulling the image. Will override the global parameter if set | `nil` |
 | `chrome.pullPolicy` | The pull policy for the node chrome image | `IfNotPresent` |
 | `chrome.replicas` | The number of selenium node chrome pods. This is ignored if runAsDaemonSet is enabled. | `1` |
+| `chrome.enableLivenessProbe` | When true will add a liveness check to the pod | `false` |
+| `chrome.waitForRunningSessions` | When true will wait for current running sessions to finish before terminating the pod | `false` |
 | `chrome.podAnnotations` | Annotations on the chrome pods | `{}` |
 | `chrome.securityContext` |	SecurityContext on the chrome pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `chrome.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
@@ -119,6 +121,8 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `chromeDebug.imagePullSecrets` | The secret to use for pulling the image. Will override the global parameter if set | `nil` |
 | `chromeDebug.pullPolicy` | The selenium node chrome debug pull policy | `IfNotPresent` |
 | `chromeDebug.replicas` | The number of selenium node chrome debug pods. This is ignored if runAsDaemonSet is enabled. | `1` |
+| `chromeDebug.enableLivenessProbe` | When true will add a liveness check to the pod | `false` |
+| `chromeDebug.waitForRunningSessions` | When true will wait for current running sessions to finish before terminating the pod | `false` |
 | `chromeDebug.podAnnotations` | Annotations on the Chrome debug pod | `{}` |
 | `chromeDebug.securityContext` |	SecurityContext on the Chrome debug pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `chromeDebug.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
@@ -147,6 +151,8 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `firefox.imagePullSecrets` | The secret to use for pulling the image. Will override the global parameter if set | `nil` |
 | `firefox.pullPolicy` | The selenium node firefox pull policy | `IfNotPresent` |
 | `firefox.replicas` | The number of selenium node firefox pods. This is ignored if runAsDaemonSet is enabled. | `1` |
+| `firefox.enableLivenessProbe` | When true will add a liveness check to the pod | `false` |
+| `firefox.waitForRunningSessions` | When true will wait for current running sessions to finish before terminating the pod | `false` |
 | `firefox.podAnnotations` | Annotations on the firefox pods | `{}` |
 | `firefox.securityContext` |	SecurityContext on the firefox pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `firefox.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
@@ -173,6 +179,8 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `firefoxDebug.imagePullSecrets` | The secret to use for pulling the image. Will override the global parameter if set | `nil` |
 | `firefoxDebug.pullPolicy` | The selenium node firefox debug pull policy | `IfNotPresent` |
 | `firefoxDebug.replicas` | The number of selenium node firefox debug pods. This is ignored if runAsDaemonSet is enabled. | `1` |
+| `firefoxDebug.enableLivenessProbe` | When true will add a liveness check to the pod | `false` |
+| `firefoxDebug.waitForRunningSessions` | When true will wait for current running sessions to finish before terminating the pod | `false` |
 | `firefoxDebug.podAnnotations` | Annotations on the firefox debug pods | `{}` |
 | `firefoxDebug.securityContext` |	SecurityContext on the firefox debug pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `firefoxDebug.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |

--- a/stable/selenium/templates/chrome-daemonset.yaml
+++ b/stable/selenium/templates/chrome-daemonset.yaml
@@ -32,6 +32,20 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.chrome.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chrome.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chrome-daemonset.yaml
+++ b/stable/selenium/templates/chrome-daemonset.yaml
@@ -32,6 +32,7 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          {{- if .Values.chrome.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -39,6 +40,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.chrome.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -46,6 +49,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chrome.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -37,6 +37,20 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.chrome.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chrome.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -37,6 +37,7 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          {{- if .Values.chrome.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -44,6 +45,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.chrome.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -51,6 +54,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chrome.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chromeDebug-daemonset.yaml
+++ b/stable/selenium/templates/chromeDebug-daemonset.yaml
@@ -34,6 +34,20 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.chromeDebug.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chromeDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chromeDebug-daemonset.yaml
+++ b/stable/selenium/templates/chromeDebug-daemonset.yaml
@@ -34,6 +34,7 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          {{- if .Values.chromeDebug.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -41,6 +42,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.chromeDebug.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -48,6 +51,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chromeDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -39,6 +39,7 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          {{- if .Values.chromeDebug.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -46,6 +47,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.chromeDebug.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -53,6 +56,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chromeDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -39,6 +39,20 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.chromeDebug.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.chromeDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefox-daemonset.yaml
+++ b/stable/selenium/templates/firefox-daemonset.yaml
@@ -32,6 +32,20 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.firefox.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefox.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefox-daemonset.yaml
+++ b/stable/selenium/templates/firefox-daemonset.yaml
@@ -32,6 +32,7 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          {{- if .Values.firefox.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -39,6 +40,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.firefox.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -46,6 +49,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefox.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -37,6 +37,7 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          {{- if .Values.firefox.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -44,6 +45,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.firefox.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -51,6 +54,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefox.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -37,6 +37,20 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.firefox.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefox.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefoxDebug-daemonset.yaml
+++ b/stable/selenium/templates/firefoxDebug-daemonset.yaml
@@ -35,6 +35,20 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.firefoxDebug.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefoxDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefoxDebug-daemonset.yaml
+++ b/stable/selenium/templates/firefoxDebug-daemonset.yaml
@@ -35,6 +35,7 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          {{- if .Values.firefoxDebug.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -42,6 +43,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.firefoxDebug.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -49,6 +52,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefoxDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -39,6 +39,20 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          livenessProbe:
+            httpGet:
+              path: /wd/hub/status
+              port: {{ default "5555" .Values.firefoxDebug.nodePort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 1
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefoxDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -39,6 +39,7 @@ spec:
             {{- end }}
             - containerPort: 5900
               name: vnc
+          {{- if .Values.firefoxDebug.enableLivenessProbe }}
           livenessProbe:
             httpGet:
               path: /wd/hub/status
@@ -46,6 +47,8 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 1
+          {{- end }}
+          {{- if .Values.firefoxDebug.waitForRunningSessions }}
           lifecycle:
             preStop:
               exec:
@@ -53,6 +56,7 @@ spec:
                 - /bin/bash
                 - -c
                 - "while [ $(wget -q -O - http://localhost:{{ default "5555" .Values.firefoxDebug.nodePort }}/wd/hub/sessions | grep -c capabilities) -gt 0 ]; do sleep 1; done"
+          {{- end }}
           env:
             - name: HUB_PORT_4444_TCP_ADDR
               value: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -173,6 +173,12 @@ chrome:
   ## The number of pods in the deployment. This is ignored if runAsDaemonSet is enabled.
   replicas: 1
 
+  ## When true will add a liveness check to the pod
+  enableLivenessProbe: false
+
+  ## When true will wait for current running sessions to finish before terminating the pod
+  waitForRunningSessions: false
+
   ## Configure annotations on the chrome pods
   podAnnotations: {}
 
@@ -272,6 +278,12 @@ chromeDebug:
   ## The number of pods in the deployment. This is ignored if runAsDaemonSet is enabled.
   replicas: 1
 
+  ## When true will add a liveness check to the pod
+  enableLivenessProbe: false
+
+  ## When true will wait for current running sessions to finish before terminating the pod
+  waitForRunningSessions: false
+
   ## Configure annotations on the chrome debug pods
   podAnnotations: {}
 
@@ -370,6 +382,12 @@ firefox:
   ## The number of pods in the deployment. This is ignored if runAsDaemonSet is enabled.
   replicas: 1
 
+  ## When true will add a liveness check to the pod
+  enableLivenessProbe: false
+
+  ## When true will wait for current running sessions to finish before terminating the pod
+  waitForRunningSessions: false
+
   ## Configure annotations on the firefox pods
   podAnnotations: {}
 
@@ -454,6 +472,12 @@ firefoxDebug:
 
   ## The number of pods in the deployment. This is ignored if runAsDaemonSet is enabled.
   replicas: 1
+
+  ## When true will add a liveness check to the pod
+  enableLivenessProbe: false
+
+  ## When true will wait for current running sessions to finish before terminating the pod
+  waitForRunningSessions: false
 
   ## Configure annotations on the firefox debug pods
   podAnnotations: {}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds the following functionality:
- liveness probes on the Chrome and Firefox nodes (including debug versions)
- preStop lifecycle hook to ensure running sessions are not interrupted when the container is being terminated

Reasoning behind this: we have been running the official hub and node images for a long time (over 2 years now) and in our specific use case, the nodes are long-running (currently I have node pods running for 205 days). What we've seen in the past is eventually the node becomes unresponsive and needs to be restarted. The liveness probe ensures this happens automatically, and the preStop lifecycle hook ensures any running sessions are not abruptly interrupted when the container is restarted.

The proposed changes in this PR have been in use as-is in our custom helm chart that leverages the official images for over 2 years.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
