### PR TITLE
[stable/jenkins] Configure UI security in default JCasC

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.22.0
+
+Add support for UI security in the default JCasC via `master.JCasC.securityRealm` and `master.JCasC.authorizationStrategy` which deny anonymous access by default
+
 ## 1.21.3
 
 Render `agent.envVars` in kubernetes pod template JCasC

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.21.3
+version: 1.22.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -74,8 +74,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.markupFormatter`          | Yaml of the markup formatter to use  | `plainText`                               |
 | `master.customJenkinsLabels`      | Append Jenkins labels to the master  | `{}`                                      |
 | `master.useSecurity`              | Use basic security                   | `true`                                    |
-| `master.securityRealm`            | Custom Security Realm                | Not set                                   |
-| `master.authorizationStrategy`    | Jenkins XML job config for AuthorizationStrategy | Not set                       |
+| `master.securityRealm`            | Jenkins XML for Security Realm       | XML for `LegacySecurityRealm`             |
+| `master.authorizationStrategy`    | Jenkins XML for Authorization Strategy | XML for `FullControlOnceLoggedInAuthorizationStrategy` |
 | `master.deploymentLabels`         | Custom Deployment labels             | Not set                                   |
 | `master.serviceLabels`            | Custom Service labels                | Not set                                   |
 | `master.podLabels`                | Custom Pod labels                    | Not set                                   |
@@ -147,6 +147,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.JCasC.enabled`            | Wheter Jenkins Configuration as Code is enabled or not | `false`                 |
 | `master.JCasC.defaultConfig`      | Enables default Jenkins configuration via configuration as code plugin | `false` |
 | `master.JCasC.configScripts`      | List of Jenkins Config as Code scripts | `{}`                                    |
+| `master.JCasC.securityRealm`      | Jenkins Config as Code for Security Realm | `legacy`                             |
+| `master.JCasC.authorizationStrategy` | Jenkins Config as Code for Authorization Strategy | `loggedInUsersCanDoAnything` |
 | `master.enableXmlConfig`          | enables configuration done via XML files | `true`                               |
 | `master.sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                   |
 | `master.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `false`                                                      |
@@ -369,13 +371,12 @@ configScripts:
       securityRealm:
         ldap:
           configurations:
-            configurations:
-              - server: ldap.acme.com
-                rootDN: dc=acme,dc=uk
-                managerPasswordSecret: ${LDAP_PASSWORD}
-              - groupMembershipStrategy:
-                  fromUserRecord:
-                    attributeName: "memberOf"
+            - server: ldap.acme.com
+              rootDN: dc=acme,dc=uk
+              managerPasswordSecret: ${LDAP_PASSWORD}
+              groupMembershipStrategy:
+                fromUserRecord:
+                  attributeName: "memberOf"
 ```
 
 Further JCasC examples can be found [here.](https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos)

--- a/stable/jenkins/ci/casc-values.yaml
+++ b/stable/jenkins/ci/casc-values.yaml
@@ -2,10 +2,31 @@ master:
   JCasC:
     enabled: true
     defaultConfig: true
+    authorizationStrategy: |-
+      loggedInUsersCanDoAnything:
+        allowAnonymousRead: true
+    securityRealm: |-
+      ldap:
+        configurations:
+          - server: ldap.acme.com
+            rootDN: dc=acme,dc=uk
+            managerPasswordSecret: ${LDAP_PASSWORD}
+            groupMembershipStrategy:
+              fromUserRecord:
+                attributeName: "memberOf"
   sidecars:
     configAutoReload:
       enabled: true
+  enableXmlConfig: false
   healthProbeLivenessInitialDelay: 10
   healthProbeReadinessInitialDelay: 10
+  installPlugins:
+    - kubernetes:1.25.3
+    - workflow-job:2.38
+    - workflow-aggregator:2.6
+    - credentials-binding:1.21
+    - git:4.2.2
+    - configuration-as-code:1.39
+    - ldap:1.24
 persistence:
   enabled: false

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -72,6 +72,17 @@ Returns configuration as code default config
 */}}
 {{- define "jenkins.casc.defaults" -}}
 jenkins:
+{{- if eq .Values.master.enableXmlConfig false }}
+  {{- $configScripts := toYaml .Values.master.JCasC.configScripts }}
+  {{- if not (contains "authorizationStrategy:" $configScripts) }}
+  authorizationStrategy:
+    {{- tpl .Values.master.JCasC.authorizationStrategy . | nindent 4 }}
+  {{- end }}
+  {{- if not (contains "securityRealm:" $configScripts) }}
+  securityRealm:
+    {{- tpl .Values.master.JCasC.securityRealm . | nindent 4 }}
+  {{- end }}
+{{- end }}
   disableRememberMe: {{ .Values.master.disableRememberMe }}
   remotingSecurity:
     enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -268,6 +268,15 @@ master:
     enabled: false
     defaultConfig: false
     configScripts: {}
+    # Ignored if securityRealm is defined in master.JCasC.configScripts and
+    # ignored if master.enableXmlConfig=true as master.securityRealm takes precedence
+    securityRealm: |-
+      legacy
+    # Ignored if authorizationStrategy is defined in master.JCasC.configScripts and
+    # ignored if master.enableXmlConfig=true as master.authorizationStrategy takes precedence
+    authorizationStrategy: |-
+      loggedInUsersCanDoAnything:
+        allowAnonymousRead: false
     # welcome-message: |
     #   jenkins:
     #     systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Add support for UI security in the default JCasC via `master.JCasC.securityRealm` and `master.JCasC.authorizationStrategy` which deny anonymous access by default.

For backwards compatibility, `master.JCasC.securityRealm` and `master.JCasC.authorizationStrategy` are not configured in the default JCasC if `securityRealm` and `authorizationStrategy` are configured in `master.JCasC.configScripts` or if XML configuration is enabled as it configures `master.securityRealm` and `master.authorizationStrategy` which take precedence.

#### values.yaml
```yaml
master:
  JCasC:
    # Ignored if securityRealm is defined in master.JCasC.configScripts and
    # ignored if master.enableXmlConfig=true as master.securityRealm takes precedence
    securityRealm: |-
      legacy
    # Ignored if authorizationStrategy is defined in master.JCasC.configScripts and
    # ignored if master.enableXmlConfig=true as master.authorizationStrategy takes precedence
    authorizationStrategy: |-
      loggedInUsersCanDoAnything:
        allowAnonymousRead: false
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
### Default `master.JCasC.securityRealm` and `master.JCasC.authorizationStrategy`
#### helm template
default JCasC with auto-reload (jcasc-config.yaml)
```bash
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--set master.sidecars.configAutoReload.enabled=true \
--set master.enableXmlConfig=false
```
```yaml
data:
  jcasc-default-config.yaml: |-
    jenkins:
      authorizationStrategy:
        loggedInUsersCanDoAnything:
          allowAnonymousRead: false
      securityRealm:
        legacy
```
#### helm install
```bash
helm install ui-security-test stable/jenkins \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true \
--set master.sidecars.configAutoReload.enabled=true \
--set master.enableXmlConfig=false
```
#### Jenkins URL screenshot
![image](https://user-images.githubusercontent.com/7925481/82778540-b2d99480-9e1f-11ea-8a89-84ff1b4bf39e.png)

### Override `master.JCasC.securityRealm` and `master.JCasC.authorizationStrategy`
Given the following in `stable/jenkins/ci/casc-values.yaml` with `securityRealm` being the example from the README and the ldap plugin included in `master.installPlugins`.
```yaml
master:
  JCasC:
    authorizationStrategy: |-
      loggedInUsersCanDoAnything:
        allowAnonymousRead: true
    securityRealm: |-
      ldap:
        configurations:
          - server: ldap.acme.com
            rootDN: dc=acme,dc=uk
            managerPasswordSecret: ${LDAP_PASSWORD}
            groupMembershipStrategy:
              fromUserRecord:
                attributeName: "memberOf"
  installPlugins:
    - kubernetes:1.25.3
    - workflow-job:2.38
    - workflow-aggregator:2.6
    - credentials-binding:1.21
    - git:4.2.2
    - configuration-as-code:1.39
    - ldap:1.24
```
#### helm template
default JCasC with auto-reload (jcasc-config.yaml)
```bash
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--values stable/jenkins/ci/casc-values.yaml
```
```yaml
data:
  jcasc-default-config.yaml: |-
    jenkins:
      authorizationStrategy:
        loggedInUsersCanDoAnything:
          allowAnonymousRead: true
      securityRealm:
        ldap:
          configurations:
            - server: ldap.acme.com
              rootDN: dc=acme,dc=uk
              managerPasswordSecret: ${LDAP_PASSWORD}
              groupMembershipStrategy:
                fromUserRecord:
                  attributeName: "memberOf"
```
#### helm install
```bash
helm install ui-security-test stable/jenkins \
--values stable/jenkins/ci/casc-values.yaml
```
#### Jenkins URL screenshot
![image](https://user-images.githubusercontent.com/7925481/82778765-4e6b0500-9e20-11ea-997a-b1ef859a2ab9.png)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
