### PR TITLE
[stable/prometheus] Fix default non-HA state for alertmanager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.2.1
+version: 11.2.2
 appVersion: 2.18.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-statefulset.yaml
+++ b/stable/prometheus/templates/alertmanager-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
             - --cluster.peer={{ template "prometheus.alertmanager.fullname" $ }}-{{ $n }}.{{ template "prometheus.alertmanager.fullname" $ }}-headless:6783
           {{- end }}
           {{- else }}
-            - --cluster.listen-address=""
+            - --cluster.listen-address=
           {{- end }}
           {{- range $key, $value := .Values.alertmanager.extraArgs }}
             - --{{ $key }}={{ $value }}


### PR DESCRIPTION
Signed-off-by: Vesa Laakso <vesa.laakso@cfg.fi>

#### Is this a new chart
No

#### What this PR does / why we need it:
Since enableMeshPeer is false by default, cluster.listen-address should be empty.
Commit 5b4f507 caused regression and it is passing string as a parameter which is wrong. Documentation https://github.com/prometheus/alertmanager/blob/master/README.md#high-availability explicitly says cluster listen address should be defined like --cluster.listen-address= without passing an empty string.

#### Which issue this PR fixes
Regression caused by commit 5b4f507

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/prometheus]`)
