### PR TITLE
[stable/jenkins] Render agent.envVars in kubernetes pod template JCasC

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.21.3
+
+Render `agent.envVars` in kubernetes pod template JCasC
+
 ## 1.21.2
 
 Cleanup `agent.yamlTemplate` rendering in kubernetes pod template XML configuration

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.21.2
+version: 1.21.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/ci/other-values.yaml
+++ b/stable/jenkins/ci/other-values.yaml
@@ -7,6 +7,11 @@ agent:
     limits:
       cpu: "1"
       memory: "2048Mi"
+  envVars:
+    - name: HOME
+      value: /home/jenkins
+    - name: PATH
+      value: /usr/local/bin
   nodeSelector:
     "app.kubernetes.io/component": "{{ .Values.agent.componentName }}"
   yamlTemplate: |-

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -181,6 +181,14 @@ Returns kubernetes pod template configuration as code
     resourceRequestMemory: {{.Values.agent.resources.requests.memory}}
     ttyEnabled: {{ .Values.agent.TTYEnabled }}
     workingDir: "/home/jenkins"
+{{- if .Values.agent.envVars }}
+  envVars:
+  {{- range $index, $var := .Values.agent.envVars }}
+    - envVar:
+        key: {{ $var.name }}
+        value: {{ tpl $var.value $ }}
+  {{- end }}
+{{- end }}
   idleMinutes: {{ .Values.agent.idleMinutes }}
   instanceCap: 2147483647
   {{- if .Values.agent.imagePullSecretName }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Render `agent.envVars` in kubernetes pod template JCasC

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
### helm template
Given the following in stable/jenkins/ci/other-values.yaml
```yaml
agent:
  envVars:
    - name: HOME
      value: /home/jenkins
    - name: PATH
      value: /usr/local/bin
```
default JCasC with auto-reload (jcasc-config.yaml)
```bash
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--values stable/jenkins/ci/casc-values.yaml \
--values stable/jenkins/ci/other-values.yaml
```

rendering of `agent.envVars` in kubernetes pod template envVars
```yaml
data:
  jcasc-default-config.yaml: |-
    jenkins:
      clouds:
      - kubernetes:
          templates:
            - name: "default"
              envVars:
                - envVar:
                    key: HOME
                    value: /home/jenkins
                - envVar:
                    key: PATH
                    value: /usr/local/bin
```
### helm install
```bash
helm install envvar-test stable/jenkins \
--values stable/jenkins/ci/casc-values.yaml \
--values stable/jenkins/ci/other-values.yaml \
--set master.enableXmlConfig=false
```

Jenkins Configure Clouds screenshot
![image](https://user-images.githubusercontent.com/7925481/82280281-87a50000-995c-11ea-93b8-334f463a13e3.png)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
