### PR TITLE
[Sealed secrets/optional] runAs and fsGroup have to be optional

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.10.0
+version: 1.10.1
 appVersion: 0.12.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -59,6 +59,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **crd.keep**                  | `true` if the sealed secret CRD should be kept when the chart is deleted   | `true`                                      |
 | **networkPolicy**             | Whether to create a network policy that allows access to the service       | `false`                                     |
 | **securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`                                      |
+| **securityContext.fsGroup**   | Defines fsGroup for the operator Pod and its containers/processes run      | `65534`                                     |
 | **commandArgs**               | Set optional command line arguments passed to the controller process       | `[]`                                        |
 | **ingress.enabled**           | Enables Ingress                                                            | `false`                                     |
 | **ingress.annotations**       | Ingress annotations                                                        | `{}`                                        |
@@ -73,3 +74,9 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
 - If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.
+- OpenShift: unset the runAsUser and fsGroup like this:
+```
+  securityContext:
+    runAsUser:
+    fsGroup:
+```

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -59,12 +59,16 @@ spec:
               port: 8080
           securityContext:
             readOnlyRootFilesystem: true
+            {{- if .Values.securityContext.runAsUser }}
             runAsNonRoot: true
             runAsUser: {{ .Values.securityContext.runAsUser }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      {{- if .Values.securityContext.fsGroup }}
       securityContext:
         fsGroup: 65534
+      {{- end }}
       volumes:
       - name: tmp
         emptyDir: {}

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       {{- if .Values.securityContext.fsGroup }}
       securityContext:
-        fsGroup: 65534
+        fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
       volumes:
       - name: tmp

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -50,6 +50,8 @@ networkPolicy: false
 securityContext:
   # securityContext.runAsUser defines under which user the operator Pod and its containers/processes run.
   runAsUser: 1001
+  # securityContext.fsGroup defines the filesystem group
+  fsGroup: 65534
 
 podAnnotations: {}
 


### PR DESCRIPTION
*Describe the bug*
OpenShift does not accept runAs specific user by default. The runAs and fsGroup elements in the securityContext in deployments should therefore be optional.

*Version of Helm and Kubernetes:*
Any version

*Which chart:*
stable/sealed-secrets

*What happened:*
Installing sealed-secrets at OpenShift results in error
sealed-secrets-8668f96d98-" is forbidden: unable to validate against any security context constraint: [fsGroup: Invalid value: []int64{65534}: 65534 is not an allowed group spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 1001: must be in the ranges: [1000810000, 1000819999]]

*What you expected to happen:*
OpenShift by default assigns a random userId and the chart should not provide the user id.

*How to reproduce it (as minimally and precisely as possible):*
helm install towards a OpenShift cluster.