### PR TITLE
[stable/fluent-bit] Added `input.tail.exclude_path` parameter

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.17
+version: 2.9.0
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -137,6 +137,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.tail.ignore_older`          | Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax.        | ``                                             |
 | `input.tail.dockerMode`            | Recombine split Docker log lines before passing them to the parser.        | `false`                                             |
 | `input.tail.dockerModeFlush`       | Wait period time in seconds to flush queued unfinished split lines in docker mode.        | `4`                                             |
+| `input.tail.exclude_path`          | Exclude paths from tail input (`Exclude_Path` configuration parameter).        | ``                                             |
 | `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -45,6 +45,9 @@ data:
         Docker_Mode       On
         Docker_Mode_Flush {{ .Values.input.tail.dockerModeFlush }}
 {{- end }}
+{{- if .Values.input.tail.exclude_path }}
+        Exclude_Path    {{ .Values.input.tail.exclude_path }}
+{{- end }}
 {{- if .Values.input.systemd.enabled }}
     [INPUT]
         Name            systemd

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -250,6 +250,7 @@ input:
     ignore_older: ""
     dockerMode: false
     dockerModeFlush: 4
+    exclude_path: ""
   systemd:
     enabled: false
     filters:


### PR DESCRIPTION
Signed-off-by: Ivan Kurnosov <zerkms@zerkms.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

At the moment it's impossible to ignore some paths from being fed to the `tail` input, this PR simply adds another parameter

One of the real-life use cases: is to mute kibana logs (which cause problems): https://github.com/fluent/fluent-bit/issues/628#issuecomment-625644881

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
