### PR TITLE
[stable/fluent-bit] Added output es Logstash_DateFormat parameter

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.14
+version: 2.8.15
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.es.logstash_format`          | Enable Logstash format compatibility. | `On` |
 | `backend.es.logstash_prefix`  | Index Prefix. If Logstash_Prefix is equal to 'mydata' your index will become 'mydata-YYYY.MM.DD'. | `kubernetes_cluster` |
 | `backend.es.logstash_prefix_key`  | Index Prefix key. When included, the value in the record that belongs to the key will be looked up and overwrite `Logstash_Prefix` for index generation. If `Logstash_Prefix_Key` = 'mydata' the index becomes 'mydata-YYYY.MM.DD'. | `` |
+| `backend.es.logstash_dateformat`  | Time format (based on strftime) to generate the second part of the Index name. Fluent-bit by default use %Y.%m.%d | `` |
 | `backend.es.replace_dots`     | Enable/Disable Replace_Dots option. | `On` |
 | `backend.es.http_user`        | Optional username credential for Elastic X-Pack access. | `` |
 | `backend.es.http_passwd`      | Password for user defined in HTTP_User. | `` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -140,6 +140,7 @@ data:
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
 {{- if .Values.backend.es.logstash_prefix_key }}
         Logstash_Prefix_Key {{ .Values.backend.es.logstash_prefix_key }}
+{{- end }}
 {{- if .Values.backend.es.logstash_dateformat }}
         Logstash_DateFormat {{ .Values.backend.es.logstash_dateformat }}
 {{- end }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -140,6 +140,8 @@ data:
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
 {{- if .Values.backend.es.logstash_prefix_key }}
         Logstash_Prefix_Key {{ .Values.backend.es.logstash_prefix_key }}
+{{- if .Values.backend.es.logstash_dateformat }}
+        Logstash_DateFormat {{ .Values.backend.es.logstash_dateformat }}
 {{- end }}
 {{ else if .Values.backend.es.index }}
         Index {{ .Values.backend.es.index }}


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No
#### What this PR does / why we need it:
Adds the ability to use the fluent-bit Logstash_DateFormat parameter to change the format of the second part of the index name.
#### Which issue this PR fixes
There isn't 

#### Special notes for your reviewer:
You can read the documentation of the parameter in: https://docs.fluentbit.io/manual/v/1.3/output/elasticsearch
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
