### PR TITLE
[stable/mongodb-replicaset] Update MongoDB Exporter

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.15.0
+version: 3.15.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -79,8 +79,6 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `metrics.securityContext.enabled`   | Enable security context                                                   | `true`                                              |
 | `metrics.securityContext.fsGroup`   | Group ID for the metrics container                                        | `1001`                                              |
 | `metrics.securityContext.runAsUser` | User ID for the metrics container                                         | `1001`                                              |
-| `metrics.socketTimeout`             | Time to wait for a non-responding socket                                  | `3s`                                                |
-| `metrics.syncTimeout`               | Time an operation with this session will wait before returning an error   | `1m`                                                |
 | `metrics.prometheusServiceDiscovery`| Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |
 | `auth.enabled`                      | If `true`, keyfile access control is enabled                              | `false`                                             |
 | `auth.key`                          | Key for internal authentication                                           | ``                                                  |

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -251,8 +251,6 @@ spec:
             - >-
               /bin/mongodb_exporter
               --mongodb.uri {{ template "mongodb-replicaset.connection-string" . }}
-              --mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
-              --mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
               --web.telemetry-path={{ .Values.metrics.path }}
               --web.listen-address=:{{ .Values.metrics.port }}
           volumeMounts:

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -67,12 +67,10 @@ metrics:
   enabled: false
   image:
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r71
+    tag: 0.11.0
     pullPolicy: IfNotPresent
   port: 9216
   path: "/metrics"
-  socketTimeout: 3s
-  syncTimeout: 1m
   prometheusServiceDiscovery: true
   resources: {}
   securityContext:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the MongoDB exporter to version [0.11.0](https://github.com/percona/mongodb_exporter/releases/tag/v0.11.0). Remove the the values for the `--mongodb.socket-timeout` and `--mongodb.sync-timeout` flag.

Another option would be to add the socket and connection timeout to the [connection string](https://docs.mongodb.com/manual/reference/connection-string/#timeout-options) and change the value names to sth. like `metrics.connectTimeoutMS` and `metrics.socketTimeoutMS`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
