### PR TITLE
[stable/metabase] Upgrade metabase to 0.35.3

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.10.6
-appVersion: v0.34.3
+version: 0.11.0
+appVersion: v0.35.3
 maintainers:
 - name: pmint93
   email: phamminhthanh69@gmail.com

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                   | controller pods annotations                                 | {}                |
 | podLabels                        | extra pods labels                                           | {}                |
 | image.repository                 | controller container image repository                       | metabase/metabase |
-| image.tag                        | controller container image tag                              | v0.34.0           |
+| image.tag                        | controller container image tag                              | v0.35.3           |
 | image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
 | fullnameOverride                 | String to fully override metabase.fullname template         | null              |
 | listen.host                      | Listening on a specific network host                        | 0.0.0.0           |
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | jetty.maxQueued                  | Jetty max queue size                                        | null              |
 | jetty.maxIdleTime                | Jetty max idle time                                         | null              |
 
-The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](http://www.metabase.com/docs/v0.34.3/).
+The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](http://www.metabase.com/docs/v0.35.3/).
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -7,7 +7,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.34.3
+  tag: v0.35.3
   pullPolicy: IfNotPresent
 
 ## String to fully override metabase.fullname template


### PR DESCRIPTION
Signed-off-by: Albert Wang <amwang217@gmail.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Upgrades metabase from 0.34.3 to 0.35.3. There's new features, bugfixes, and performance enhancements starting from 0.35.0. 

#### Special notes for your reviewer:
I upgrade from 0.10.6 to 0.11.0 since the underlying image might be breaking. I believe we should increment the 'minor' portion of the semantic versioning if the `minor` portion of semantic versioning of Metabase also gets upgraded. Please let me know your thoughts.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
