### PR TITLE
[stable/promtheus-consul-exporter] Removed deprecated psp apiVersion

### DIFF
--- a/stable/prometheus-consul-exporter/Chart.yaml
+++ b/stable/prometheus-consul-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: A Helm chart for the Prometheus Consul Exporter
 name: prometheus-consul-exporter
-version: 0.1.4
+version: 0.1.5
 keywords:
   - metrics
   - consul

--- a/stable/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-consul-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Morgan Williams <morgan.williams@localz.co>

#### What this PR does / why we need it:
Since Kubernetes 1.16 the `extensions/v1beta1` PodSecurityPolicy API has been deprecated in favor of `policy/v1beta1`, this PR updates the API being used

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
