### PR TITLE
[stable/schema-registry-ui] Enable schema-registry-ui advanced settings

### DIFF
--- a/stable/schema-registry-ui/Chart.yaml
+++ b/stable/schema-registry-ui/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - Kafka
   - avro
   - schema-registry
-version: 0.4.1
+version: 0.4.2
 maintainers:
 - email: cristian04@gmail.com
   name: cristian04

--- a/stable/schema-registry-ui/README.md
+++ b/stable/schema-registry-ui/README.md
@@ -65,6 +65,10 @@ The following table lists the configurable parameters of the SchemaRegistryUI ch
 | `schemaRegistry.url` | URL to the schema registry endpoint | `http://localhost` |
 | `schemaRegistry.port` | Port for the schema registry | `8081` |
 | `schemaRegistry.proxy` | Whether to proxy Schema Registry endpoint via the internal webserver | `false` |
+| `schemaRegistry.allowGlobal` | Support for global compatibility level configuration support —i.e change the default compatibility level of your schema registry | `false` |
+| `schemaRegistry.allowTransitive` | Support for transitive compatibility levels (Schema Registry version 3.1.1 or better) | `false` |
+| `schemaRegistry.allowDeletion` | Support for Schema deletion (Schema Registry version 3.3.0 or better) | `false` |
+| `schemaRegistry.readOnlyMode` | Support for readonly mode (overwrites settings for global compatibility configuration and schema deletion) | `false` |
 | `service.type` | Type of the service | `LoadBalancer` |
 | `service.port` | Port to use | `80` |
 | `service.annotations` | Kubernetes service annotations | `{}` |

--- a/stable/schema-registry-ui/templates/deployment.yaml
+++ b/stable/schema-registry-ui/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
             value: "{{ .Values.schemaRegistry.url }}:{{ .Values.schemaRegistry.port }}"
           - name: PROXY
             value: "{{ .Values.schemaRegistry.proxy }}"
+          - name: ALLOW_GLOBAL
+            value: "{{ .Values.schemaRegistry.allowGlobal }}"
+          - name: ALLOW_TRANSITIVE
+            value: "{{ .Values.schemaRegistry.allowTransitive }}"
+          - name: ALLOW_DELETION
+            value: "{{ .Values.schemaRegistry.allowDeletion }}"
+          - name: READONLY_MODE
+            value: "{{ .Values.schemaRegistry.readOnlyMode }}"
           ports:
             - name: http
               containerPort: 8000

--- a/stable/schema-registry-ui/values.yaml
+++ b/stable/schema-registry-ui/values.yaml
@@ -20,6 +20,10 @@ schemaRegistry:
   url: "http://localhost"
   port: 8081
   proxy: false
+  allowGlobal: false
+  allowTransitive: false
+  allowDeletion: false
+  readOnlyMode: false
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Enable schema-registry-ui advanced settings as per the [docker image](https://hub.docker.com/r/landoop/schema-registry-ui/)

#### Checklist
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@cristian04 