### PR TITLE
[stable/jenkins] Render agent.nodeSelector in pod template JCasC

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.21.1
+
+Render `agent.nodeSelector` in the kubernetes pod template JCasC
+
 ## 1.21.0
 
 Add support for overriding Ingress paths via `master.ingress.paths`

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.21.0
+version: 1.21.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -223,6 +223,7 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}` |
 | `agent.volumes`            | Additional volumes                              | `[]`                   |
 | `agent.envVars`            | Environment variables for the agent Pod         | `[]`                   |
+| `agent.nodeSelector`       | Node labels for pod assignment                  | `{}`                   |
 | `agent.command`            | Executed command when side container starts     | Not set                |
 | `agent.args`               | Arguments passed to executed command            | `${computer.jnlpmac} ${computer.name}` |
 | `agent.sideContainerName`  | Side container name in agent                    | jnlp                   |

--- a/stable/jenkins/ci/other-values.yaml
+++ b/stable/jenkins/ci/other-values.yaml
@@ -7,6 +7,17 @@ agent:
     limits:
       cpu: "1"
       memory: "2048Mi"
+  nodeSelector:
+    "app.kubernetes.io/component": "{{ .Values.agent.componentName }}"
+  yamlTemplate: |-
+    apiVersion: v1
+    kind: Pod
+    spec:
+      tolerations:
+        - key: "app.kubernetes.io/component"
+          operator: "Equal"
+          value: "{{ .Values.agent.componentName }}"
+          effect: "NoSchedule"
   additionalAgents:
     maven:
       podName: maven

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -188,6 +188,15 @@ Returns kubernetes pod template configuration as code
   - name: {{ .Values.agent.imagePullSecretName }}
   {{- end }}
   label: "{{ .Release.Name }}-{{ .Values.agent.componentName }} {{ .Values.agent.customJenkinsLabels  | join " " }}"
+{{- if .Values.agent.nodeSelector }}
+  nodeSelector:
+  {{- $local := dict "first" true }}
+  {{- range $key, $value := .Values.agent.nodeSelector }}
+    {{- if $local.first }} {{ else }},{{ end }}
+    {{- $key }}={{ tpl $value $ }}
+    {{- $_ := set $local "first" false }}
+  {{- end }}
+{{- end }}
   nodeUsageMode: "NORMAL"
   podRetention: {{ .Values.agent.podRetention }}
   showRawYaml: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Render `agent.nodeSelector` in the kubernetes pod template JCasC.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

### helm template
Given the following in stable/jenkins/agent-values.yaml
```yaml
agent:
  nodeSelector:
    "app.kubernetes.io/component": "{{ .Values.agent.componentName }}"
    "env": "dev"
```
default JCasC with auto-reload (jcasc-config.yaml)
```bash
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--values stable/jenkins/ci/casc-values.yaml \
--values stable/jenkins/agent-values.yaml
```

rendering of `agent.nodeSelector` in kubernetes pod template nodeSelector
```yaml
data:
  jcasc-default-config.yaml: |-
    jenkins:
      clouds:
      - kubernetes:
          templates:
            - name: "default"
              nodeSelector: app.kubernetes.io/component=jenkins-slave,env=dev
```
### helm install
```bash
helm install nodeselector-test stable/jenkins \
--values stable/jenkins/ci/casc-values.yaml \
--values stable/jenkins/agent-values.yaml \
--set master.enableXmlConfig=false
```

Jenkins Configure Clouds screenshot
![image](https://user-images.githubusercontent.com/7925481/82170803-7fcd5900-9893-11ea-865c-45f91368f5b6.png)


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
