### PR TITLE
[stable/nextcloud] support statically assigning nodePort

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.9.3
+version: 1.9.4
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -121,6 +121,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.affinity`                                           | Cronjob affinity                                        | `nil`                                                   |
 | `service.type`                                               | Kubernetes Service type                                 | `ClusterIp`                                             |
 | `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer            | `nil`                                                   |
+| `service.nodePort`                                           | NodePort for service type NodePort                      | `nil`                                                   |
 | `persistence.enabled`                                        | Enable persistence using PVC                            | `false`                                                 |
 | `persistence.annotations`                                    | PVC annotations                                         | `{}`                                                    |
 | `persistence.storageClass`                                   | PVC Storage Class for nextcloud volume                  | `nil` (uses alpha storage class annotation)             |

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 7.1.0
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 10.0.1
+digest: sha256:88489b3a1a5bf1cd3f9e264e540f8c3515d40020bb1073f3bb281f0da56efc3f
+generated: "2019-11-28T12:08:10.111637339+01:00"

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.1.0
-- name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 10.0.1
-digest: sha256:88489b3a1a5bf1cd3f9e264e540f8c3515d40020bb1073f3bb281f0da56efc3f
-generated: "2019-11-28T12:08:10.111637339+01:00"

--- a/stable/nextcloud/templates/service.yaml
+++ b/stable/nextcloud/templates/service.yaml
@@ -17,5 +17,8 @@ spec:
     targetPort: http
     protocol: TCP
     name: http
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ default "" .Values.service.nodePort}}
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "nextcloud.name" . }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -258,6 +258,7 @@ service:
   type: ClusterIP
   port: 8080
   loadBalancerIP: nil
+  nodePort: nil
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
### What this PR does / why we need it:
The nodePort can not be statically assigned in the current chart. This makes nextcloud hard to integrate with external load balancers.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
