### PR TITLE
[stable/home-assistant]: ServiceMonitor bearerTokenSecret requires a SecretKeySelector

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.108.7
 description: Home Assistant
 name: home-assistant
-version: 0.13.2
+version: 0.13.3
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/templates/servicemonitor.yaml
+++ b/stable/home-assistant/templates/servicemonitor.yaml
@@ -21,7 +21,12 @@ spec:
     bearerTokenFile: {{ .Values.monitoring.serviceMonitor.bearerTokenFile }}
 {{- end }}
 {{- if .Values.monitoring.serviceMonitor.bearerTokenSecret }}
-    bearerTokenSecret: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret }}
+    bearerTokenSecret:
+      name: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.name }}
+      key: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.key }}
+      {{- if .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
+      optional: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
+      {{- end }}
 {{- end }}
   jobLabel: {{ template "home-assistant.fullname" . }}-prometheus-exporter
   namespaceSelector:


### PR DESCRIPTION
This PR fixes an issue with Home Assistant's Service Monitor template to allow usage of a `bearerTokenSecret`.

Prometheus Operator's ServiceMonitor Endpoint requires the `bearerTokenSecret` value to be a [`SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#secretkeyselector-v1-core), the current chart expects it to be a string.

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
