### PR TITLE
[stable/minio] Prevent hook error on upgrade

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.30
+version: 5.0.31
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 {{- with .Values.makeBucketJob.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Prevent error such as the following on upgrade:

```
ERROR: Failed to install helm chart on namespace: xxxxx
Reason: Error: UPGRADE FAILED: post-upgrade hooks failed: warning: Hook post-upgrade build/charts/minio/templates/post-install-create-bucket-job.yaml failed: jobs.batch "minio-make-bucket-job" already exists
```

Work around: https://github.com/helm/helm/issues/8101

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
