### PR TITLE
[stable/datadog] Remove old and misleading KSM option from value file

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.2.10
+
+* Remove `kubeStateMetrics` section from `values.yaml` as not used anymore
+
 ## 2.2.9
 
 * Fixing variables description in README and Migration documentation (#22031)

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.2.9
+version: 2.2.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -535,13 +535,6 @@ clusterAgent:
   #
   createPodDisruptionBudget: false
 
-kubeStateMetrics:
-  ## @param enabled - boolean - required
-  ## If true, deploys the kube-state-metrics deployment.
-  ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
-  #
-  enabled: true
-
 agents:
   ## @param enabled - boolean - required
   ## You should keep Datadog DaemonSet enabled!


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove unused `kubeStateMetrics` section from `values.yaml` as not used anymore and could be misleading for users.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
