### PR TITLE
[incubator/zookeeper] Add pod security policy to template

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.4
+version: 2.1.5
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/podsecuritypolicy.yaml
+++ b/incubator/zookeeper/templates/podsecuritypolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  {{- if .Values.podSecurityPolicy.name }}
+  name: {{ .Values.podSecurityPolicy.name | quote }}
+  {{- else }}
+  name: {{ include "zookeeper.fullname" . | quote }}
+  {{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ include "zookeeper.fullname" . | quote }}
+spec:
+{{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
+{{- end -}}

--- a/incubator/zookeeper/templates/role.yaml
+++ b/incubator/zookeeper/templates/role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "zookeeper.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      {{- if eq .Values.podSecurityPolicy.name "" }}
+      - {{ $fullName | quote }}
+      {{- else }}
+      - {{ .Values.podSecurityPolicy.name | quote }}
+      {{- end }}
+    verbs:
+      - use
+{{- end -}}

--- a/incubator/zookeeper/templates/rolebinding.yaml
+++ b/incubator/zookeeper/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "zookeeper.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+subjects:
+  - kind: ServiceAccount
+    {{- if eq .Values.rbac.serviceAccountName "" }}
+    name: {{ $fullName | quote }}
+    {{- else }}
+    name: {{ .Values.rbac.serviceAccountName | quote }}
+    {{- end }}
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ $fullName | quote }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/incubator/zookeeper/templates/serviceaccount.yaml
+++ b/incubator/zookeeper/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "zookeeper.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if eq .Values.rbac.serviceAccountName "" }}
+  name: {{ $fullName | quote }}
+  {{- else }}
+  name: {{ .Values.rbac.serviceAccountName | quote }}
+  {{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+{{- end -}}

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -47,6 +47,11 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
+      {{- if .Values.rbac.create }}
+      serviceAccountName: "{{ template "zookeeper.fullname" . }}"
+      {{- else if not (eq .Values.rbac.serviceAccountName "") }}
+      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- end }}
       containers:
 
         - name: zookeeper

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -93,6 +93,30 @@ securityContext:
   fsGroup: 1000
   runAsUser: 1000
 
+podSecurityPolicy:
+  create: false
+  name: ""
+  spec:
+    privileged: true
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - secret
+      - configMap
+      - persistentVolumeClaim
+      - projected
+      - emptyDir
+
+rbac:
+  create: false
+  serviceAccountName: ""
+
 ## Useful, if you want to use an alternate image.
 command:
   - /bin/bash


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Allows the chart to work on a cluster with pod security policy enabled.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
./.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
