### PR TITLE
[stable/airflow] Added resources limit to git-clone initcontainer

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.9.1
+version: 6.9.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -106,6 +106,8 @@ spec:
               name: "{{ template "airflow.fullname" . }}-env"
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
+          resources:
+{{ toYaml .Values.scheduler.resources | indent 12 }}
           command:
             - /usr/local/git/git-clone.sh
           args:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -84,6 +84,8 @@ spec:
               name: "{{ template "airflow.fullname" . }}-env"
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
+          resources:
+{{ toYaml .Values.web.resources | indent 12 }}
           command:
             - /usr/local/git/git-clone.sh
           args:

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -86,6 +86,8 @@ spec:
               name: "{{ template "airflow.fullname" . }}-env"
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
+          resources:
+{{ toYaml .Values.workers.resources | indent 12 }}
           command:
           - /usr/local/git/git-clone.sh
           args:


### PR DESCRIPTION
Signed-off-by: Joshua Leuenberger <joshua.leuenberger@bedag.ch>

#### What this PR does / why we need it:
Git-Clone InitContainers were missing a ressources limitation. 
Defaulted it to the main container (eg. scheduler, web...)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
