### PR TITLE
[stable/fluentd] Switched to new registry location and update image

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.4.1
-appVersion: v2.4.0
+version: 2.5.0
+appVersion: v2.8.0
 home: https://www.fluentd.org/
 sources:
 - https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image
-- https://quay.io/repository/coreos/fluentd-kubernetes
+- https://quay.io/repository/fluentd_elasticsearch/fluentd
 - https://github.com/coreos/fluentd-kubernetes-daemonset
 - https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 maintainers:

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: gcr.io/google-containers/fluentd-elasticsearch
-  tag: v2.4.0
+  repository: quay.io/fluentd_elasticsearch/fluentd
+  tag: v2.8.0
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - secret1


### PR DESCRIPTION
Switches the location of the registry to the official location as per:
https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image/README.md

Bumped the version (v2.8.0) to the image referenced as per the current stable Kubernetes tag (1.18.2).

This fixes using an outdated and unsupported version of Ruby (2.3).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
