### PR TITLE
[stable/oauth2-proxy] Add ingress extraPaths support

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.1.0
+version: 3.2.0
 apiVersion: v1
 appVersion: 5.1.0
 home: https://pusher.github.io/oauth2_proxy/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -84,6 +84,7 @@ Parameter | Description | Default
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | Enable Ingress | `false`
 `ingress.path` | Ingress accepted path | `/`
+`ingress.extraPaths` | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`
 `ingress.annotations` | Ingress annotations | `nil`
 `ingress.hosts` | Ingress accepted hostnames | `nil`
 `ingress.tls` | Ingress TLS configuration | `nil`

--- a/stable/oauth2-proxy/ci/ingress-extra-paths-values.yaml
+++ b/stable/oauth2-proxy/ci/ingress-extra-paths-values.yaml
@@ -1,0 +1,6 @@
+ingress:
+  extraPaths:
+  - path: /*
+    backend:
+      serviceName: ssl-redirect
+      servicePort: use-annotation

--- a/stable/oauth2-proxy/templates/ingress.yaml
+++ b/stable/oauth2-proxy/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "oauth2-proxy.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,6 +22,9 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+{{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $serviceName }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -85,6 +85,12 @@ ingress:
   # Used to create an Ingress record.
   # hosts:
     # - chart-example.local
+  # Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  # extraPaths:
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
   # annotations:
   #   kubernetes.io/ingress.class: nginx
   #   kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for adding extra paths to the ingress in oauth2-proxy. This is needed for cases like ALB Ingress controller, which needs special paths for redirecting HTTP to HTTPS. See #16628 for an example of this kind of addition in the stable/grafana chart.

#### Which issue this PR fixes
  - fixes #21484 (which was prematurely closed)

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
