### PR TITLE
stable/superset add ingress.labels to values

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.10
+version: 1.1.11
 appVersion: "0.35.2"
 keywords:
 - bi

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -67,6 +67,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `readinessProbe`           | Parameter for readiness probe                   | See [values.yaml](./values.yaml)                             |
 | `ingress.enabled`          | Create an ingress resource when true            | `false`                                                      |
 | `ingress.annotations`      | ingress annotations                             | `{}`                                                         |
+| `ingress.labels`           | ingress labels                                  | `{}`                                                         |
 | `ingress.hosts`            | ingress hosts                                   | `[superset.domain.com]`                                      |
 | `ingress.path`             | ingress path                                    | `\`                                                          |
 | `ingress.tls`              | ingress tls                                     | `[]`                                                         |

--- a/stable/superset/templates/ingress.yaml
+++ b/stable/superset/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ include "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.ingress.labels }}
+    {{- . | toYaml | nindent 4}}
+  {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- . | toYaml | nindent 4 }}

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -143,6 +143,9 @@ ingress:
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: 'true'
 
+  ## superset Ingress labels
+  labels: {}
+
   ## superset Ingress hostnames
   ## Must be provided if Ingress is enabled
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds `ingress.labels` to the `values.yaml`, so that it's possible to add custom labels to the deployment.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
