### PR TITLE
[stable/airflow] DAGs serialization without git-sync for web pods

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.9.4
+version: 6.10.4
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -464,6 +464,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `flower.securityContext`                 | (optional) security context for the flower deployment   | `{}`                      |
 | `web.baseUrl`                            | webserver UI URL                                        | `http://localhost:8080`   |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
+| `web.serializeDAGs`                      | if web will use DAG serialization (https://airflow.apache.org/docs/stable/dag-serialization.html). If enabled, git-sync containers will not be added to web pods               | `false`                   |
 | `web.labels`                             | labels for the web deployment                           | `{}`                      |
 | `web.podLabels`                          | podLabels for the web deployment                        | `{}`                      |
 | `web.annotations`                        | annotations for the web deployment                      | `{}`                      |

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -464,7 +464,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `flower.securityContext`                 | (optional) security context for the flower deployment   | `{}`                      |
 | `web.baseUrl`                            | webserver UI URL                                        | `http://localhost:8080`   |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
-| `web.serializeDAGs`                      | if web will use DAG serialization (https://airflow.apache.org/docs/stable/dag-serialization.html). If enabled, git-sync containers will not be added to web pods               | `false`                   |
+| `web.serializeDAGs`                      | if web will use DAG serialization (https://airflow.apache.org/docs/stable/dag-serialization.html). If enabled, git-sync containers will not be added to web pods. Completely supported in Airflow >= 1.10.10               | `false`                   |
 | `web.labels`                             | labels for the web deployment                           | `{}`                      |
 | `web.podLabels`                          | podLabels for the web deployment                        | `{}`                      |
 | `web.annotations`                        | annotations for the web deployment                      | `{}`                      |

--- a/stable/airflow/templates/configmap-env.yaml
+++ b/stable/airflow/templates/configmap-env.yaml
@@ -38,6 +38,9 @@ data:
   AIRFLOW__WEBSERVER__BASE_URL: "{{ .Values.web.baseUrl }}"
   # Disabling XCom pickling for forward compatibility
   AIRFLOW__CORE__ENABLE_XCOM_PICKLING: "false"
+  {{- if .Values.web.serializeDAGs }}
+  AIRFLOW__CORE__STORE_SERIALIZED_DAGS: "true"
+  {{- end }}
   # Note: changing `Values.airflow.config` won't change the configmap checksum and so won't make
   # the pods to restart
   {{- range $setting, $option := .Values.airflow.config }}

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -74,7 +74,7 @@ spec:
       securityContext:
 {{ toYaml .Values.web.securityContext | indent 8 }}
       {{- end }}
-      {{- if .Values.dags.initContainer.enabled }}
+      {{- if and ( .Values.dags.initContainer.enabled ) ( not .Values.web.serializeDAGs ) }}
       initContainers:
         - name: git-clone
           image: {{ .Values.dags.initContainer.image.repository }}:{{ .Values.dags.initContainer.image.tag }} # Any image with git will do
@@ -106,7 +106,7 @@ spec:
             {{- end }}
       {{- end }}
       containers:
-        {{- if .Values.dags.git.gitSync.enabled }}
+        {{- if and ( .Values.dags.git.gitSync.enabled ) ( not .Values.web.serializeDAGs ) }}
         - name: git-sync
           image: {{ .Values.dags.git.gitSync.image.repository }}:{{ .Values.dags.git.gitSync.image.tag }} # Any image with git will do
           imagePullPolicy: {{ .Values.dags.git.gitSync.image.pullPolicy }}
@@ -164,9 +164,11 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
               subPath: {{ .Values.persistence.subPath | default "" }}
-          {{- else if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
+          {{- else if not .Values.web.serializeDAGs }}
+          {{- if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
+          {{- end }}
           {{- end }}
           {{- if .Values.logsPersistence.enabled }}
             - name: logs-data
@@ -257,6 +259,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
+        {{- if not .Values.web.serializeDAGs }}
         {{- if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
         - name: git-clone
           configMap:
@@ -267,6 +270,7 @@ spec:
           secret:
             secretName: {{ .Values.dags.git.secret }}
             defaultMode: 0700
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- range .Values.airflow.extraConfigmapMounts }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -256,6 +256,7 @@ flower:
   #   subPath: extra-cert.pem
 
 web:
+  serializeDAGs: false
   ##
   ## Set AIRFLOW__WEBSERVER__BASE_URL
   ## Path should match Ingress configuration

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -256,7 +256,7 @@ flower:
   #   subPath: extra-cert.pem
 
 web:
-  ## Enable DAG serialization and do not add git-sync containers to web pods
+  ## Enable DAG serialization and do not add git-sync containers to web pods. Completely supported in Airflow >= 1.10.10
   serializeDAGs: false
   ##
   ## Set AIRFLOW__WEBSERVER__BASE_URL

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -256,6 +256,7 @@ flower:
   #   subPath: extra-cert.pem
 
 web:
+  ## Enable DAG serialization and do not add git-sync containers to web pods
   serializeDAGs: false
   ##
   ## Set AIRFLOW__WEBSERVER__BASE_URL


### PR DESCRIPTION
### What this PR does / why we need it:
In the latest Airflow implementation web no longer needs to parse DAGs from the filesystem: https://airflow.apache.org/docs/stable/dag-serialization.html, so git-sync needs to be added only to scheduler and worker pods. Also sometimes git repository may be inaccessible (happened to me several times with GitHub), which leads to a git-sync container failure, web pods become unhealthy and UI stops being accessible. DAG serialization will prevent this.

#### Which issue this PR fixes
Added new parameter web.serializeDAGs which will enable DAGs serialization and stop adding git-sync init container and sidecar container to web pods.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
