### PR TITLE
[stable/mongodb-replicaset] Lifecycle hooks

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.15.0
+version: 3.15.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -79,8 +79,6 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `metrics.securityContext.enabled`   | Enable security context                                                   | `true`                                              |
 | `metrics.securityContext.fsGroup`   | Group ID for the metrics container                                        | `1001`                                              |
 | `metrics.securityContext.runAsUser` | User ID for the metrics container                                         | `1001`                                              |
-| `metrics.socketTimeout`             | Time to wait for a non-responding socket                                  | `3s`                                                |
-| `metrics.syncTimeout`               | Time an operation with this session will wait before returning an error   | `1m`                                                |
 | `metrics.prometheusServiceDiscovery`| Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |
 | `auth.enabled`                      | If `true`, keyfile access control is enabled                              | `false`                                             |
 | `auth.key`                          | Key for internal authentication                                           | ``                                                  |

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `metrics.securityContext.fsGroup`   | Group ID for the metrics container                                        | `1001`                                              |
 | `metrics.securityContext.runAsUser` | User ID for the metrics container                                         | `1001`                                              |
 | `metrics.prometheusServiceDiscovery`| Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |
+| `metrics.lifecycle`                 | Lifecycle hooks for the MongoDB metrics container                         | `{}`                                                |
 | `auth.enabled`                      | If `true`, keyfile access control is enabled                              | `false`                                             |
 | `auth.key`                          | Key for internal authentication                                           | ``                                                  |
 | `auth.existingKeySecret`            | If set, an existing secret with this name for the key is used             | ``                                                  |

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -251,8 +251,6 @@ spec:
             - >-
               /bin/mongodb_exporter
               --mongodb.uri {{ template "mongodb-replicaset.connection-string" . }}
-              --mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
-              --mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
               --web.telemetry-path={{ .Values.metrics.path }}
               --web.listen-address=:{{ .Values.metrics.port }}
           volumeMounts:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -246,7 +246,7 @@ spec:
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
-            - sh
+            - bash
             - -c
             - >-
               /bin/mongodb_exporter

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -284,6 +284,10 @@ spec:
           securityContext:
             runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
           {{- end }}
+          {{- with .Values.metrics.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -67,12 +67,10 @@ metrics:
   enabled: false
   image:
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r71
+    tag: 0.11.0
     pullPolicy: IfNotPresent
   port: 9216
   path: "/metrics"
-  socketTimeout: 3s
-  syncTimeout: 1m
   prometheusServiceDiscovery: true
   resources: {}
   securityContext:

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -76,6 +76,7 @@ metrics:
   securityContext:
     enabled: true
     runAsUser: 1001
+  lifecycle: {}
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}

--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.0.0
+version: 4.1.0
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -69,6 +69,8 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `allowIcmp`                               | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
 | `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
 | `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
+| `livenessProbe`                           | Container liveness probe                                                         | See values.yaml                                                              |
+| `readinessProbe`                          | Container readiness probe                                                        | See values.yaml                                                              |
 | `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
 | `service.labels`                          | additional labels for the service                                                | None                                                                         |
 | `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |

--- a/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -77,13 +77,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               name: http
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           volumeMounts:
             - mountPath: /config
               name: config

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -82,13 +82,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               name: http
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           volumeMounts:
             - mountPath: /config
               name: config

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -31,6 +31,16 @@ runAsUser: 1000
 readOnlyRootFilesystem: true
 runAsNonRoot: true
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add lifecycle hooks for the MongoDB and Metrics container. This requires #22241. 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
