### PR TITLE
[stable/prometheus-cloudwatch-exporter] Enable to set an existing service account name

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.7.0
+version: 0.8.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | Parameter                         | Description                                                             | Default                     |
 | --------------------------------- | ----------------------------------------------------------------------- | --------------------------- |
 | `image.repository`                | Image                                                                   | `prom/cloudwatch-exporter`  |
-| `image.tag`                       | Image tag                                                               | `cloudwatch_exporter-0.6.0` |
+| `image.tag`                       | Image tag                                                               | `cloudwatch_exporter-0.8.0` |
 | `image.pullPolicy`                | Image pull policy                                                       | `IfNotPresent`              |
 | `command`                         | Container entrypoint command                                            | `[]`                        |
 | `service.type`                    | Service type                                                            | `ClusterIP`                 |

--- a/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create serviceAccountName for deployment.
+*/}}
+{{- define "prometheus-cloudwatch-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "prometheus-cloudwatch-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "deployment.apiVersion" -}}

--- a/stable/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+    name: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -106,10 +106,8 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccount: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
       serviceAccountName: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
-    {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -107,8 +107,8 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- if .Values.serviceAccount.create }}
-      serviceAccount: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
-      serviceAccountName: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+      serviceAccount: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
+      serviceAccountName: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
     {{- end }}
       volumes:
       - configMap:

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  name: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows to pass the existing service account name. I thought it's a feature desired by users who want to use IRSA because IAM Role and service account can be easily created with `eksctl`.

#### Which issue this PR fixes

  - fixes #22227

It seems to be solved by checking  the reproducing step below.

> 1, update the values.yaml with prepared service account which have the permission to access cloudwatch.


#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
