### PR TITLE
[stable/superset] fix init startup script for superset entrypoint. 

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.10
-appVersion: "0.35.2"
+version: 1.1.11
+appVersion: "0.36.0"
 keywords:
 - bi
 home: https://github.com/apache/incubator-superset

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -15,6 +15,8 @@ initFile: |-
     /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
     superset run
   elif [ "$1" == "production-mode" ]; then
+    superset db upgrade
+    superset init
     gunicorn \
         -w 10 \
         -k gevent \

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -17,10 +17,14 @@ initFile: |-
     /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
     superset run
   elif [ "$1" == "production-mode" ]; then
-    gunicorn -b 0.0.0.0:8088 \
-      --limit-request-line 0 \
-      --limit-request-field_size 0 \
-      --timeout 300 superset:app
+    gunicorn \
+        -w 10 \
+        -k gevent \
+        --timeout 300 \
+        -b  0.0.0.0:8088 \
+        --limit-request-line 0 \
+        --limit-request-field_size 0 \
+        "superset.app:create_app()"
   else
     echo "You need to specify which mode to start in by setting production-mode"
     echo "or development-mode in extraArguments."

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -1,14 +1,12 @@
 # Default values for superset.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-
 replicaCount: 1
 
 ## Set default image, imageTag, and imagePullPolicy.
 image:
   repository: "amancevice/superset"
-  tag: "0.35.2"
+  tag: "0.36.0"
   pullPolicy: "IfNotPresent"
   pullSecrets: []
 


### PR DESCRIPTION
Is this a new chart?
No

What this PR does / why we need it:
Adds the following functionality:

updates Superset init script which has been changed from superset version 0.36.0 and also standard suggested from superset documentation. 
https://superset.apache.org/installation.html#a-proper-wsgi-http-server

Which issue this PR fixes
None
