### PR TITLE
[incubator/sparkoperator] Add webhookNamespaceSelector

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.6.13
+version: 0.6.14
 appVersion: v1beta2-1.1.1-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.6.14
+version: 0.7.0
 appVersion: v1beta2-1.1.1-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/README.md
+++ b/incubator/sparkoperator/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the Spark operator char
 | `podAnnotations`          | Annotations to be added to pods                              | `{}`                                   |
 | `resyncInterval`          | Informer resync interval in seconds                          | 30                                     |
 | `webhookPort`             | Service port of the webhook server                           | 8080                                   |
+| `webhookNamespaceSelector`| The webhook will only operate on namespaces with this label, specified in the form key1=value1,key2=value2 | `""` |
 | `resources`               | Resources needed for the sparkoperator deployment            | {}                                     |
 | `enableBatchScheduler`    | Whether to enable batch scheduler for pod scheduling         | false                                  |
 | `enableResourceQuotaEnforcement`    | Whether to enable the ResourceQuota enforcement for SparkApplication resources. Requires the webhook to be enabled by setting enableWebhook to true.         | false                                  |
@@ -69,6 +70,7 @@ The following table lists the configurable parameters of the Spark operator char
 | `leaderElection.lockName` | Lock name to use for leader election                         | `spark-operator-lock`                  |
 | `leaderElection.lockNamespace` | Namespace to use for leader election                    | (namespace of release)                 |
 | `securityContext` | Defines security context for operator container. | `{}` |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 #### Upgrading

--- a/incubator/sparkoperator/ci/test-values.yaml
+++ b/incubator/sparkoperator/ci/test-values.yaml
@@ -25,6 +25,9 @@ securityContext: {}
 
 enableWebhook: false
 webhookPort: 8080
+## The webhook will only operate on namespaces with this label, specified in the form key1=value1,key2=value2
+## empty string will operate on all namespaces
+webhookNamespaceSelector: ""
 
 enableMetrics: true
 metricsPort: 10254

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -90,6 +90,7 @@ spec:
         - -webhook-port={{ .Values.webhookPort }}
         - -webhook-svc-name={{ .Release.Name }}-webhook
         - -webhook-config-name={{ include "sparkoperator.fullname" . }}-webhook-config
+        - -webhook-namespace-selector={{ .Values.webhookNamespaceSelector }}
         {{- end }}
         {{- if .Values.enableResourceQuotaEnforcement }}
         - -enable-resource-quota-enforcement={{ .Values.enableResourceQuotaEnforcement }}

--- a/incubator/sparkoperator/values.yaml
+++ b/incubator/sparkoperator/values.yaml
@@ -25,6 +25,9 @@ securityContext: {}
 
 enableWebhook: false
 webhookPort: 8080
+## The webhook will only operate on namespaces with this label, specified in the form key1=value1,key2=value2
+## empty string will operate on all namespaces
+webhookNamespaceSelector: ""
 
 enableMetrics: true
 metricsPort: 10254


### PR DESCRIPTION
Signed-off-by: Hagai Barel <hagaibarel@gmail.com>

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
@yuchaoran2011 

#### What this PR does / why we need it:
Add webhook namespace selector option to allow the webhook to only operate on specific namespaces 

#### Which issue this PR fixes
  - fixes #22433 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
