### PR TITLE
[stable/airflow] partially revert #22162

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.8.0
+version: 6.8.1
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/configmap-git-clone.yaml
+++ b/stable/airflow/templates/configmap-git-clone.yaml
@@ -14,13 +14,16 @@ data:
     REF=$2
     DIR=$3
     REPO_HOST=$4
-    PRIVATE_KEY=$5
-    {{- if .Values.dags.git.secret }}
+    REPO_PORT=$5
+    PRIVATE_KEY=$6
     mkdir -p ~/.ssh/
+    {{- if .Values.dags.git.sshKeyscan }}
+    ssh-keyscan -p $REPO_PORT $REPO_HOST >> ~/.ssh/known_hosts
+    {{- end }}
+    {{- if .Values.dags.git.secret }}
     cp -rL /keys/* ~/.ssh/
     chmod 600 ~/.ssh/*
-    ssh-keyscan -H $REPO_HOST >> ~/.ssh/known_hosts
-    echo -e "HOST $REPO_HOST\n  IdentityFile ~/.ssh/$PRIVATE_KEY" > ~/.ssh/config
+    echo -e "Host $REPO_HOST\n  Port $REPO_PORT\n  IdentityFile ~/.ssh/$PRIVATE_KEY" > ~/.ssh/config
     {{- end }}
     # Init Containers will re-run on Pod restart. Remove the directory's contents
     # and reprovision when this happens.
@@ -34,14 +37,17 @@ data:
     REF=$2
     DIR=$3
     REPO_HOST=$4
-    PRIVATE_KEY=$5
-    SYNC_TIME=$6
-    {{- if .Values.dags.git.secret }}
+    REPO_PORT=$5
+    PRIVATE_KEY=$6
+    SYNC_TIME=$7
     mkdir -p ~/.ssh/
+    {{- if .Values.dags.git.sshKeyscan }}
+    ssh-keyscan -p $REPO_PORT $REPO_HOST >> ~/.ssh/known_hosts
+    {{- end }}
+    {{- if .Values.dags.git.secret }}
     cp -rL /keys/* ~/.ssh/
     chmod 600 ~/.ssh/*
-    ssh-keyscan -H $REPO_HOST >> ~/.ssh/known_hosts
-    echo -e "HOST $REPO_HOST\n  IdentityFile ~/.ssh/$PRIVATE_KEY" > ~/.ssh/config
+    echo -e "Host $REPO_HOST\n  Port $REPO_PORT\n  IdentityFile ~/.ssh/$PRIVATE_KEY" > ~/.ssh/config
     {{- end }}
     {{- if eq .Values.dags.initContainer.enabled  false }}
     if [ -d "$DIR" ]; then

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -113,6 +113,7 @@ spec:
             - "{{ .Values.dags.git.ref }}"
             - "{{ .Values.dags.initContainer.mountPath }}{{ .Values.dags.initContainer.syncSubPath | default "" }}"
             - "{{ .Values.dags.git.repoHost}}"
+            - "{{ .Values.dags.git.repoPort}}"
             - "{{ .Values.dags.git.privateKeyName }}"
           volumeMounts:
             - name: git-clone
@@ -148,6 +149,7 @@ spec:
             - "{{ .Values.dags.git.ref }}"
             - "{{ .Values.dags.initContainer.mountPath }}"
             - "{{ .Values.dags.git.repoHost}}"
+            - "{{ .Values.dags.git.repoPort}}"
             - "{{ .Values.dags.git.privateKeyName }}"
             - "{{ .Values.dags.git.gitSync.refreshTime }}"
           volumeMounts:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -91,6 +91,7 @@ spec:
             - "{{ .Values.dags.git.ref }}"
             - "{{ .Values.dags.initContainer.mountPath }}{{ .Values.dags.initContainer.syncSubPath | default "" }}"
             - "{{ .Values.dags.git.repoHost}}"
+            - "{{ .Values.dags.git.repoPort}}"
             - "{{ .Values.dags.git.privateKeyName }}"
           volumeMounts:
             - name: git-clone
@@ -119,6 +120,7 @@ spec:
             - "{{ .Values.dags.git.ref }}"
             - "{{ .Values.dags.initContainer.mountPath }}{{ .Values.dags.initContainer.syncSubPath | default "" }}"
             - "{{ .Values.dags.git.repoHost}}"
+            - "{{ .Values.dags.git.repoPort}}"
             - "{{ .Values.dags.git.privateKeyName }}"
             - "{{ .Values.dags.git.gitSync.refreshTime }}"
           volumeMounts:

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -93,6 +93,7 @@ spec:
           - "{{ .Values.dags.git.ref }}"
           - "{{ .Values.dags.initContainer.mountPath }}{{ .Values.dags.initContainer.syncSubPath | default "" }}"
           - "{{ .Values.dags.git.repoHost}}"
+          - "{{ .Values.dags.git.repoPort}}"
           - "{{ .Values.dags.git.privateKeyName }}"
           volumeMounts:
           - name: git-clone
@@ -121,6 +122,7 @@ spec:
             - "{{ .Values.dags.git.ref }}"
             - "{{ .Values.dags.initContainer.mountPath }}{{ .Values.dags.initContainer.syncSubPath | default "" }}"
             - "{{ .Values.dags.git.repoHost}}"
+            - "{{ .Values.dags.git.repoPort}}"
             - "{{ .Values.dags.git.privateKeyName }}"
             - "{{ .Values.dags.git.gitSync.refreshTime }}"
           volumeMounts:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -571,12 +571,20 @@ dags:
     ##
     ## branch name, tag or sha1 to reset to
     ref: master
-    ## pre-created secret with key, key.pub and known_hosts file for private repos
+    ## The name of a pre-created secret containing files for ~/.ssh/ (only needed for PRIVATE ssh repos)
+    ## Note commonly includes id_rsa, id_rsa.pub and known_hosts files
+    ## Note known_hosts is not needed if git.sshKeyscan is true
     secret: ""
-    ## The host of the repo so for example if a github repo put github.com (Only need if using ssh not https git sync)
+    ## Implicitly trust [git.repoHost]:git.repoPort, by auto populating ~/.ssh/known_hosts (only needed for ssh repos)
+    ## Note this is not needed if known_hosts is provided in git.secret
+    ## Note git.repoHost and git.repoPort are required for this to work
+    sshKeyscan: false
+    ## The host of the repo so for example if a github repo put github.com (only needed for ssh repos)
     repoHost: ""
-    ## The name of the private key in your git sync secret (Only need if using ssh not https git sync)
-    privateKeyName: ""
+    ## The port of the repo (only needed for ssh repos)
+    repoPort: 22
+    ## The name of the private key file in your git.secret (only needed for ssh repos)
+    privateKeyName: id_rsa
     gitSync:
       ## Turns on the side car container
       enabled: false
@@ -585,12 +593,12 @@ dags:
         ## docker-airflow image
         repository: alpine/git
         ## image tag
-        tag: 1.0.7
+        tag: 1.0.12
         ## Image pull policy
         ## values: Always or IfNotPresent
         pullPolicy: IfNotPresent
       ## The amount of time in seconds to git pull dags
-      refreshTime: 0
+      refreshTime: 60
       ## If using workers.autoscaling=true with git-sync, git-sync needs to have resources requested
       resources: {}
   initContainer:
@@ -601,7 +609,7 @@ dags:
       ## docker-airflow image
       repository: alpine/git
       ## image tag
-      tag: 1.0.7
+      tag: 1.0.12
       ## Image pull policy
       ## values: Always or IfNotPresent
       pullPolicy: IfNotPresent


### PR DESCRIPTION
Changes:
* There was a security issue introduced in #22162 which caused the remote git ssh host to be implicitly trusted by default.
* In addition to the security issue, #22162 broke any user with a non-standard ssh repo port.
* This commit keeps the implicit trust if the user specifies git.sshKeyscan=true (with a default of false), in addition to generally cleaning up this part of the codebase.