### PR TITLE
[stable/graylog] allow image pull secrects in graylog and cleaned up README.md

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.6.3
+version: 1.6.4
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/README.md
+++ b/stable/graylog/README.md
@@ -187,7 +187,6 @@ The following table lists the configurable parameters of the Graylog chart and t
 | `serviceAccount.name`                          | Name of the server service account to use or create                                                                                                   | `{{ graylog.fullname }}`          |
 | `tags.install-mongodb`                         | If true, this chart will install MongoDB from requirement dependencies. If you want to install MongoDB by yourself, please set to `false`             | `true`                            |
 | `tags.install-elasticsearch`                   | If true, this chart will install Elasticsearch from requirement dependencies. If you want to install Elasticsearch by yourself, please set to `false` | `true`                            |
-| `tags.install-elasticsearch`                   | If true, this chart will install Elasticsearch from requirement dependencies. If you want to install Elasticsearch by yourself, please set to `false` | `true`                            |
 | `imagePullSecrets`                             | Configuration for [imagePullSecrets][3] so that you can use a private registry for your images                                                        | `[]`                              |
 
 ## How it works

--- a/stable/graylog/README.md
+++ b/stable/graylog/README.md
@@ -1,9 +1,10 @@
 # Graylog
 
-This chart provide the [Graylog](https://www.graylog.org/) deployments.
+This chart provide the [Graylog][1] deployments.
 Note: It is strongly recommend to use on Official Graylog image to run this chart.
 
 ## Quick Installation
+
 This chart requires the following charts before install Graylog
 
 1. MongoDB
@@ -18,6 +19,7 @@ helm install --namespace "graylog" -n "graylog" stable/graylog
 ```
 
 ## Manually Install Dependencies
+
 This method is *recommended* when you want to expand the availability, scalability, and security of the services. You need to install MongoDB replicaset and Elasticsearch with proper settings before install Graylog.
 
 To install MongoDB, run
@@ -35,6 +37,7 @@ helm install --namespace "graylog" -n "elasticsearch" stable/elasticsearch
 Note: There are many alternative Elasticsearch available on GitHub. If you found the `stable/elasticsearch` is not suitable, you can search other charts from GitHub repositories.
 
 ## Install Chart
+
 To install the Graylog Chart into your Kubernetes cluster (This Chart requires persistent volume by default, you may need to create a storage class before install chart.
 
 ```bash
@@ -52,11 +55,13 @@ helm status "graylog"
 ```
 
 If you want to delete your Chart, use this command
+
 ```bash
 helm delete --purge "graylog"
 ```
 
 ## Install Chart with specific Graylog cluster size
+
 By default, this Chart will create a graylog with 2 nodes (1 master, 1 coordinating). If you want to change the cluster size during installation, you can use `--set graylog.replicas={value}` argument. Or edit `values.yaml`
 
 For example:
@@ -69,9 +74,11 @@ helm install --namespace "graylog" -n "graylog" --set graylog.replicas=5 stable/
 The command above will install 1 master and 4 coordinating.
 
 ## Install Chart with specific node pool
+
 Sometime you may need to deploy your graylog to specific node pool to allocate resources.
 
 ### Using node selector
+
 For example, you have 6 vms in node pools and you want to deploy graylog to node which labeled as `cloud.google.com/gke-nodepool: graylog-pool`
 Set the following values in `values.yaml`
 
@@ -81,6 +88,7 @@ graylog:
 ```
 
 ### Using tolerations
+
 For example, you have 6 vms in node pools and 3 nodes are tainted with `NO_SCHEDULE graylog=true`
 Set the following values in `values.yaml`
 
@@ -96,99 +104,103 @@ graylog:
 
 The following table lists the configurable parameters of the Graylog chart and their default values.
 
-| Parameter                               | Description                                                                                                                                           | Default                               |
-|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `graylog.image.repository`              | `graylog` image repository   | `graylog/graylog:3.1`                 |
-| `graylog.imagePullPolicy`               | Image pull policy                                                                                                                                     | `IfNotPresent`                        |
-| `graylog.replicas`                      | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                                   |
-| `graylog.resources`                     | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`         |
-| `graylog.heapSize`                      | Override Java heap size. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`                                   | ``                                    |
-| `graylog.externalUri`                   | External URI that Graylog is available at                                                                                                             | ``                                    |
-| `graylog.nodeSelector`                  | Graylog server pod assignment                                                                                                                         | `{}`                                  |
-| `graylog.affinity`                      | Graylog server affinity                                                                                                                               | `{}`                                  |
-| `graylog.tolerations`                   | Graylog server tolerations                                                                                                                            | `[]`                                  |
-| `graylog.nodeSelector`                  | Graylog server node selector                                                                                                                          | `{}`                                  |
-| `graylog.env`                           | Graylog server env variables                                                                                                                          | `{}`                                  |
-| `graylog.envRaw`                        | Graylog server env variables in raw yaml format                                                                                                       | `{}`                                  |
-| `graylog.privileged`                    | Run as a privileged container                                                                                                        | `false`                                                |
-| `graylog.additionalJavaOpts`            | Graylog service additional `JAVA_OPTS`                                                                                                                | ``                                    |
-| `graylog.service.type`                  | Kubernetes Service type                                                                                                                               | `ClusterIP`                           |
-| `graylog.service.port`                  | Graylog Service port                                                                                                                                  | `9000`                                |
-| `graylog.service.ports`                 | Graylog Service extra ports                                                                                                                           | `[]`                                  |
-| `graylog.service.master.enabled`        | If true, Graylog Master Service will be created                                                                                                       | `true`                                |
-| `graylog.service.master.port`           | Graylog Master Service port                                                                                                                           | `9000`                                |
-| `graylog.service.master.annotations`    | Graylog Master Service annotations                                                                                                                    | `{}`                                  |
-| `graylog.service.headless.suffix`       | If present, suffix appended to the name of the chart to form the headless service name, ie: `-headless` would result in `graylog-headless`            | ``                                    |
-| `graylog.podAnnotations`                | Kubernetes Pod annotations                                                                                                                            | `{}`                                  |
-| `graylog.terminationGracePeriodSeconds` | Pod termination grace period                                                                                                                          | `120`                                 |
-| `graylog.updateStrategy`                | Update Strategy of the StatefulSet                                                                                                                    | `RollingUpdate`                           |
-| `graylog.persistence.enabled`           | Use a PVC to persist data                                                                                                                             | `true`                                |
-| `graylog.persistence.storageClass`      | Storage class of backing PVC                                                                                                                          | `nil` (uses storage class annotation) |
-| `graylog.persistence.accessMode`        | Use volume as ReadOnly or ReadWrite                                                                                                                   | `ReadWriteOnce`                       |
-| `graylog.persistence.size`              | Size of data volume                                                                                                                                   | `10Gi`                                |
-| `graylog.tls.enabled`                   | If true, Graylog will listen on HTTPS                                                                                                                 | `false`                               |
-| `graylog.tls.keyFile`                   | Path to key file for HTTPS                                                                                                                            | `/etc/graylog/server/server.key`      |
-| `graylog.tls.certFile`                  | Path to crt file for HTTPS                                                                                                                            | `/etc/graylog/server/server.cert`     |
-| `graylog.ingress.enabled`               | If true, Graylog Ingress will be created                                                                                                              | `false`                               |
-| `graylog.ingress.port`                  | Graylog Ingress port                                                                                                                                  | `false`                               |
-| `graylog.ingress.annotations`           | Graylog Ingress annotations                                                                                                                           | `{}`                                  |
-| `graylog.ingress.hosts`                 | Graylog Ingress host names                                                                                                                            | `[]`                                  |
-| `graylog.ingress.tls`                   | Graylog Ingress TLS configuration (YAML)                                                                                                              | `[]`                                  |
-| `graylog.ingress.extraPaths`            | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`                                  |
-| `graylog.input`                         | Graylog Input configuration (YAML) Sees #Input section for detail                                                                                     | `{}`                                  |
-| `graylog.metrics.enabled`               | If true, add Prometheus annotations to pods                                                                                                           | `false`                               |
-| `graylog.geoip.enabled`                 | If true, Maxmind Geoip Lite will be installed to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb                                                               | `false`                               |
-| `graylog.geoip.ddbbUri`                 | If set and geoip enabled,  Maxmind Geoip Lite will be installed from the URL you have defined to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb                                                               | ``                               |
-| `graylog.plugins`                       | A list of Graylog installation plugins                                                                                                                | `[]`                                  |
-| `graylog.rootUsername`                  | Graylog root user name                                                                                                                                | `admin`                               |
-| `graylog.rootPassword`                  | Graylog root password. If not set, random 16-character alphanumeric string                                                                            | ``                                    |
-| `graylog.rootEmail`                     | Graylog root email.                                                                                                                                   | ``                                    |
-| `graylog.existingRootSecret`            | Graylog existing root secret                                                                                                                          | ``                                    |
-| `graylog.rootTimezone`                  | Graylog root timezone.                                                                                                                                | `UTC`                                 |
-| `graylog.elasticsearch.hosts`           | Graylog Elasticsearch host name. You need to specific where data will be stored.                                                                      | ``                                    |
-| `graylog.elasticsearch.uriSecretName`   | K8s secret name where elasticsearch hosts will be set from.                                                                                           | `{{ graylog.fullname }}-es`           |
-| `graylog.elasticsearch.uriSecretKey`    | K8s secret key name where elasticsearch hosts will be set from.                                                                                       | ``                                    |
-| `graylog.elasticsearch.uriSSL`          | Prepends 'https://' to the URL fetched from 'uriSecretKey' if true. Prepends http:// otherwise.                                                       | false                                 |
-| `graylog.mongodb.uri`                   | Graylog MongoDB connection string. You need to specific where data will be stored.                                                                    | ``                                    |
-| `graylog.mongodb.uriSecretName`         | K8s secret name where MongoDB URI will be set from.                                                                                                   | `{{ graylog.fullname }}-mongodb`      |
-| `graylog.mongodb.uriSecretKey`          | K8s secret key name where MongoDB URI will be set from.                                                                                               | ``                                    |
-| `graylog.transportEmail.enabled`        | If true, enable transport email settings on Graylog                                                                                                   | `false`                               |
-| `graylog.transportEmail.hostname`       | The hostname of the server used to send the email                                                                                                     | ``                                    |
-| `graylog.transportEmail.port`           | The port of the server used to send the email                                                                                                         | ``                                    |
-| `graylog.transportEmail.useTls`         | If true, use TLS to connect to the mailserver                                                                                                         | ``                                    |
-| `graylog.transportEmail.useSsl`         | If true, use SSL to connect to the mailserver                                                                                                         | ``                                    |
-| `graylog.transportEmail.useAuth`        | If true, authenticate to the email server                                                                                                             | ``                                    |
-| `graylog.transportEmail.authUsername`   | The username for server authentication                                                                                                                | ``                                    |
-| `graylog.transportEmail.authPassword`   | The password for server authentication                                                                                                                | ``                                    |
-| `graylog.transportEmail.subjectPrefix`  | Prepend this string to every mail subjects                                                                                                            | ``                                    |
-| `graylog.transportEmail.fromEmail`      | Use this as a FROM address                                                                                                                            | ``                                    |
-| `graylog.config`                        | Add additional server configuration to `graylog.conf` file.                                                                                           | ``                                    |
-| `graylog.serverFiles`                   | Add additional server files on /etc/graylog/server. This is useful for enable TLS on input                                                            | `{}`                                  |
-| `graylog.journal.deleteBeforeStart`     | Delete all journal files before start Graylog                                                                                                         | `false`                               |
-| `graylog.init.resources`                | Configure resource requests and limits for the Graylog StatefulSet initContainer                                                                      | `{}`                                  |
-| `graylog.provisioner.enabled`           | Enable optional Job to run an arbitrary Bash script                                                                                                   | `false`                               |
-| `graylog.provisioner.useGraylogServiceAccount` | Use the same ServiceAccount used by Graylog pod                                                                                                | `false`                               |
-| `graylog.provisioner.script`            | The contents of the provisioner Bash script                                                                                                           | ``                                    |
-| `graylog.sidecarContainers`             | Sidecar containers to run in the server statefulset                                                                                                   | `[]`                                  |
-| `graylog.extraVolumeMounts`             | Additional Volume mounts                                                                                                                              | `[]`                                  |
-| `graylog.extraVolumes`                  | Additional Volumes                                                                                                                                    | `[]`                                  |
-| `graylog.extraInitContainers`           | Additional Init containers                                                                                                                            | `[]`                                  |
-| `rbac.create`                           | If true, create & use RBAC resources                                                                                                                  | `true`                                |
-| `rbac.resources`                        | List of resources                                                                                                                                     | `[pods, secrets]`                     |
-| `serviceAccount.create`                 | If true, create the Graylog service account                                                                                                           | `true`                                |
-| `serviceAccount.name`                   | Name of the server service account to use or create                                                                                                   | `{{ graylog.fullname }}`              |
-| `tags.install-mongodb`                  | If true, this chart will install MongoDB from requirement dependencies. If you want to install MongoDB by yourself, please set to `false`             | `true`                                |
-| `tags.install-elasticsearch`            | If true, this chart will install Elasticsearch from requirement dependencies. If you want to install Elasticsearch by yourself, please set to `false` | `true`                                |
+| Parameter                                      | Description                                                                                                                                           | Default                           |
+|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------- |
+| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog:3.1`             |
+| `graylog.imagePullPolicy`                      | Image pull policy                                                                                                                                     | `IfNotPresent`                    |
+| `graylog.replicas`                             | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                               |
+| `graylog.resources`                            | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`     |
+| `graylog.heapSize`                             | Override Java heap size. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`                                   |                                   |
+| `graylog.externalUri`                          | External URI that Graylog is available at                                                                                                             |                                   |
+| `graylog.nodeSelector`                         | Graylog server pod assignment                                                                                                                         | `{}`                              |
+| `graylog.affinity`                             | Graylog server affinity                                                                                                                               | `{}`                              |
+| `graylog.tolerations`                          | Graylog server tolerations                                                                                                                            | `[]`                              |
+| `graylog.nodeSelector`                         | Graylog server node selector                                                                                                                          | `{}`                              |
+| `graylog.env`                                  | Graylog server env variables                                                                                                                          | `{}`                              |
+| `graylog.envRaw`                               | Graylog server env variables in raw yaml format                                                                                                       | `{}`                              |
+| `graylog.privileged`                           | Run as a privileged container                                                                                                                         | `false`                           |
+| `graylog.additionalJavaOpts`                   | Graylog service additional `JAVA_OPTS`                                                                                                                |                                   |
+| `graylog.service.type`                         | Kubernetes Service type                                                                                                                               | `ClusterIP`                       |
+| `graylog.service.port`                         | Graylog Service port                                                                                                                                  | `9000`                            |
+| `graylog.service.ports`                        | Graylog Service extra ports                                                                                                                           | `[]`                              |
+| `graylog.service.master.enabled`               | If true, Graylog Master Service will be created                                                                                                       | `true`                            |
+| `graylog.service.master.port`                  | Graylog Master Service port                                                                                                                           | `9000`                            |
+| `graylog.service.master.annotations`           | Graylog Master Service annotations                                                                                                                    | `{}`                              |
+| `graylog.service.headless.suffix`              | If present, suffix appended to the name of the chart to form the headless service name, ie: `-headless` would result in `graylog-headless`            |                                   |
+| `graylog.podAnnotations`                       | Kubernetes Pod annotations                                                                                                                            | `{}`                              |
+| `graylog.terminationGracePeriodSeconds`        | Pod termination grace period                                                                                                                          | `120`                             |
+| `graylog.updateStrategy`                       | Update Strategy of the StatefulSet                                                                                                                    | `RollingUpdate`                   |
+| `graylog.persistence.enabled`                  | Use a PVC to persist data                                                                                                                             | `true`                            |
+| `graylog.persistence.storageClass`             | Storage class of backing PVC (uses storage class annotation)                                                                                          | `nil`                             |
+| `graylog.persistence.accessMode`               | Use volume as ReadOnly or ReadWrite                                                                                                                   | `ReadWriteOnce`                   |
+| `graylog.persistence.size`                     | Size of data volume                                                                                                                                   | `10Gi`                            |
+| `graylog.tls.enabled`                          | If true, Graylog will listen on HTTPS                                                                                                                 | `false`                           |
+| `graylog.tls.keyFile`                          | Path to key file for HTTPS                                                                                                                            | `/etc/graylog/server/server.key`  |
+| `graylog.tls.certFile`                         | Path to crt file for HTTPS                                                                                                                            | `/etc/graylog/server/server.cert` |
+| `graylog.ingress.enabled`                      | If true, Graylog Ingress will be created                                                                                                              | `false`                           |
+| `graylog.ingress.port`                         | Graylog Ingress port                                                                                                                                  | `false`                           |
+| `graylog.ingress.annotations`                  | Graylog Ingress annotations                                                                                                                           | `{}`                              |
+| `graylog.ingress.hosts`                        | Graylog Ingress host names                                                                                                                            | `[]`                              |
+| `graylog.ingress.tls`                          | Graylog Ingress TLS configuration (YAML)                                                                                                              | `[]`                              |
+| `graylog.ingress.extraPaths`                   | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller][2].              | `[]`                              |
+| `graylog.input`                                | Graylog Input configuration (YAML) Sees #Input section for detail                                                                                     | `{}`                              |
+| `graylog.metrics.enabled`                      | If true, add Prometheus annotations to pods                                                                                                           | `false`                           |
+| `graylog.geoip.enabled`                        | If true, Maxmind Geoip Lite will be installed to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb                                                               | `false`                           |
+| `graylog.geoip.ddbbUri`                        | If set and geoip enabled,  Maxmind Geoip Lite will be installed from the URL you have defined to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb               |                                   |
+| `graylog.plugins`                              | A list of Graylog installation plugins                                                                                                                | `[]`                              |
+| `graylog.rootUsername`                         | Graylog root user name                                                                                                                                | `admin`                           |
+| `graylog.rootPassword`                         | Graylog root password. If not set, random 16-character alphanumeric string                                                                            |                                   |
+| `graylog.rootEmail`                            | Graylog root email.                                                                                                                                   |                                   |
+| `graylog.existingRootSecret`                   | Graylog existing root secret                                                                                                                          |                                   |
+| `graylog.rootTimezone`                         | Graylog root timezone.                                                                                                                                | `UTC`                             |
+| `graylog.elasticsearch.hosts`                  | Graylog Elasticsearch host name. You need to specific where data will be stored.                                                                      |                                   |
+| `graylog.elasticsearch.uriSecretName`          | K8s secret name where elasticsearch hosts will be set from.                                                                                           | `{{ graylog.fullname }}-es`       |
+| `graylog.elasticsearch.uriSecretKey`           | K8s secret key name where elasticsearch hosts will be set from.                                                                                       |                                   |
+| `graylog.elasticsearch.uriSSL`                 | Prepends 'https://' to the URL fetched from 'uriSecretKey' if true. Prepends `http://` otherwise.                                                     | `false`                           |
+| `graylog.mongodb.uri`                          | Graylog MongoDB connection string. You need to specific where data will be stored.                                                                    |                                   |
+| `graylog.mongodb.uriSecretName`                | K8s secret name where MongoDB URI will be set from.                                                                                                   | `{{ graylog.fullname }}-mongodb`  |
+| `graylog.mongodb.uriSecretKey`                 | K8s secret key name where MongoDB URI will be set from.                                                                                               |                                   |
+| `graylog.transportEmail.enabled`               | If true, enable transport email settings on Graylog                                                                                                   | `false`                           |
+| `graylog.transportEmail.hostname`              | The hostname of the server used to send the email                                                                                                     |                                   |
+| `graylog.transportEmail.port`                  | The port of the server used to send the email                                                                                                         |                                   |
+| `graylog.transportEmail.useTls`                | If true, use TLS to connect to the mailserver                                                                                                         |                                   |
+| `graylog.transportEmail.useSsl`                | If true, use SSL to connect to the mailserver                                                                                                         |                                   |
+| `graylog.transportEmail.useAuth`               | If true, authenticate to the email server                                                                                                             |                                   |
+| `graylog.transportEmail.authUsername`          | The username for server authentication                                                                                                                |                                   |
+| `graylog.transportEmail.authPassword`          | The password for server authentication                                                                                                                |                                   |
+| `graylog.transportEmail.subjectPrefix`         | Prepend this string to every mail subjects                                                                                                            |                                   |
+| `graylog.transportEmail.fromEmail`             | Use this as a FROM address                                                                                                                            |                                   |
+| `graylog.config`                               | Add additional server configuration to `graylog.conf` file.                                                                                           |                                   |
+| `graylog.serverFiles`                          | Add additional server files on /etc/graylog/server. This is useful for enable TLS on input                                                            | `{}`                              |
+| `graylog.journal.deleteBeforeStart`            | Delete all journal files before start Graylog                                                                                                         | `false`                           |
+| `graylog.init.resources`                       | Configure resource requests and limits for the Graylog StatefulSet initContainer                                                                      | `{}`                              |
+| `graylog.provisioner.enabled`                  | Enable optional Job to run an arbitrary Bash script                                                                                                   | `false`                           |
+| `graylog.provisioner.useGraylogServiceAccount` | Use the same ServiceAccount used by Graylog pod                                                                                                       | `false`                           |
+| `graylog.provisioner.script`                   | The contents of the provisioner Bash script                                                                                                           |                                   |
+| `graylog.sidecarContainers`                    | Sidecar containers to run in the server statefulset                                                                                                   | `[]`                              |
+| `graylog.extraVolumeMounts`                    | Additional Volume mounts                                                                                                                              | `[]`                              |
+| `graylog.extraVolumes`                         | Additional Volumes                                                                                                                                    | `[]`                              |
+| `graylog.extraInitContainers`                  | Additional Init containers                                                                                                                            | `[]`                              |
+| `rbac.create`                                  | If true, create & use RBAC resources                                                                                                                  | `true`                            |
+| `rbac.resources`                               | List of resources                                                                                                                                     | `[pods, secrets]`                 |
+| `serviceAccount.create`                        | If true, create the Graylog service account                                                                                                           | `true`                            |
+| `serviceAccount.name`                          | Name of the server service account to use or create                                                                                                   | `{{ graylog.fullname }}`          |
+| `tags.install-mongodb`                         | If true, this chart will install MongoDB from requirement dependencies. If you want to install MongoDB by yourself, please set to `false`             | `true`                            |
+| `tags.install-elasticsearch`                   | If true, this chart will install Elasticsearch from requirement dependencies. If you want to install Elasticsearch by yourself, please set to `false` | `true`                            |
+| `tags.install-elasticsearch`                   | If true, this chart will install Elasticsearch from requirement dependencies. If you want to install Elasticsearch by yourself, please set to `false` | `true`                            |
+| `imagePullSecrets`                             | Configuration for [imagePullSecrets][3] so that you can use a private registry for your images                                                        | `[]`                              |
 
 ## How it works
-This chart will create a Graylog statefulset with one Master node. The chart will automatically create Master node Pod label `graylog-role=master`, if it does not exists. The others Pods will be label with `graylog-role=coordinating`
+
+This chart will create a Graylog [statefulset][4] with one Master node. The chart will automatically create Master node Pod label `graylog-role=master`, if it does not exists. The others Pods will be label with `graylog-role=coordinating`
 
 This chart will automatically calculate Java heap size from given `resources.requests.memory` value. If you want to specify number of heap size, you can set `graylog.heapSize` to your desired value. The `graylog.heapSize` value must be in JVM `-Xmx` format.
 
 ## Input
+
 You can enable input ports by edit the `input` values. For example, you want to create a GELF input on port `12222`, and `12223` with Cloud LoadBalancer and syslog on UDP port `5410` without load balancer.
 
-```
+```yaml
   input:
     tcp:
       service:
@@ -209,7 +221,7 @@ You can enable input ports by edit the `input` values. For example, you want to 
 
 OR, if you want to expose only a single service with all the input ports open, you can do so by specifying the `service.ports` value:
 
-```
+```yaml
   service:
     ports:
       - name: gelf
@@ -220,10 +232,9 @@ OR, if you want to expose only a single service with all the input ports open, y
         protocol: UDP
 ```
 
-Note: Name must be in IANA_SVC_NAME (at most 15 characters, matching regex [a-z0-9]([a-z0-9-]*[a-z0-9])* and it must contains at least one letter [a-z], hyphens cannot be adjacent to other hyphens)
+Note: Name must be in **IANA_SVC_NAME** format - at most 15 characters, matching regex **[a-z0-9]**, containing at least one letter, and hyphens cannot be adjacent to other hyphens
 
 Note: The port list should be sorted by port number.
-
 
 ## TLS
 
@@ -279,20 +290,23 @@ Each Graylog node coordinates with each other through the DNS entry exposed via 
 the certificates, be sure to include a SAN entry for `*.graylog[-<suffix>].<namespace>.cluster.local` (or your configured FQDN).
 
 ## Get Graylog status
+
 You can get your Graylog status by running the command
 
-```
+```bash
 kubectl get po -L graylog-role
 ```
 
 Output
-```
+
+```output
 NAME                        READY     STATUS    RESTARTS   AGE       graylog-ROLE
 graylog-0                   1/1       Running     0          1d        master
 graylog-1                   1/1       Running     0          1d        coordinating
 graylog-2                   1/1       Running     0          1m        coordinating
 ```
-## Trouble shooting
+
+## Troubleshooting
 
 If you are encounter "Unprocessed Messages" or Journal files corrupted, you may need to delete all journal files before staring Graylog.
 You can do this automatically by setting `graylog.journal.deleteBeforeStart` to `true`
@@ -300,3 +314,8 @@ You can do this automatically by setting `graylog.journal.deleteBeforeStart` to 
 The chart will delete all journal files before starting Graylog.
 
 Note: All uncommitted logs will be permanently DELETED when this value is true
+
+[1]: https://www.graylog.org/
+[2]: https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions
+[3]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+[4]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
 {{ toYaml .Values.graylog.tolerations | indent 8 }}
 {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       initContainers:
         - name: "setup"
           image: "alpine"

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -380,7 +380,11 @@ graylog:
     #    "roles_header": "Roles"
     #  }'
     #  curl -v -u "admin:$GRAYLOG_PASSWORD_SECRET" -X PUT --header 'Content-Type: application/json' --header 'X-Requested-By: localhost' --data-binary "${json}" http://graylog-master:9000/api/plugins/org.graylog.plugins.auth.sso/config
-
+## Specify image pull secrets used in the deployment
+imagePullSecrets: []
+## imagePullSecrets:
+##   - name: some-registry
+##   - name: another-registry
 ## Specify Elasticsearch version from requirement dependencies. Ignore this seection if you install Elasticsearch manually.
 ## Note: Graylog 2.4 requires Elasticsearch version <= 5.6
 elasticsearch:


### PR DESCRIPTION
#### Purpose
This PR allows users to specify image pull secrets for Graylog. This is particularly useful for people who run a custom image (because they need to bake plugins into their image - in particular, Graylog Enterprise license holders need to bake in the plugins).

I also cleaned up the formatting on the README.md file.

#### Special notes for your reviewer:

@KongZ - you are listed as the reviewer. The changes are fairly straight-forward.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
