### PR TITLE
[stable/prometheus] Configure enableServiceLinks for server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.1.5
+version: 11.1.6
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -38,6 +38,7 @@ spec:
 {{- if .Values.server.schedulerName }}
       schedulerName: "{{ .Values.server.schedulerName }}"
 {{- end }}
+      enableServiceLinks: {{ .Values.server.enableServiceLinks | default "true" }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -552,6 +552,9 @@ server:
   ##
   priorityClassName: ""
 
+  # EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links.
+  enableServiceLinks: true
+
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
   ## so that the various internal URLs are still able to access as they are in the default case.
   ## (Optional)


### PR DESCRIPTION
#### What this PR does / why we need it:

Prometheus 2.18 supports experimental Jaegar tracing which is configured by [environment variables](https://github.com/jaegertracing/jaeger-client-go#environment-variables). However, if you have existing services called `jaegar`, this might cause issues because the Kubernetes injected environment variables for services are not the format that Jaegar client expects, leading to crashloops.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
