### PR TITLE
stable/unifi implements subPath functionality

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.7.0
+version: 0.8.0
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -111,6 +111,7 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `persistence.enabled`                           | `true`                       | Use persistent volume to store data                                                                                    |
 | `persistence.size`                              | `5Gi`                        | Size of persistent volume claim                                                                                        |
 | `persistence.existingClaim`                     | `nil`                        | Use an existing PVC to persist data                                                                                    |
+| `persistence.subPath`                           | ``                           | Store data in a subdirectory of PV instead of at the root directory                                                    |
 | `persistence.storageClass`                      | `-`                          | Type of persistent volume claim                                                                                        |
 | `persistence.accessModes`                       | `[]`                         | Persistence access modes                                                                                               |
 | `extraConfigFiles`                              | `{}`                         | Dictionary containing files mounted to `/configmap` inside the pod (See [values.yaml](values.yaml) for examples)       |

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -104,16 +104,16 @@ spec:
           volumeMounts:
             - mountPath: /unifi/data
               name: unifi-data
-              subPath: data
+              subPath: {{ ternary "data" (printf "%s/%s" .Values.persistence.subPath "data") (empty .Values.persistence.subPath) }}
             - mountPath: /unifi/log
               name: unifi-data
-              subPath: log
+              subPath: {{ ternary "log" (printf "%s/%s" .Values.persistence.subPath "log") (empty .Values.persistence.subPath) }}
             - mountPath: /unifi/cert
               name: unifi-data
-              subPath: cert
+              subPath: {{ ternary "cert" (printf "%s/%s" .Values.persistence.subPath "cert") (empty .Values.persistence.subPath) }}
             - mountPath: /unifi/init.d
               name: unifi-data
-              subPath: init.d
+              subPath: {{ ternary "init.d" (printf "%s/%s" .Values.persistence.subPath "init.d") (empty .Values.persistence.subPath) }}
             {{- if .Values.extraConfigFiles }}
             - name: extra-config
               mountPath: /configmap

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -209,6 +209,9 @@ persistence:
   ## If you want to reuse an existing claim, you can pass the name of the PVC using
   ## the existingClaim variable
   # existingClaim: your-claim
+  #
+  ## Applies a prefix to the directories created by the unifi container
+  # subPath: unifi
   accessMode: ReadWriteOnce
   size: 5Gi
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
The unifi chart can now be configured with subPath to store data in a subdirectory of existing PVs instead of only at the root directory.

#### Which issue this PR fixes
No issues linked to this PR.

#### Special notes for your reviewer:
Hi @billimek @mcronce, this PR implements the same informal standard for subPath as many other charts like stable/nextcloud, stable/prometheus, etc.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
