### PR TITLE
[stable/prometheus] Fix incorrect rendering of enableServiceLinks

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.2.2
+version: 11.2.3
 appVersion: 2.18.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -38,7 +38,11 @@ spec:
 {{- if .Values.server.schedulerName }}
       schedulerName: "{{ .Values.server.schedulerName }}"
 {{- end }}
-      enableServiceLinks: {{ .Values.server.enableServiceLinks | default "true" }}
+      {{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") }}
+      enableServiceLinks: true
+      {{- else }}
+      enableServiceLinks: false
+      {{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}


### PR DESCRIPTION
If `.Values.enableServiceLinks`  was set to `false`, `true` was still rendered.

cf. https://github.com/helm/helm/issues/3308

Signed-off-by: Yong Wen Chua <lawliet89@users.noreply.github.com>


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
