### PR TITLE
[stable/datadog] Allow pre-release versions as docker image tag

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.3
+
+* Allow pre-release versions as docker image tag
+
 ## 2.3.2
 
 * Update the DCA RBAC to allow it to create events in the HPA

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.2
+version: 2.3.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -13,7 +13,7 @@
 {{- if and (eq $length 1) (eq $version "latest") -}}
 {{- $version = "7.19.0" -}}
 {{- end -}}
-{{- if not (semverCompare "^6.19.0 || ^7.19.0" $version) -}}
+{{- if not (semverCompare "^6.19.0-0 || ^7.19.0-0" $version) -}}
 {{- fail "This version of the chart requires an agent image 7.19.0 or greater. If you want to force and skip this check, use `--set agents.image.doNotCheckTag=true`" -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

Allow pre-release versions as docker image tag.

#### Which issue this PR fixes

Trying to use a pre-release version that matches the version requirement failed.
For example, using `7.20.0-rc.2` as `agents.image.tag` was unexpectingly generating the following error:
```
This version of the chart requires an agent image 7.19.0 or greater.
```

#### Special notes for your reviewer:

See http://masterminds.github.io/sprig/semver.html#working-with-prerelease-versions

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
