### PR TITLE
[stable/neo4j] Improve pod lifecycle

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -36,6 +36,8 @@ spec:
             value: DNS
           - name: NEO4J_causal__clustering_initial__discovery__members
             value: "{{ template "neo4j.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:5000"
+          - name: JAVA_TOOL_OPTIONS
+            value: "-XX:+ExitOnOutOfMemoryError"
           {{- if .Values.authEnabled }}
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -64,6 +64,17 @@ spec:
             fi
 
             exec /docker-entrypoint.sh "neo4j"
+        livenessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - wget --auth-no-challenge --user=neo4j --password=${NEO4J_SECRETS_PASSWORD} --server-response --spider --timeout 10 --tries 1 http://127.0.0.1:7474/db/manage/server/core/available 2>&1 | grep -c -e '200 OK'
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          timeoutSeconds: 11 # 1 more than in the wget command
+          successThreshold: 1 # default
+          failureThreshold: 3 # reboot pod after 3 unsuccesful queries, so after 3*(15+11) seconds
         ports:
         - containerPort: 5000
           name: discovery


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR started when we had a pod die on us with the following error: 
```
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "hz._hzInstance_1_dev.IOBalancerThread"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "CustomProcedureStorage"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "neo4j.Scheduler-1"
java.lang.OutOfMemoryError: Java heap space
Exception in thread "hz._hzInstance_1_dev.cached.thread-3" java.lang.OutOfMemoryError: Java heap space
java.lang.OutOfMemoryError: Java heap space
```

Unfortunately this does not kill the Java Process, so it doesn't change the way K8s sees the pod. 

To improve upon this I've made 2 additions:

* Add a `livenessProbe`, basically every query every so often to see if this core is available. A leader election can take a maximum of 7 seconds. The `wget` waits 10 seconds for an answer, and as such I set K8s to wait 11 seconds, to make sure we have no overlaps. 

After then seeing the pod being killed I dug a little deeper to find a better way to fix the OOM issue, and after I re-read the message I noticed the keyword here is 'uncaught'

```
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "hz._hzInstance_1_dev.IOBalancerThread"
```

Since no-once captures this when this exception gets thrown I found that we can basically stop the JVM when we run out of memory, and that's the second addition: 

* Add `JAVA_TOOL_OPTIONS` with `-XX:+ExitOnOutOfMemoryError`

While this negates the need for the `livenessProbe` in this particular case, I still believe it is useful for other cases. 

#### Special notes for your reviewer:

@mneedham your input would be greatly appreciated. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
