### PR TITLE
[stable/airflow] added option to specify git-clone initContainer custom resources

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.9.3
+version: 6.9.4
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -544,6 +544,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `dags.initContainer.installRequirements` | auto install requirements.txt deps                      | `true`                    |
 | `dags.initContainer.mountPath`           | Mountpath inside init container for dags                | `/dags`                   |
 | `dags.initContainer.syncSubPath`         | Path inside init container used to sync/clone git repo to; appended to `dags.initContainer.mountPath` | ``                      |
+| `dags.initContainer.resources`             | custom resource configuration for the git-clone initContainer    | `{}`                      |
 | `dags.git.url`                           | url to clone the git repository                         | nil                       |
 | `dags.git.ref`                           | branch name, tag or sha1 to reset to                    | `master`                  |
 | `dags.git.secret`                        | name of a secret containing an ssh deploy key           | nil                       |

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -107,7 +107,7 @@ spec:
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           resources:
-{{ toYaml .Values.scheduler.resources | indent 12 }}
+{{ toYaml .Values.dags.initContainer.resources | indent 12 }}
           command:
             - /usr/local/git/git-clone.sh
           args:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -85,7 +85,7 @@ spec:
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           resources:
-{{ toYaml .Values.web.resources | indent 12 }}
+{{ toYaml .Values.dags.initContainer.resources | indent 12 }}
           command:
             - /usr/local/git/git-clone.sh
           args:

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -87,7 +87,7 @@ spec:
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           resources:
-{{ toYaml .Values.workers.resources | indent 12 }}
+{{ toYaml .Values.dags.initContainer.resources | indent 12 }}
           command:
           - /usr/local/git/git-clone.sh
           args:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -622,6 +622,8 @@ dags:
     ## Path to add to `mountPath` where we clone/sync git to. Include leading /
     ## example: "/subdirWithDags"
     syncSubPath: ""
+    ## Custom resource configuration
+    resources: {}
 
 ##
 ## Configure logs


### PR DESCRIPTION
Signed-off-by: Joshua Leuenberger <joshua.leuenberger@bedag.ch>

#### What this PR does / why we need it:
The default resource limitation of the resource container using the main container needed to much resources. #22274 
Added the option to specify the initContainer ressources

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
