### PR TITLE
[stable/airflow] allow specification of probe scheme

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.8.1
+version: 6.9.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -469,11 +469,13 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `web.annotations`                        | annotations for the web deployment                      | `{}`                      |
 | `web.podAnnotations`                     | pod-annotations for the web deployment                  | `{}`                      |
 | `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
-| `web.minReadySeconds`                    | minReadySeconds in the web deployment                   | `120`
+| `web.minReadySeconds`                    | minReadySeconds in the web deployment                   | `120` |
+| `web.livenessProbe.scheme`               | scheme to use for connecting to the host (HTTP or HTTPS) | `HTTP` |
 | `web.livenessProbe.periodSeconds`        | interval between probes                         | `60`  |
 | `web.livenessProbe.timeoutSeconds`       | time allowed for a result to return             | `1`  |
 | `web.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful             | `1`  |
 | `web.livenessProbe.failureThreshold`     | Minimum consecutive successes for the probe to be considered failed                 | `5`  |
+| `web.readinessProbe.scheme`              | scheme to use for connecting to the host (HTTP or HTTPS) | `HTTP` |
 | `web.readinessProbe.periodSeconds`       | interval between probes                         | `60`  |
 | `web.readinessProbe.timeoutSeconds`      | time allowed for a result to return             | `1`  |
 | `web.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful             | `1`  |

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -206,6 +206,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
+              scheme: {{ .Values.web.livenessProbe.scheme }}
               {{- if .Values.ingress.web.livenessPath }}
               path: "{{ .Values.ingress.web.livenessPath }}"
               {{- else }}
@@ -221,6 +222,7 @@ spec:
 
           readinessProbe:
             httpGet:
+              scheme: {{ .Values.web.readinessProbe.scheme }}
               path: "{{ .Values.ingress.web.path }}/health"
               port: web
             initialDelaySeconds: {{ .Values.web.initialDelaySeconds }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -284,11 +284,13 @@ web:
   initialDelaySeconds: "360"
   minReadySeconds: 120
   readinessProbe:
+    scheme: HTTP
     periodSeconds: 60
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 5
   livenessProbe:
+    scheme: HTTP
     periodSeconds: 60
     timeoutSeconds: 1
     successThreshold: 1


### PR DESCRIPTION
This PR introduces the ability to specify the probe scheme for `livenessProbe` and `readinessProbe`, this is needed to allow users to enable SSL on the Airflow webserver.

It introduces the following values:
* `web.livenessProbe.scheme`
* `web.readinessProbe.scheme`