### PR TITLE
[stable/prometheus-cloudwatch-exporter] Add aws.externalID value

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.7.0
+version: 0.8.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -61,7 +61,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `service.annotations`             | Custom annotations for service                                          | `{}`                        |
 | `service.labels`                  | Additional custom labels for the service                                | `{}`                        |
 | `resources`                       |                                                                         | `{}`                        |
-| `aws.role`                        | AWS IAM Role To Use                                                     |                             |
+| `aws.role`                        | AWS IAM Role to use                                                     |                             |
+| `aws.externalID`                  | AWS External ID to use when role specified                              |                             |
 | `aws.aws_access_key_id`           | AWS access key id                                                       |                             |
 | `aws.aws_secret_access_key`       | AWS secret access key                                                   |                             |
 | `aws.secret.name`                 | The name of a pre-created secret in which AWS credentials are stored    |                             |

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -19,7 +19,10 @@ spec:
         app: {{ template "prometheus-cloudwatch-exporter.name" . }}
         release: {{ .Release.Name }}
       annotations:
-        {{ if .Values.aws.role}}iam.amazonaws.com/role: {{ .Values.aws.role }}{{ end }}
+        {{ if .Values.aws.role}}
+        iam.amazonaws.com/role: {{ .Values.aws.role }}
+        {{ if .Values.aws.externalID}}iam.amazonaws.com/external-id: {{ .Values.aws.externalID }}{{ end }}
+        {{ end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -44,6 +44,9 @@ resources: {}
 
 aws:
   role:
+  # External ID can be used when a role is specified.
+  # https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/
+  externalID:
 
   # The name of a pre-created secret in which AWS credentials are stored. When
   # set, aws_access_key_id is assumed to be in a field called access_key,


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR adds a new value named `aws.externalID` which can be used when `aws.role` is specified.
#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
