### PR TITLE
[stable/grafana] Add extraContainerVolumes

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.23
+version: 5.0.24
 appVersion: 6.7.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -80,6 +80,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `affinity`                                | Affinity settings for pod assignment          | `{}`                                                    |
 | `extraInitContainers`                     | Init containers to add to the grafana pod     | `{}`                                                    |
 | `extraContainers`                         | Sidecar containers to add to the grafana pod  | `{}`                                                    |
+| `extraContainerVolumes`                   | Volumes that can be mounted in sidecar containers | `[]`                                                |
 | `schedulerName`                           | Name of the k8s scheduler (other than default) | `nil`                                                  |
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
 | `persistence.type`                        | Type of persistence (`pvc` or `statefulset`)  | `pvc`                                                   |

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -366,4 +366,7 @@ volumes:
   - name: {{ .name }}
     emptyDir: {}
 {{- end -}}
+{{- if .Values.extraInitContainerVolumes }}
+{{ toYaml .Values.extraInitContainerVolumes | indent 2 }}
+{{- end }}
 {{- end }}

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -366,7 +366,7 @@ volumes:
   - name: {{ .name }}
     emptyDir: {}
 {{- end -}}
-{{- if .Values.extraInitContainerVolumes }}
-{{ toYaml .Values.extraInitContainerVolumes | indent 2 }}
+{{- if .Values.extraContainerVolumes }}
+{{ toYaml .Values.extraContainerVolumes | indent 2 }}
 {{- end }}
 {{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -191,6 +191,14 @@ extraContainers: |
 #     - name: proxy-web
 #       containerPort: 4181
 
+## Volumes that can be used in init containers that will not be mounted to deployment pods
+extraContainerVolumes: []
+#  - name: volume-from-secret
+#    secret:
+#      secretName: secret-to-mount
+#  - name: empty-dir-volume
+#    emptyDir: {}
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR adds a new `extraContainerVolumes` variable to define arbitrary volumes in the pod spec. 

The current options for adding additional volumes (`extraVolumeMounts` and `extraSecretMounts`) do not allow you to define volumes for a sidecar container without them being automatically mounted in the main grafana container. This is not always desirable as the volumes for the sidecar may contain secrets that should not be exposed to grafana.

Example use case with the Google Cloud SQL Proxy:
```
...
extraContainers: |
  - name: cloudsql-proxy
    image: gcr.io/cloudsql-docker/gce-proxy:1.16
    command: ["/cloud_sql_proxy",
              "-instances=<instance_name>=tcp:5432",
              "-credential_file=/secrets/cloudsql/credentials.json"]
    securityContext:
      runAsUser: 2  # non-root user
      allowPrivilegeEscalation: false
    volumeMounts:
      - name: cloudsql-instance-credentials
        mountPath: /secrets/cloudsql
        readOnly: true

## Volumes that can be used in extra containers that will not be mounted to grafana deployment pods
extraContainerVolumes:
  - name: cloudsql-instance-credentials
    secret:
      secretName: cloudsql-instance-credentials
...
```

#### Which issue this PR fixes
N\A

#### Special notes for your reviewer:
N\A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
