### PR TITLE
[stable/prometheus-operator]Fix range loop for ingresses

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.4
+version: 8.13.5
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.5
+version: 8.13.7
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/ingressperreplica.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingressperreplica.yaml
@@ -10,7 +10,7 @@ metadata:
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
-    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
     apiVersion: networking.k8s.io/v1beta1
     {{ else }}
     apiVersion: extensions/v1beta1

--- a/stable/prometheus-operator/templates/prometheus/ingressperreplica.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingressperreplica.yaml
@@ -10,7 +10,7 @@ metadata:
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
-    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
     apiVersion: networking.k8s.io/v1beta1
     {{ else }}
     apiVersion: extensions/v1beta1


### PR DESCRIPTION
#### What this PR does / why we need it:

Creation of ingress per replica is broken for both alertmanager and prometheus

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
