### PR TITLE
[stable/jenkins] Make node executor mode configurable

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.18.1
+
+Add support for executor mode configuraton with `master.executorMode`.
+
 ## 1.18.0 Make installation of configuration-as-code plugin explicit
 
 Instead of configuring the configuration-as-code plugin version via

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.19.0
+version: 1.18.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.18.0
+version: 1.19.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -69,6 +69,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.imagePullPolicy`          | Master image pull policy             | `Always`                                  |
 | `master.imagePullSecretName`      | Master image pull secret             | Not set                                   |
 | `master.numExecutors`             | Set Number of executors              | 0                                         |
+| `master.executorMode`             | Set executor mode of the Jenkins node. Possible values are: NORMAL or EXCLUSIVE | NORMAL |
 | `master.customJenkinsLabels`      | Append Jenkins labels to the master  | `{}`                                      |
 | `master.useSecurity`              | Use basic security                   | `true`                                    |
 | `master.securityRealm`            | Custom Security Realm                | Not set                                   |

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -75,7 +75,7 @@ jenkins:
   disableRememberMe: false
   remotingSecurity:
     enabled: true
-  mode: NORMAL
+  mode: {{ .Values.master.executorMode }}
   numExecutors: {{ .Values.master.numExecutors }}
   projectNamingStrategy: "standard"
   markupFormatter:

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -24,7 +24,7 @@ data:
       <version>{{ .Values.master.tag }}</version>
 {{- end }}
       <numExecutors>{{ .Values.master.numExecutors }}</numExecutors>
-      <mode>{{.Values.master.executorMode}}</mode>
+      <mode>{{ .Values.master.executorMode }}</mode>
       <useSecurity>{{ .Values.master.useSecurity }}</useSecurity>
 {{ .Values.master.authorizationStrategy | indent 6 }}
 {{ .Values.master.securityRealm | indent 6 }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -24,7 +24,7 @@ data:
       <version>{{ .Values.master.tag }}</version>
 {{- end }}
       <numExecutors>{{ .Values.master.numExecutors }}</numExecutors>
-      <mode>NORMAL</mode>
+      <mode>{{.Values.master.executorMode}}</mode>
       <useSecurity>{{ .Values.master.useSecurity }}</useSecurity>
 {{ .Values.master.authorizationStrategy | indent 6 }}
 {{ .Values.master.securityRealm | indent 6 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -77,6 +77,8 @@ master:
   #      - "uname"
   #      - "-a"
   numExecutors: 0
+  # configures the executor mode of the Jenkins node. Possible values are: NORMAL or EXCLUSIVE
+  executorMode: "NORMAL"
   customJenkinsLabels: []
   # configAutoReload requires UseSecurity is set to true:
   useSecurity: true


### PR DESCRIPTION
Signed-off-by: Ragin-LundF <ragin666@gmail.com>

**Is this a new chart**
No

**What this PR does / why we need it:**
With the possibility to set the Jenkins to the EXCLUSIVE mode it is possible to assign e.g. a seed job to the master and delegate all other jobs to slave containers.

Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
