### PR TITLE
[stable/unifi] Adding secretName variable to customCert

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.8.0
+version: 0.8.1
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -102,8 +102,9 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `GID`                                           | `999`                        | Run the controller as group GID                                                                                        |
 | `customCert.enabled`                            | `false`                      | Define whether you are using s custom certificate                                                                      |
 | `customCert.isChain`                            | `false`                      | If you are using a Let's Encrypt certificate which already includes the full chain set this to `true`                  |
-| `customCert.certName`                           | `cert.pem`                   | Name of the the certificate file in `<unifi-data>/cert`                                                                |
-| `customCert.keyName`                            | `privkey.pem`                | Name of the the private key file in `<unifi-data>/cert`                                                                |
+| `customCert.certName`                           | `tls.crt`                    | Name of the the certificate file in `<unifi-data>/cert`                                                                |
+| `customCert.keyName`                            | `tls.key`                    | Name of the the private key file in `<unifi-data>/cert`                                                                |
+| `customCert.secretName`                         | `unifi-tls`                  | Name of the the k8s tls secret where the certificate and its key are stored.                                           |
 | `mongodb.enabled`                               | `false`                      | Use external MongoDB for data storage                                                                                  |
 | `mongodb.dbUri`                                 | `mongodb://mongo/unifi`      | external MongoDB URI                                                                                                   |
 | `mongodb.statDbUri`                             | `mongodb://mongo/unifi_stat` | external MongoDB statdb URI                                                                                            |

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -101,6 +101,14 @@ spec:
             - name: DB_NAME
               value: "{{ .Values.mongodb.databaseName }}"
             {{- end }}
+            {{- if and .Values.customCert .Values.customCert.enabled }}
+            - name: CERT_IS_CHAIN
+              value: "{{ .Values.customCert.isChain }}"
+            - name: CERTNAME
+              value: "{{ .Values.customCert.certName }}"
+            - name: CERT_PRIVATE_NAME
+              value: "{{ .Values.customCert.keyName }}"
+            {{- end }}
           volumeMounts:
             - mountPath: /unifi/data
               name: unifi-data
@@ -109,22 +117,18 @@ spec:
               name: unifi-data
               subPath: {{ ternary "log" (printf "%s/%s" .Values.persistence.subPath "log") (empty .Values.persistence.subPath) }}
             - mountPath: /unifi/cert
+              {{- if and .Values.customCert .Values.customCert.enabled .Values.customCert.certSecret }}
+              name: unifi-cert-secret
+              {{- else }}
               name: unifi-data
               subPath: {{ ternary "cert" (printf "%s/%s" .Values.persistence.subPath "cert") (empty .Values.persistence.subPath) }}
+              {{- end }}
             - mountPath: /unifi/init.d
               name: unifi-data
               subPath: {{ ternary "init.d" (printf "%s/%s" .Values.persistence.subPath "init.d") (empty .Values.persistence.subPath) }}
             {{- if .Values.extraConfigFiles }}
             - name: extra-config
               mountPath: /configmap
-            {{- end }}
-            {{- if and .Values.customCert .Values.customCert.enabled }}
-            - name: CERT_IS_CHAIN
-              value: "{{ .Values.customCert.isChain }}"
-            - name: CERTNAME
-              value: "{{ .Values.customCert.certName }}"
-            - name: CERT_PRIVATE_NAME
-              value: "{{ .Values.customCert.keyName }}"
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -140,6 +144,11 @@ spec:
         - name: extra-config
           configMap:
             name: {{ template "unifi.fullname" . }}
+        {{- end }}
+        {{- if and .Values.customCert .Values.customCert.enabled .Values.customCert.certSecret }}
+        - name: unifi-cert-secret
+          secret:
+            secretName: "{{ .Values.customCert.certSecret }}"
         {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -185,8 +185,11 @@ GID: 999
 customCert:
   enabled: false
   isChain: false
-  certName: cert.pem
-  keyName: privkey.pem
+  certName: tls.crt
+  keyName: tls.key
+  # If you want to store certificate and its key as a Kubernetes tls secret
+  # you can pass the name of that secret using certSecret variable
+  # certSecret: unifi-tls
 
 # define an external mongoDB instead of using the built-in mongodb
 mongodb:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Kubernetes provides a way to expose TLS certificates to pods via secret/tls. This PR adds possibility to expose certificate and its key via such a secret. 

#### Which issue this PR fixes
no issue reported for this feature

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
