### PR TITLE
[stable/oauth2-proxy] Support advanced secret config in oauth2-proxy

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.0.0
+version: 3.1.0
 apiVersion: v1
 appVersion: 5.1.0
 home: https://pusher.github.io/oauth2_proxy/

--- a/stable/oauth2-proxy/templates/_helpers.tpl
+++ b/stable/oauth2-proxy/templates/_helpers.tpl
@@ -52,3 +52,55 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Secret name to use for clientID
+*/}}
+{{- define "oauth2-proxy.clientIDSecretName" -}}
+{{- if .Values.config.secretConfig.clientID.secretName -}}
+{{- printf "%s" .Values.config.secretConfig.clientID.secretName -}}
+{{- else -}}
+{{- printf "%s" (include "oauth2-proxy.fullname" . ) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name to use for clientSecret
+*/}}
+{{- define "oauth2-proxy.clientSecretSecretName" -}}
+{{- if .Values.config.secretConfig.clientSecret.secretName -}}
+{{- printf "%s" .Values.config.secretConfig.clientSecret.secretName -}}
+{{- else -}}
+{{- printf "%s" (include "oauth2-proxy.fullname" . ) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret name to use for clientID
+*/}}
+{{- define "oauth2-proxy.cookieSecretSecretName" -}}
+{{- if .Values.config.secretConfig.cookieSecret.secretName -}}
+{{- printf "%s" .Values.config.secretConfig.cookieSecret.secretName -}}
+{{- else -}}
+{{- printf "%s" (include "oauth2-proxy.fullname" . ) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Check to see if any entries in secret.
+Expects an array with:
+index 0 as the secret name
+index 1 as .
+*/}}
+{{- define "oauth2-proxy.entriesInSecret" -}}
+{{- $name := (index . 0) }}
+{{- with (index . 1) }}
+{{- if and .Values.config.secretConfig.cookieSecret.write (eq $name (include "oauth2-proxy.cookieSecretSecretName" .)) }}
+t
+{{- else if and .Values.config.secretConfig.clientSecret.write (eq $name (include "oauth2-proxy.clientSecretSecretName" .)) }}
+t
+{{- else if and .Values.config.secretConfig.clientID.write (eq $name (include "oauth2-proxy.clientIDSecretName" .)) }}
+t
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -74,18 +74,18 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.secretName" . }}
-              key: client-id
+              name:  {{ template "oauth2-proxy.clientIDSecretName" . }}
+              key: {{ .Values.config.secretConfig.clientID.keyName }}
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.secretName" . }}
-              key: client-secret
+              name:  {{ template "oauth2-proxy.clientSecretSecretName" . }}
+              key: {{ .Values.config.secretConfig.clientSecret.keyName }}
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.secretName" . }}
-              key: cookie-secret
+              name:  {{ template "oauth2-proxy.cookieSecretSecretName" . }}
+              key: {{ .Values.config.secretConfig.cookieSecret.keyName }}
         {{- end }}
         {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,4 +1,10 @@
 {{- if and (not .Values.config.existingSecret) (.Values.proxyVarsAsSecrets) }}
+{{- if or .Values.config.secretConfig.clientID.write .Values.config.secretConfig.clientSecret.write .Values.config.secretConfig.cookieSecret.write }}
+{{- $global := . }}
+{{- range $name := list (include "oauth2-proxy.clientIDSecretName" .) (include "oauth2-proxy.clientSecretSecretName" .) (include "oauth2-proxy.cookieSecretSecretName" .) "" | uniq }}
+---
+{{- with $global }}
+{{- if ne (include "oauth2-proxy.entriesInSecret" (list $name .)) "" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,10 +13,20 @@ metadata:
     chart: {{ template "oauth2-proxy.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "oauth2-proxy.fullname" . }}
+  name: {{ $name }}
 type: Opaque
 data:
-  cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
-  client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
-  client-id: {{ .Values.config.clientID | b64enc | quote }}
+{{- if and .Values.config.secretConfig.cookieSecret.write (eq $name (include "oauth2-proxy.cookieSecretSecretName" .)) }}
+  {{ .Values.config.secretConfig.cookieSecret.keyName }}: {{ .Values.config.cookieSecret | b64enc | quote }}
+{{- end -}}
+{{- if and .Values.config.secretConfig.clientSecret.write (eq $name (include "oauth2-proxy.clientSecretSecretName" .)) }}
+  {{ .Values.config.secretConfig.clientSecret.keyName }}: {{ .Values.config.clientSecret | b64enc | quote }}
+{{- end -}}
+{{- if and .Values.config.secretConfig.clientID.write (eq $name (include "oauth2-proxy.clientIDSecretName" .)) }}
+  {{ .Values.config.secretConfig.clientID.keyName }}: {{ .Values.config.clientID | b64enc | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -10,6 +10,55 @@ config:
   # Example:
   # existingSecret: secret
   cookieSecret: "XXXXXXXXXX"
+  secretConfig:
+    # If existingSecret is set, all three values are expected to be in
+    # the specified existingSecret. .secretConfig.clientID.keyName,
+    # .secretConfig.clientSecret.keyName and .secretConfig.cookieSecret.keyName will
+    # be respected. All other values in secretConfig are ignored.
+    #
+    # If existingSecret not set:
+    # If .secretConfig.clientID.write == true, clientID will be written to secret
+    # .secretConfig.clientID.secretName in the key .secretConfig.clientID.keyName.
+    # If .secretConfig.clientSecret.write == true, clientSecret will be written to secret
+    # .secretConfig.clientSecret.secretName in the key .secretConfig.clientSecret.keyName.
+    # If .secretConfig.cookieSecret.write == true, cookieSecret will be written to secret
+    # .secretConfig.cookieSecret.secretName in the key .secretConfig.cookieSecret.keyName.
+    # Then no matter what the state of the write values:
+    # * clientID will be read out of the secret named .secretConfig.clientID.secretName
+    #   from the value associated with .secretConfig.clientID.keyName
+    # * clientSecret will be read out of the secret named .secretConfig.clientSecret.secretName
+    #   from the value associated with .secretConfig.clientSecret.keyName
+    # * cookieSecret will be read out of the secret named .secretConfig.cookieSecret.secretName
+    #   from the value associated with .secretConfig.clientSecret.keyName
+    #
+    # This can be used for example with the keycloak-operator to automatically read clientID
+    # and clientSecret from the secret managed by a kind=KeycloakClient object like so:
+    # cookieSecret: <changeme>
+    # secretConfig:
+    #   clientID:
+    #     secretName: keycloak-client-secret-<clientid>
+    #     keyName: CLIENT_ID
+    #     write: false
+    #   clientSecret:
+    #     secretName: keycloak-client-secret-<clientid>
+    #     keyName: CLIENT_SECRET
+    #     write: false
+    clientID:
+      # If not set, the chart will manage the secret name
+      # secretName: ""
+      keyName: client-id
+      write: true
+    clientSecret:
+      # If not set, the chart will manage the secret name
+      # secretName: ""
+      keyName: client-secret
+      write: true
+    cookieSecret:
+      # If not set, the chart will manage the secret name
+      # secretName: ""
+      keyName: cookie-secret
+      write: true
+
   google: {}
     # adminEmail: xxxx
     # serviceAccountJson: xxxx


### PR DESCRIPTION
This change allows clientID, clientSecret and cookieSecret to all
be managed independently. This enables easy integration with other
services such as keycloak-operator.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)