### PR TITLE
[stable/openldap] Prevent "field is immutable" error on Helm 3 upgrade

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 1.2.3
+version: 1.2.4
 appVersion: 2.4.48
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -34,6 +34,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | `podAnnotations`                   | Annotations to add to the pod                                                                                                             | `{}`                |
 | `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                | `""`                |
 | `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
+| `service.omitClusterIP`            | Should the `clusterIP` key/value be left out of the service resource?                                                                     | `true`                |
 | `service.clusterIP`                | IP address to assign to the service                                                                                                       | `""`                |
 | `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
 | `service.ldapPort`                 | External service port for LDAP                                                                                                            | `389`               |

--- a/stable/openldap/templates/service.yaml
+++ b/stable/openldap/templates/service.yaml
@@ -15,7 +15,11 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
+{{- if not .Values.service.omitClusterIP }}
+  {{- with .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- end }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -38,6 +38,7 @@ extraLabels: {}
 podAnnotations: {}
 service:
   annotations: {}
+  omitClusterIP: false
   clusterIP: ""
 
   ldapPort: 389


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:

When attempting to upgrade openldap resources with Helm client v3,
OpenLDAP resources fail to upgrade after initial installation because
we DON'T supply a static cluster IP for these resources.

As described in the referenced discussion below, when a cluster ip
isn't supplied for this chart, the Helm 3 client sees the "live" state
of the resource as having the cluster assigned IP address, but our
requested state is to unset that IP address - IE the cluster IP value
is "".

- https://github.com/helm/helm/issues/6378#issuecomment-557746499

As a fix-forward, this change aims to prevent this from happening by
ommitting the cluster ip value from the template altogether if no
value, or an empty value is supplied.

Additionally, it supplies an avenue for backward compatibility. For
existing Helm 2 deployments of this service, one might want to ensure
that they continue to apply an empty clusterIP value. In this case one
would set:

```
service:
  omitClusterIP: false
  clusterIP: ""
```

to force the empty-string value into the rendered service resource
definition - with the aim that this `omitClusterIP` flag eventually be
removed in future releases of this chart.

#### Which issue this PR fixes

  - fixes https://github.com/helm/helm/issues/6378

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
