### PR TITLE
[stable/openebs] Add the opportunity to change docker registry

### DIFF
--- a/stable/openebs/Chart.yaml
+++ b/stable/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.9.1
+version: 1.9.2
 name: openebs
 appVersion: 1.9.0
 description: Containerized Storage for Containers

--- a/stable/openebs/README.md
+++ b/stable/openebs/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
 | `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
 | `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
-| `image.registry`                        | Specify witch docker registry to use          | `quay.io\`                            |
+| `image.registry`                        | Specify witch docker registry to use          | `quay.io/`                            |
 | `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
 | `apiserver.image`                       | Image for API Server                          | `quay.io/openebs/m-apiserver`             |
 | `apiserver.imageTag`                    | Image Tag for API Server                      | `1.9.0`                                   |

--- a/stable/openebs/README.md
+++ b/stable/openebs/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
 | `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
 | `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
+| `image.registry`                        | Specify witch docker registry to use          | `quay.io\`                            |
 | `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
 | `apiserver.image`                       | Image for API Server                          | `quay.io/openebs/m-apiserver`             |
 | `apiserver.imageTag`                    | Image Tag for API Server                      | `1.9.0`                                   |

--- a/stable/openebs/templates/daemonset-ndm.yaml
+++ b/stable/openebs/templates/daemonset-ndm.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: {{ template "openebs.name" . }}-ndm
-        image: "{{ .Values.ndm.image }}:{{ .Values.ndm.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.ndm.image }}:{{ .Values.ndm.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true

--- a/stable/openebs/templates/deployment-admission-server.yaml
+++ b/stable/openebs/templates/deployment-admission-server.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
         - name: admission-webhook
-          image: "{{ .Values.webhook.image }}:{{ .Values.webhook.imageTag }}"
+          image: "{{ .Values.image.repository }}{{ .Values.webhook.image }}:{{ .Values.webhook.imageTag }}"
           imagePullPolicy: Always 
           args:
             - -alsologtostderr

--- a/stable/openebs/templates/deployment-local-provisioner.yaml
+++ b/stable/openebs/templates/deployment-local-provisioner.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-localpv-provisioner
-        image: "{{ .Values.localprovisioner.image }}:{{ .Values.localprovisioner.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.localprovisioner.image }}:{{ .Values.localprovisioner.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s

--- a/stable/openebs/templates/deployment-local-provisioner.yaml
+++ b/stable/openebs/templates/deployment-local-provisioner.yaml
@@ -67,7 +67,7 @@ spec:
         - name: OPENEBS_IO_BASE_PATH
           value: "{{ .Values.localprovisioner.basePath }}"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "charts-helm"
         # Process name used for matching is limited to the 15 characters

--- a/stable/openebs/templates/deployment-maya-apiserver.yaml
+++ b/stable/openebs/templates/deployment-maya-apiserver.yaml
@@ -110,25 +110,25 @@ spec:
         - name: OPENEBS_IO_BASE_DIR
           value: "{{ .Values.varDirectoryPath.baseDir }}"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "{{ .Values.jiva.replicas }}"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "{{ .Values.cstor.target.image }}:{{ .Values.cstor.target.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.cstor.target.image }}:{{ .Values.cstor.target.imageTag }}"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "{{ .Values.cstor.pool.image }}:{{ .Values.cstor.pool.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.cstor.pool.image }}:{{ .Values.cstor.pool.imageTag }}"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "{{ .Values.cstor.poolMgmt.image }}:{{ .Values.cstor.poolMgmt.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.cstor.poolMgmt.image }}:{{ .Values.cstor.poolMgmt.imageTag }}"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "{{ .Values.cstor.volumeMgmt.image }}:{{ .Values.cstor.volumeMgmt.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.cstor.volumeMgmt.image }}:{{ .Values.cstor.volumeMgmt.imageTag }}"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
         - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS

--- a/stable/openebs/templates/deployment-maya-apiserver.yaml
+++ b/stable/openebs/templates/deployment-maya-apiserver.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-apiserver
-        image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.apiserver.ports.internalPort }}

--- a/stable/openebs/templates/deployment-maya-provisioner.yaml
+++ b/stable/openebs/templates/deployment-maya-provisioner.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-provisioner
-        image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s

--- a/stable/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/stable/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-snapshot-controller
-        image: "{{ .Values.snapshotOperator.controller.image }}:{{ .Values.snapshotOperator.controller.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.snapshotOperator.controller.image }}:{{ .Values.snapshotOperator.controller.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs snapshot controller to connect to K8s
@@ -75,7 +75,7 @@ spec:
           initialDelaySeconds: {{ .Values.snapshotOperator.healthCheck.initialDelaySeconds }}
           periodSeconds: {{ .Values.snapshotOperator.healthCheck.periodSeconds }}
       - name: {{ template "openebs.name" . }}-snapshot-provisioner
-        image: "{{ .Values.snapshotOperator.provisioner.image }}:{{ .Values.snapshotOperator.provisioner.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.snapshotOperator.provisioner.image }}:{{ .Values.snapshotOperator.provisioner.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs snapshot provisioner to connect to K8s

--- a/stable/openebs/templates/deployment-ndm-operator.yaml
+++ b/stable/openebs/templates/deployment-ndm-operator.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.fullname" . }}-ndm-operator
-        image: "{{ .Values.ndmOperator.image }}:{{ .Values.ndmOperator.imageTag }}"
+        image: "{{ .Values.image.repository }}{{ .Values.ndmOperator.image }}:{{ .Values.ndmOperator.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         readinessProbe:
           exec:

--- a/stable/openebs/templates/deployment-ndm-operator.yaml
+++ b/stable/openebs/templates/deployment-ndm-operator.yaml
@@ -61,7 +61,7 @@ spec:
         - name: OPERATOR_NAME
           value: "node-disk-operator"
         - name: CLEANUP_JOB_IMAGE
-          value: "{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
+          value: "{{ .Values.image.repository }}{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
         # Process name used for matching is limited to the 15 characters
         # present in the pgrep output.
         # So fullname can be used here with pgrep (cmd is < 15 chars).

--- a/stable/openebs/values.yaml
+++ b/stable/openebs/values.yaml
@@ -17,10 +17,11 @@ release:
 
 image:
   pullPolicy: IfNotPresent
+  repository: "quay.io/"
 
 apiserver:
   enabled: true
-  image: "quay.io/openebs/m-apiserver"
+  image: "openebs/m-apiserver"
   imageTag: "1.9.0"
   replicas: 1
   ports:
@@ -45,7 +46,7 @@ varDirectoryPath:
 
 provisioner:
   enabled: true
-  image: "quay.io/openebs/openebs-k8s-provisioner"
+  image: "openebs/openebs-k8s-provisioner"
   imageTag: "1.9.0"
   replicas: 1
   nodeSelector: {}
@@ -57,7 +58,7 @@ provisioner:
 
 localprovisioner:
   enabled: true
-  image: "quay.io/openebs/provisioner-localpv"
+  image: "openebs/provisioner-localpv"
   imageTag: "1.9.0"
   replicas: 1
   basePath: "/var/openebs/local"
@@ -71,10 +72,10 @@ localprovisioner:
 snapshotOperator:
   enabled: true
   controller:
-    image: "quay.io/openebs/snapshot-controller"
+    image: "openebs/snapshot-controller"
     imageTag: "1.9.0"
   provisioner:
-    image: "quay.io/openebs/snapshot-provisioner"
+    image: "openebs/snapshot-provisioner"
     imageTag: "1.9.0"
   replicas: 1
   upgradeStrategy: "Recreate"
@@ -87,7 +88,7 @@ snapshotOperator:
 
 ndm:
   enabled: true
-  image: "quay.io/openebs/node-disk-manager-amd64"
+  image: "openebs/node-disk-manager-amd64"
   imageTag: "v0.4.9"
   sparse:
     path: "/var/openebs/sparse"
@@ -107,7 +108,7 @@ ndm:
 
 ndmOperator:
   enabled: true
-  image: "quay.io/openebs/node-disk-operator-amd64"
+  image: "openebs/node-disk-operator-amd64"
   imageTag: "v0.4.9"
   replicas: 1
   upgradeStrategy: Recreate
@@ -123,7 +124,7 @@ ndmOperator:
 
 webhook:
   enabled: true
-  image: "quay.io/openebs/admission-server"
+  image: "openebs/admission-server"
   imageTag: "1.9.0"
   failurePolicy: Ignore
   replicas: 1
@@ -135,33 +136,33 @@ webhook:
   affinity: {}
 
 jiva:
-  image: "quay.io/openebs/jiva"
+  image: "openebs/jiva"
   imageTag: "1.9.0"
   replicas: 3
   defaultStoragePath: "/var/openebs"
 
 cstor:
   pool:
-    image: "quay.io/openebs/cstor-pool"
+    image: "openebs/cstor-pool"
     imageTag: "1.9.0"
   poolMgmt:
-    image: "quay.io/openebs/cstor-pool-mgmt"
+    image: "openebs/cstor-pool-mgmt"
     imageTag: "1.9.0"
   target:
-    image: "quay.io/openebs/cstor-istgt"
+    image: "openebs/cstor-istgt"
     imageTag: "1.9.0"
   volumeMgmt:
-    image: "quay.io/openebs/cstor-volume-mgmt"
+    image: "openebs/cstor-volume-mgmt"
     imageTag: "1.9.0"
 
 helper:
-  image: "quay.io/openebs/linux-utils"
+  image: "openebs/linux-utils"
   imageTag: "1.9.0"
 
 policies:
   monitoring:
     enabled: true
-    image: "quay.io/openebs/m-exporter"
+    image: "openebs/m-exporter"
     imageTag: "1.9.0"
 
 analytics:


### PR DESCRIPTION
Signed-off-by: olivier beyler <olivier.beyler@orange.com>
#### Is this a new chart
no
#### What this PR does / why we need it:
In case of airgap, it's frequent to use a private docker registry and not neither docker.io or quay.io
It give the opportunity to change the docker repository from quai.io to private repository in one shot 
and evict to have to change all docker image in the helm chart 


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
