### PR TITLE
[stable/spring-cloud-data-flow] Use release namespace for prometheus-proxy serviceaccount

### DIFF
--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 2.6.0
+version: 2.6.1
 appVersion: 2.4.0.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/stable/spring-cloud-data-flow/templates/prometheus-proxy-clusterrolebinding.yaml
+++ b/stable/spring-cloud-data-flow/templates/prometheus-proxy-clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-prometheus-proxy
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/stable/spring-cloud-data-flow/templates/prometheus-proxy-serviceaccount.yaml
+++ b/stable/spring-cloud-data-flow/templates/prometheus-proxy-serviceaccount.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ .Release.Name }}-prometheus-proxy
   labels:
     app: {{ .Release.Name }}-prometheus-proxy
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Users should be able to install the chart release into a specific namespace so we should use the release namespace when creating serviceaccount for prometheus-proxy

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Thomas Risberg <trisberg@pivotal.io>
