### PR TITLE
[stable/kube-state-metrics] Support imagePullSecrets

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.8
+version: 2.8.9
 appVersion: 1.9.6
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -14,9 +14,10 @@ $ helm install stable/kube-state-metrics
 
 | Parameter                                    | Description                                                                           | Default                                    |
 |:---------------------------------------------|:--------------------------------------------------------------------------------------|:-------------------------------------------|
-| `image.repository`                           | The image repository to pull from                                                     | quay.io/coreos/kube-state-metrics          |
+| `image.repository`                           | The image repository to pull from                                                     | `quay.io/coreos/kube-state-metrics`        |
 | `image.tag`                                  | The image tag to pull from                                                            | `v1.9.6`                                   |
 | `image.pullPolicy`                           | Image pull policy                                                                     | `IfNotPresent`                             |
+| `imagePullSecrets`                           | List of container registry secrets                                                    | `[]`                                       |
 | `replicas`                                   | Number of replicas                                                                    | `1`                                        |
 | `autosharding.enabled`                       | Set to `true` to automatically shard data across `replicas` pods. EXPERIMENTAL        | `false`                                    |
 | `service.port`                               | The port of the container                                                             | `8080`                                     |
@@ -28,20 +29,20 @@ $ helm install stable/kube-state-metrics
 | `serviceAccount.create`                      | If true, create & use serviceAccount                                                  | `true`                                     |
 | `serviceAccount.name`                        | If not set & create is true, use template fullname                                    |                                            |
 | `serviceAccount.imagePullSecrets`            | Specify image pull secrets field                                                      | `[]`                                       |
-| `podSecurityPolicy.enabled`                  | If true, create & use PodSecurityPolicy resources. Note that related RBACs are created only if `rbac.enabled` is `true. | `false`  |
-| `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                                    | {}                                         |
-| `podSecurityPolicy.additionalVolumes`        | Specify allowed volumes in the pod security policy (`secret` is always allowed)       | []                                         |
+| `podSecurityPolicy.enabled`                  | If true, create & use PodSecurityPolicy resources. Note that related RBACs are created only if `rbac.enabled` is `true`. | `false` |
+| `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                                    | `{}`                                       |
+| `podSecurityPolicy.additionalVolumes`        | Specify allowed volumes in the pod security policy (`secret` is always allowed)       | `[]`                                       |
 | `securityContext.enabled`                    | Enable security context                                                               | `true`                                     |
 | `securityContext.fsGroup`                    | Group ID for the filesystem                                                           | `65534`                                    |
 | `securityContext.runAsGroup`                 | Group ID for the container                                                            | `65534`                                    |
 | `securityContext.runAsUser`                  | User ID for the container                                                             | `65534`                                    |
 | `priorityClassName`                          | Name of Priority Class to assign pods                                                 | `nil`                                      |
-| `nodeSelector`                               | Node labels for pod assignment                                                        | {}                                         |
-| `affinity`                                   | Affinity settings for pod assignment                                                  | {}                                         |
-| `tolerations`                                | Tolerations for pod assignment                                                        | []                                         |
-| `podAnnotations`                             | Annotations to be added to the pod                                                    | {}                                         |
-| `podDisruptionBudget`                        | Optional PodDisruptionBudget                                                          | {}                                         |
-| `resources`                                  | kube-state-metrics resource requests and limits                                       | {}                                         |
+| `nodeSelector`                               | Node labels for pod assignment                                                        | `{}`                                       |
+| `affinity`                                   | Affinity settings for pod assignment                                                  | `{}`                                       |
+| `tolerations`                                | Tolerations for pod assignment                                                        | `[]`                                       |
+| `podAnnotations`                             | Annotations to be added to the pod                                                    | `{}`                                       |
+| `podDisruptionBudget`                        | Optional PodDisruptionBudget                                                          | `{}`                                       |
+| `resources`                                  | kube-state-metrics resource requests and limits                                       | `{}`                                       |
 | `collectors.certificatesigningrequests`      | Enable the certificatesigningrequests collector.                                      | `true`                                     |
 | `collectors.configmaps`                      | Enable the configmaps collector.                                                      | `true`                                     |
 | `collectors.cronjobs`                        | Enable the cronjobs collector.                                                        | `true`                                     |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -173,6 +173,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -5,6 +5,9 @@ image:
   tag: v1.9.6
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+# - name: "image-pull-secret"
+
 # If set to true, this will deploy kube-state-metrics as a StatefulSet and the data
 # will be automatically sharded across <.Values.replicas> pods using the built-in
 # autodiscovery feature: https://github.com/kubernetes/kube-state-metrics#automated-sharding


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Adds support for the `imagePullSecrets` section on the `Deployment`. This used to be supported when this was a part of the `prometheus` chart, but is no longer.

It's important to me because some of my clusters have intermediate image caches that require authentication.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>

/cc @fiunchinho @tariq1890, @mrueg