### PR TITLE
[stable/jenkins] Adding override for ingress paths

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.21.0
+
+Add support for overriding Ingress paths via `master.ingress.paths`
+
 ## 1.20.0
 
   Add the following options for configuring the Kubernetes plugin.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.20.0
+version: 1.21.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -131,6 +131,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.ingress.annotations`      | Ingress annotations                  | `{}`                                      |
 | `master.ingress.labels`           | Ingress labels                       | `{}`                                      |
 | `master.ingress.path`             | Ingress path                         | Not set                                   |
+| `master.ingress.paths`            | Override for the default Ingress paths  | `[]`                                   |
 | `master.ingress.tls`              | Ingress TLS configuration            | `[]`                                      |
 | `master.backendconfig.enabled`     | Enables backendconfig     | `false`              |
 | `master.backendconfig.apiVersion`  | backendconfig API version | `extensions/v1beta1` |

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -21,11 +21,15 @@ spec:
   rules:
   - http:
       paths:
+{{- if len (.Values.master.ingress.paths) }}
+{{ tpl (toYaml .Values.master.ingress.paths | indent 6) . }}
+{{- else }}
       - backend:
           serviceName: {{ template "jenkins.fullname" . }}
           servicePort: {{ .Values.master.servicePort }}
 {{- if .Values.master.ingress.path }}
         path: {{ .Values.master.ingress.path }}
+{{- end -}}
 {{- end -}}
 {{- if .Values.master.ingress.hostName }}
     host: {{ .Values.master.ingress.hostName | quote }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -357,6 +357,16 @@ master:
 
   ingress:
     enabled: false
+    # Override for the default paths that map requests to the backend
+    paths: []
+    # - backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
+    # - backend:
+    #     serviceName: >-
+    #       {{ template "jenkins.fullname" . }}
+    #     # Don't use string here, use only integer value!
+    #     servicePort: 8080
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     apiVersion: "extensions/v1beta1"
     labels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is adding the possibility to override the default Ingress paths with a new block of paths defined as YAML data structure. This allows to configure the Ingress resource to work with the AWS ALB Ingress Controller to automatically [redirect HTTP traffic to HTTPS](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/) on the load balancer (@lachie83, @viglesiasce, @maorfr, @torstenwalter, @mogaal, @wmcdona89).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
