### PR TITLE
[stable/oauth2-proxy] Update to new repo and upstream release

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.1.0
+version: 3.2.0
 apiVersion: v1
 appVersion: 5.1.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,8 +1,8 @@
 name: oauth2-proxy
 version: 3.1.0
 apiVersion: v1
-appVersion: 5.1.0
-home: https://pusher.github.io/oauth2_proxy/
+appVersion: 5.1.1
+home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
 - kubernetes
@@ -17,6 +17,6 @@ maintainers:
   - name: miouge1
     email: maxime@root314.com
 sources:
-- https://github.com/pusher/oauth2_proxy
+- https://oauth2-proxy.github.io/oauth2-proxy/
 engine: gotpl
 kubeVersion: ">=1.9.0-0"

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -65,7 +65,7 @@ Parameter | Description | Default
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `openssl rand -base64 32 | head -c 32 | base64` | `""`
 `config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
-`config.configFile` | custom [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
+`config.configFile` | custom [oauth2_proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example) contents for settings not overridable via environment nor command line (Note we use `oauth2_proxy.cfg`, the upstream docs use a `-` in the name instead) | `""`
 `config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -1,6 +1,6 @@
 # oauth2-proxy
 
-[oauth2-proxy](https://github.com/pusher/oauth2_proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
+[oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 
 ## TL;DR;
 
@@ -39,7 +39,7 @@ incompatible breaking change needing manual actions.
 
 ### To 1.0.0
 
-This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/pusher/oauth2_proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
+This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/oauth2-proxy/oauth2-proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
 
 ### To 2.0.0
 
@@ -60,12 +60,12 @@ Parameter | Description | Default
 `affinity` | node/pod affinities | None
 `authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
 `authenticatedEmailsFile.template` | Name of the configmap that is handled outside of that chart | `""`
-`authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config | `""`
+`authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/oauth2-proxy/oauth2-proxy#email-authentication) list config | `""`
 `config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `openssl rand -base64 32 | head -c 32 | base64` | `""`
 `config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
-`config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
+`config.configFile` | custom [oauth2-proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
@@ -75,12 +75,12 @@ Parameter | Description | Default
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
-`htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) | `{}`
+`htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/configuration#command-line-options) | `{}`
 `htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file | `""`
 `httpScheme` | `http` or `https`. `name` used for port on the deployment. `httpGet` port `name` and `scheme` used for `liveness`- and `readinessProbes`. `name` and `targetPort` used for the service. | `http`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`image.repository` | Image repository | `quay.io/pusher/oauth2_proxy`
-`image.tag` | Image tag | `v5.1.0`
+`image.repository` | Image repository | `quay.io/oauth2-proxy/oauth2-proxy`
+`image.tag` | Image tag | `v5.1.1`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | Enable Ingress | `false`
 `ingress.path` | Ingress accepted path | `/`
@@ -135,7 +135,7 @@ $ helm install stable/oauth2-proxy --name my-release -f values.yaml
 
 ## SSL Configuration
 
-See: [SSL Configuration](https://pusher.github.io/oauth2_proxy/tls-configuration).
+See: [SSL Configuration](https://oauth2-proxy.github.io/oauth2-proxy/tls-configuration).
 Use ```values.yaml``` like:
 
 ```yaml

--- a/stable/oauth2-proxy/templates/configmap.yaml
+++ b/stable/oauth2-proxy/templates/configmap.yaml
@@ -10,6 +10,6 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "oauth2-proxy.fullname" . }}
 data:
-  oauth2-proxy.cfg: {{ .Values.config.configFile | quote }}
+  oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
 {{- end }}
 {{- end }}

--- a/stable/oauth2-proxy/templates/configmap.yaml
+++ b/stable/oauth2-proxy/templates/configmap.yaml
@@ -10,6 +10,6 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "oauth2-proxy.fullname" . }}
 data:
-  oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
+  oauth2-proxy.cfg: {{ .Values.config.configFile | quote }}
 {{- end }}
 {{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- if or .Values.config.existingConfig .Values.config.configFile }}
-          - --config=/etc/oauth2-proxy/oauth2-proxy.cfg
+          - --config=/etc/oauth2-proxy/oauth2_proxy.cfg
         {{- end }}
         {{- if .Values.authenticatedEmailsFile.enabled }}
         {{- if .Values.authenticatedEmailsFile.template }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- if or .Values.config.existingConfig .Values.config.configFile }}
-          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+          - --config=/etc/oauth2-proxy/oauth2-proxy.cfg
         {{- end }}
         {{- if .Values.authenticatedEmailsFile.enabled }}
         {{- if .Values.authenticatedEmailsFile.template }}
@@ -71,7 +71,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.htpasswdFile.enabled }}
-          - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt
+          - --htpasswd-file=/etc/oauth2-proxy/htpasswd/users.txt
         {{- end }}
         {{- if .Values.proxyVarsAsSecrets }}
         env:
@@ -129,7 +129,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if or .Values.config.existingConfig .Values.config.configFile }}
-        - mountPath: /etc/oauth2_proxy
+        - mountPath: /etc/oauth2-proxy
           name: configmain
 {{- end }}
 {{- if .Values.authenticatedEmailsFile.enabled }}
@@ -138,7 +138,7 @@ spec:
           readOnly: true
 {{- end }}
 {{- if .Values.htpasswdFile.enabled }}
-        - mountPath: /etc/oauth2_proxy/htpasswd
+        - mountPath: /etc/oauth2-proxy/htpasswd
           name: {{ template "oauth2-proxy.fullname" . }}-htpasswd-file
           readOnly: true
 {{- end }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -20,7 +20,7 @@ config:
   configFile: |-
     email_domains = [ "*" ]
     upstreams = [ "file:///dev/null" ]
-  # Custom configuration file: oauth2_proxy.cfg
+  # Custom configuration file: oauth2-proxy.cfg
   # configFile: |-
   #   pass_basic_auth = false
   #   pass_access_token = true
@@ -29,8 +29,8 @@ config:
   # existingConfig: config
 
 image:
-  repository: "quay.io/pusher/oauth2_proxy"
-  tag: "v5.1.0"
+  repository: "quay.io/oauth2-proxy/oauth2-proxy"
+  tag: "v5.1.1"
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -20,7 +20,7 @@ config:
   configFile: |-
     email_domains = [ "*" ]
     upstreams = [ "file:///dev/null" ]
-  # Custom configuration file: oauth2-proxy.cfg
+  # Custom configuration file: oauth2_proxy.cfg
   # configFile: |-
   #   pass_basic_auth = false
   #   pass_access_token = true


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

- oauth2-proxy has it's own github org and with that a new quay container image repo
- v5.1.1 has been released fixing a security issue.

#### Which issue this PR fixes

Minor change so didn't open an issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
