### PR TITLE
[stable/prometheus-operator] Add thanos sidecar grpc port setting in the prometheus CR service

### DIFF
--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -40,12 +40,12 @@ spec:
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
 
-{{- if .Values.prometheus.prometheusSpec.thanos }}
+  {{- if .Values.prometheus.prometheusSpec.thanos }}
   - name: grpc
     port: 10901
     protocol: TCP
     targetPort: 10901
-{{- end }}
+  {{- end }}
 
 {{- if .Values.prometheus.service.additionalPorts }}
 {{ toYaml .Values.prometheus.service.additionalPorts | indent 2 }}

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -39,6 +39,14 @@ spec:
     {{- end }}
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
+
+{{- if .Values.prometheus.prometheusSpec.thanos }}
+  - name: grpc
+    port: 10901
+    protocol: TCP
+    targetPort: 10901
+{{- end }}
+
 {{- if .Values.prometheus.service.additionalPorts }}
 {{ toYaml .Values.prometheus.service.additionalPorts | indent 2 }}
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus/serviceperreplica.yaml
+++ b/stable/prometheus-operator/templates/prometheus/serviceperreplica.yaml
@@ -37,6 +37,13 @@ items:
           {{- end }}
           port: {{ $serviceValues.port }}
           targetPort: {{ $serviceValues.targetPort }}
+        {{- if .Values.prometheus.prometheusSpec.thanos }}
+        - name: grpc
+          port: 10901
+          protocol: TCP
+          targetPort: 10901
+        {{- end }}
+
       selector:
         app: prometheus
         prometheus: {{ include "prometheus-operator.fullname" $ }}-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:
To enable thanos sidecar today the user should set `prometheus.prometheusSpec.thanos` and this will inject automatically into the prometheus pod the thanos side case as follow:
```

  - args:
    - sidecar
    - --prometheus.url=http://127.0.0.1:9090/
    - --tsdb.path=/prometheus
    - --grpc-address=[$(POD_IP)]:10901
    - --http-address=[$(POD_IP)]:10902
    - --log.level=debug
    - --log.format=logfmt
    env:
    - name: POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
    image: thanosio/thanos:v0.12.0
    imagePullPolicy: IfNotPresent
    name: thanos-sidecar
    ports:
    - containerPort: 10902
      name: http
      protocol: TCP
    - containerPort: 10901
      name: grpc
      protocol: TCP
```

BUT for enabling Thanos Querier the user must set the grpc port in the prometheus service. And for some reason its not happening as part of this helm chart like it should be. Without setting this port in the prometheus `service` the Thanos Querier will never be able to connect to the thanos sidecar.

#### Special notes for your reviewer:
@vsliouniaev ,  @bismarck , @gianrubio 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
