### PR TITLE
[stable/airflow] Fix handling of multiline vars

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.9.2
+version: 6.9.3
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/configmap-variables-pools.yaml
+++ b/stable/airflow/templates/configmap-variables-pools.yaml
@@ -11,10 +11,10 @@ metadata:
 data:
 {{- if or .Values.airflow.variables }}
     variables.json: |
-        {{ .Values.airflow.variables }}
+{{ .Values.airflow.variables | indent 8 }}
 {{- end }}
 {{- if or .Values.airflow.pools }}
     pools.json: |
-        {{ .Values.airflow.pools }}
+{{ .Values.airflow.pools | indent 8 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Ihor Kaharlichenko <ihor@kaharlichenko.org>

#### Is this a new chart: no

#### What this PR does / why we need it:

Sometimes the variable and pool definitions are big, so it's easier to put them into a separate multiline json file and embed via `--set-file` when installing the chart.

Currently, if either pools or variables contain line breaks the template rendering fails.

#### Which issue this PR fixes

Here are the steps to reproduce the issue:

```sh
cat > /tmp/variables.json <<EOF
{
    "environment": "dev"
}
EOF

cat > /tmp/pools.json <<EOF
{
    "example": {
        "description": "This is an example of a pool",
        "slots": 2
    }
}
EOF

helm template stable/airflow \
    --set-file airflow.variables=/tmp/variables.json \
    --set-file airflow.pools=/tmp/pools.json \
    --show-only templates/configmap-variables-pools.yaml
```

##### Actual result

```
Error: YAML parse error on airflow/templates/configmap-variables-pools.yaml: error converting YAML to JSON: yaml: line 13: did not find expected key
```

##### Expected result

Template gets rendered with both variables.json and pools.json embedded.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/airflow]`)
