### PR TITLE
[stable/coredns] Add security context, expose port, override service name

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.10.1
+version: 1.10.2
 appVersion: 1.6.9
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -72,6 +72,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                              | Affinity settings for pod assignment                                                  | {}                                                          |
 | `nodeSelector`                          | Node labels for pod assignment                                                        | {}                                                          |
 | `tolerations`                           | Tolerations for pod assignment                                                        | []                                                          |
+| `securityContext`                       | Security context for the container                                                    | {}                                                          |
 | `zoneFiles`                             | Configure custom Zone files                                                           | []                                                          |
 | `extraSecrets`                          | Optional array of secrets to mount inside the CoreDNS container                       | []                                                          |
 | `customLabels`                          | Optional labels for Deployment(s), Pod, Service, ServiceMonitor objects               | {}                                                          |
@@ -86,6 +87,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaler.affinity`                   | Affinity settings for pod assignment for autoscaler                                   | {}                                                          |
 | `autoscaler.nodeSelector`               | Node labels for pod assignment for autoscaler                                         | {}                                                          |
 | `autoscaler.tolerations`                | Tolerations for pod assignment for autoscaler                                         | []                                                          |
+| `autoscaler.securityContext`            | Security context for the autoscaler container                                         | {}                                                          |
 | `autoscaler.resources.limits.cpu`       | Container maximum CPU for cluster-proportional-autoscaler                             | `20m`                                                       |
 | `autoscaler.resources.limits.memory`    | Container maximum memory for cluster-proportional-autoscaler                          | `10Mi`                                                      |
 | `autoscaler.resources.requests.cpu`     | Container requested CPU for cluster-proportional-autoscaler                           | `20m`                                                       |

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -58,6 +58,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prometheus.monitor.enabled`            | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                                                     |
 | `prometheus.monitor.additionalLabels`   | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {}                                                          |
 | `prometheus.monitor.namespace`          | Selector to select which namespaces the Endpoints objects are discovered from.        | `""`                                                        |
+| `service.name`                          | If not set & create is true, use template fullname                                    |                                                             |
 | `service.clusterIP`                     | IP address to assign to service                                                       | `""`                                                        |
 | `service.loadBalancerIP`                | IP address to assign to load balancer (if supported)                                  | `""`                                                        |
 | `service.externalTrafficPolicy`         | Enable client source IP preservation                                                  | `[]`                                                        |

--- a/stable/coredns/templates/deployment-autoscaler.yaml
+++ b/stable/coredns/templates/deployment-autoscaler.yaml
@@ -74,4 +74,8 @@ spec:
           - --target=Deployment/{{ template "coredns.fullname" . }}
           - --logtostderr=true
           - --v=2
+        {{- if .Values.autoscaler.securityContext }}
+        securityContext:
+{{ toYaml .Values.autoscaler.securityContext | indent 10 }}
+        {{- end }}
 {{- end }}

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -84,7 +84,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
-{{ include "coredns.containerPorts" . | indent 8 }}
+{{ include "coredns.containerPorts" . | indent 8 -}}
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /health

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -103,6 +103,10 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 5
+        {{- if .Values.securityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+        {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "coredns.fullname" . }}
+  name: {{ default (include "coredns.fullname" .) .Values.service.name }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -26,6 +26,7 @@ prometheus:
     namespace: ""
 
 service:
+# name: ""
 # clusterIP: ""
 # loadBalancerIP: ""
 # externalTrafficPolicy: ""

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -128,6 +128,18 @@ nodeSelector: {}
 #     effect: NoSchedule
 tolerations: []
 
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#securitycontext-v1-core
+# for example:
+# securityContext:
+#   allowPrivilegeEscalation: false
+#   capabilities:
+#     add:
+#     - NET_BIND_SERVICE
+#     drop:
+#     - all
+#   readOnlyRootFilesystem: true
+securityContext: {}
+
 # https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
 podDisruptionBudget: {}
 
@@ -181,6 +193,9 @@ autoscaler:
 
   # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
   tolerations: []
+
+  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#securitycontext-v1-core
+  securityContext: {}
 
   # resources for autoscaler pod
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
* Adds ability to set security context on pods in coredns
* Adds port 9153 as a port that is exposed by the coredns pods; there are references to it for Prometheus throughout the chart, but it's not actually exposed by pods.
* Adds the ability to override the name of the service; useful in cases like AWS EKS where they override the name of the service to be "kube-dns" for backwards compatibility. (See https://docs.aws.amazon.com/eks/latest/userguide/coredns.html)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
