### PR TITLE
Added separate service for UDP ports if 'unifiedService' is true

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.7.0
+version: 0.7.1
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/templates/unified-svc-udp.yaml
+++ b/stable/unifi/templates/unified-svc-udp.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "unifi.fullname" . }}
+  name: {{ template "unifi.fullname" . }}-udp
   labels:
     app.kubernetes.io/name: {{ include "unifi.name" . }}
     helm.sh/chart: {{ include "unifi.chart" . }}
@@ -41,35 +41,19 @@ spec:
   externalTrafficPolicy: {{ .Values.unifiedService.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.controllerService.port }}
-      targetPort: controller
-      protocol: TCP
-      name: controller
-{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.controllerService.nodePort))) }}
-      nodePort: {{.Values.controllerService.nodePort}}
+    - port: {{ .Values.discoveryService.port }}
+      targetPort: discovery
+      protocol: UDP
+      name: discovery
+{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.discoveryService.nodePort))) }}
+      nodePort: {{.Values.discoveryService.nodePort}}
 {{ end }}
-    - name: https-gui
-      port: {{ .Values.guiService.port }}
-      protocol: TCP
-      targetPort: https-gui
-{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.guiService.nodePort))) }}
-      nodePort: {{.Values.guiService.nodePort}}
-{{ end }}
-{{ if .Values.captivePortalService.enabled }}
-    - name: captive-http
-      port: {{ .Values.captivePortalService.http }}
-      protocol: TCP
-      targetPort: captive-http
-{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.captivePortalService.http))) }}
-      nodePort: {{.Values.captivePortalService.http}}
-{{ end }}
-    - name: captive-https
-      port: {{ .Values.captivePortalService.https }}
-      protocol: TCP
-      targetPort: captive-https
-{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.captivePortalService.https))) }}
-      nodePort: {{.Values.captivePortalService.https}}
-{{ end }}
+    - port: {{ .Values.stunService.port }}
+      targetPort: stun
+      protocol: UDP
+      name: stun
+{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.stunService.nodePort))) }}
+      nodePort: {{.Values.stunService.nodePort}}
 {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "unifi.name" . }}


### PR DESCRIPTION
With two different services for UDP and TCP ports the 'unifiedService' can use
the type 'LoadBalancer'. Otherwise this would fail as both UDP and TCP ports
are not allowed for LoadBalancers.

metallb for example still allows both services to share an IP, such that all
ports are available on one IP. This is especiall important for the inform port
(8080) and STUN for access points.

@billimek 
@mcronce 

#### What this PR does / why we need it:

* K8s doesn't allow for LoadBalancers with both UDP and TCP ports. By splitting the unified service into two services, once for UDP and one for TCP, the use of a LoadBalancer gets possible.
A LoadBalancer typically uses IPs, which are reachable for access points. As making the NodePorts IP range routable broke k3s (k3s.io), such a LoadBalancer IP is actually needed. MetalLB allows for sharing IPs between services, such that the goal to have a unified service is still met. `metallb.universe.tf/allow-shared-ip: "<tag>"`

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed

