### PR TITLE
[stable/spring-cloud-data-flow] Support for extra env vars

### DIFF
--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 2.6.2
+version: 2.6.3
 appVersion: 2.4.0.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:
@@ -12,6 +12,6 @@ maintainers:
 - name: trisberg
   email: trisberg@pivotal.io
 - name: chrisjs
-  email: cschaefer@pivotal.io
+  email: cschaefer@vmware.com
 - name: sabbyanandan
   email: sanandan@pivotal.io

--- a/stable/spring-cloud-data-flow/README.md
+++ b/stable/spring-cloud-data-flow/README.md
@@ -162,6 +162,7 @@ The following tables list the configurable parameters and their default values.
 | server.platformName                     | The name of the configured platform account                        | default
 | server.configMap                        | Custom ConfigMap name for Data Flow server configuration           |
 | server.trustCerts                       | Trust self signed certs                                            | false
+| server.extraEnv                         | Extra environment variables to add to the server container         | {}
 
 ### Skipper Server Configuration
 
@@ -175,6 +176,7 @@ The following tables list the configurable parameters and their default values.
 | skipper.service.labels            | Extra labels for the service resource                            | {}
 | skipper.configMap                 | Custom ConfigMap name for Skipper server configuration           |
 | skipper.trustCerts                | Trust self signed certs                                          | false
+| skipper.extraEnv                  | Extra environment variables to add to the skipper container      | {}
 
 ### Spring Cloud Deployer for Kubernetes Configuration
 

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -86,6 +86,10 @@ spec:
           value: {{ .Values.features.batch.enabled | quote }}
         - name: SPRING_CLOUD_DATAFLOW_TASK_SCHEDULER_TASK_LAUNCHER_URL
           value: 'docker://springcloud/spring-cloud-dataflow-scheduler-task-launcher:{{ .Values.server.version }}'
+        {{- range $key, $value := .Values.server.extraEnv }}
+        - name: {{ $key }}
+          value: "{{ $value }}"
+        {{- end }}
       volumes:
         - name: database
           secret:

--- a/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -85,6 +85,10 @@ spec:
         {{- end }}
         - name: KUBERNETES_TRUST_CERTIFICATES
           value: {{ .Values.skipper.trustCerts | quote }}
+        {{- range $key, $value := .Values.skipper.extraEnv }}
+        - name: {{ $key }}
+          value: "{{ $value }}"
+        {{- end }}
       volumes:
         {{- if or .Values.rabbitmq.enabled (index .Values "rabbitmq-ha" "enabled") }}
         - name: rabbitmq

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -36,6 +36,7 @@ server:
   #  requests:
   #    cpu: 0.5
   #    memory: 640Mi
+  extraEnv: {}
 
 skipper:
   enabled: true
@@ -56,6 +57,7 @@ skipper:
   #  requests:
   #    cpu: 0.5
   #    memory: 640Mi
+  extraEnv: {}
 
 deployer:
   resourceLimits:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Support for adding extra env vars to server and skipper

Signed-off-by: Chris Schaefer <cschaefer@vmware.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
