### PR TITLE
stable/chartmuseum: Allow to define a schedulerName

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.12.2
+version: 2.13.0
 appVersion: 0.12.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -70,13 +70,13 @@ The following table lists common configurable parameters of the chart and
 their default values. See values.yaml for all available options.
 
 | Parameter                               | Description                                                                 | Default                              |
-|-----------------------------------------|-----------------------------------------------------------------------------|--------------------------------------|
+| --------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------ |
 | `image.pullPolicy`                      | Container pull policy                                                       | `IfNotPresent`                       |
 | `image.repository`                      | Container image to use                                                      | `chartmuseum/chartmuseum`            |
-| `image.tag`                             | Container image tag to deploy                                               | `v0.12.0`                             |
+| `image.tag`                             | Container image tag to deploy                                               | `v0.12.0`                            |
 | `persistence.accessMode`                | Access mode to use for PVC                                                  | `ReadWriteOnce`                      |
 | `persistence.enabled`                   | Whether to use a PVC for persistent storage                                 | `false`                              |
-| `persistence.path`                      | PV mount path                                                               | `/storage`                              |
+| `persistence.path`                      | PV mount path                                                               | `/storage`                           |
 | `persistence.size`                      | Amount of space to claim for PVC                                            | `8Gi`                                |
 | `persistence.labels`                    | Additional labels for PVC                                                   | `{}`                                 |
 | `persistence.storageClass`              | Storage Class to use for PVC                                                | `-`                                  |
@@ -106,6 +106,7 @@ their default values. See values.yaml for all available options.
 | `nodeSelector`                          | Map of node labels for pod assignment                                       | `{}`                                 |
 | `tolerations`                           | List of node taints to tolerate                                             | `[]`                                 |
 | `affinity`                              | Map of node/pod affinities                                                  | `{}`                                 |
+| `schedulerName`                         | Kubernetes scheduler to use                                                 | `default`                            |
 | `env.open.STORAGE`                      | Storage Backend to use                                                      | `local`                              |
 | `env.open.STORAGE_ALIBABA_BUCKET`       | Bucket to store charts in for Alibaba                                       | ``                                   |
 | `env.open.STORAGE_ALIBABA_PREFIX`       | Prefix to store charts under for Alibaba                                    | ``                                   |

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{- if .Values.deployment.matchlabes }}
   selector:
     matchLabels:
-{{ toYaml .Values.deployment.matchlabes | indent 6 }}
+{{ toYaml .Values.deployment.matchlabels | indent 6 }}
 {{- end }}
   template:
     metadata:
@@ -160,6 +160,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      schedulerName: {{ .Values.deployment.schedulerName }}
+    {{- end -}}
     {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "chartmuseum.fullname" . }}
     {{- else if .Values.serviceAccount.name }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -119,12 +119,14 @@ env:
     CACHE_REDIS_PASSWORD:
 
 deployment:
+  # Define scheduler name. Use of 'default' if empty
+  schedulerName: ""
   ## Chartmuseum Deployment annotations
   annotations: {}
   #   name: value
   labels: {}
   #   name: value
-  matchlabes: {}
+  matchlabels: {}
   #   name: value
 replica:
   ## Chartmuseum Replicas annotations


### PR DESCRIPTION

#### What this PR does / why we need it:
Allows to define a `schedulerName`
example: https://github.com/libopenstorage/stork

