### PR TITLE
[stable/prometheus-couchdb-exporter] Changed initialDelaySeconds to be a configuration of livenessProbe/readinessProbe

### DIFF
--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -43,12 +43,12 @@ spec:
             httpGet:
               path: /
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}


### PR DESCRIPTION
According to this doc: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ initialDelaySeconds is a configuration of livenessProbe/readinessProbe and not httpGet

The helm charts returns the following error:

`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction]`

For K8s version:

```
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-16T11:56:40Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"15+", GitVersion:"v1.15.9-gke.24", GitCommit:"39e41a8d6b7221b901a95d3af358dea6994b4a40", GitTreeState:"clean", BuildDate:"2020-02-29T01:24:35Z", GoVersion:"go1.12.12b4", Compiler:"gc", Platform:"linux/amd64"}
```

And helm version:

```
version.BuildInfo{Version:"v3.2.0", GitCommit:"e11b7ce3b12db2941e90399e874513fbd24bcb71", GitTreeState:"clean", GoVersion:"go1.13.10"}
```