### PR TITLE
[stable/grafana] Remove duplicate roleref in grafana rolebinding

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.25
+version: 5.0.26
 appVersion: 6.7.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/rolebinding.yaml
+++ b/stable/grafana/templates/rolebinding.yaml
@@ -18,10 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "grafana.serviceAccountName" . }}
   namespace: {{ template "grafana.namespace" . }}
-{{- if .Values.rbac.namespaced }}
-roleRef:
-  kind: Role
-  name: {{ template "grafana.fullname" . }}
-  apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
When Grafana is "namespaced", an additional roleref (**identical to the initial roleref**) is added to the rolebinding.
It ends up in errors on installation/upgrade when using post-renderer that expects non-duplicate yaml keys

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
