### PR TITLE
[incubator/kafka] Add pod security policy to template

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.21.2
+version: 0.22.0
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/podsecuritypolicy.yaml
+++ b/incubator/kafka/templates/podsecuritypolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  {{- if .Values.podSecurityPolicy.name }}
+  name: {{ .Values.podSecurityPolicy.name | quote }}
+  {{- else }}
+  name: {{ include "kafka.fullname" . | quote }}
+  {{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ include "kafka.fullname" . | quote }}
+spec:
+{{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
+{{- end -}}

--- a/incubator/kafka/templates/role.yaml
+++ b/incubator/kafka/templates/role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "kafka.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      {{- if eq .Values.podSecurityPolicy.name "" }}
+      - {{ $fullName | quote }}
+      {{- else }}
+      - {{ .Values.podSecurityPolicy.name | quote }}
+      {{- end }}
+    verbs:
+      - use
+{{- end -}}

--- a/incubator/kafka/templates/rolebinding.yaml
+++ b/incubator/kafka/templates/rolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "kafka.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+subjects:
+  - kind: ServiceAccount
+    {{- if eq .Values.rbac.serviceAccountName "" }}
+    name: {{ $fullName | quote }}
+    {{- else }}
+    name: {{ .Values.rbac.serviceAccountName | quote }}
+    {{- end }}
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ $fullName | quote }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/incubator/kafka/templates/serviceaccount.yaml
+++ b/incubator/kafka/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "kafka.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if eq .Values.rbac.serviceAccountName "" }}
+  name: {{ $fullName | quote }}
+  {{- else }}
+  name: {{ .Values.rbac.serviceAccountName | quote }}
+  {{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+{{- end -}}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -36,9 +36,11 @@ spec:
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
-{{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-{{- end }}
+      {{- if .Values.rbac.create }}
+      serviceAccountName: "{{ template "kafka.fullname" . }}"
+      {{- else if not (eq .Values.rbac.serviceAccountName "") }}
+      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -62,9 +62,29 @@ logSubPath: "logs"
 ##
 # schedulerName:
 
-## Use an alternate serviceAccount
-## Useful when using images in custom repositories
-# serviceAccountName:
+podSecurityPolicy:
+  create: false
+  name: ""
+  spec:
+    privileged: true
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - secret
+      - configMap
+      - persistentVolumeClaim
+      - projected
+      - emptyDir
+
+rbac:
+  create: false
+  serviceAccountName: ""
 
 ## Set a pod priorityClassName
 # priorityClassName: high-priority


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Allows the chart to work on a cluster with pod security policy enabled.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
./.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
