### PR TITLE
[stabel/katafygio] Correct indentation of 'volumes' property

### DIFF
--- a/stable/katafygio/Chart.yaml
+++ b/stable/katafygio/Chart.yaml
@@ -5,7 +5,7 @@ name: katafygio
 home: https://github.com/bpineau/katafygio
 sources:
 - https://github.com/bpineau/katafygio
-version: 1.0.0
+version: 1.0.1
 keywords:
 - backup
 - dump

--- a/stable/katafygio/templates/deployment.yaml
+++ b/stable/katafygio/templates/deployment.yaml
@@ -81,11 +81,11 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    volumes:
-      - name: katafygio-data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "katafygio.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
-      {{- end -}}
+      volumes:
+        - name: katafygio-data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "katafygio.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end -}}


### PR DESCRIPTION
Signed-off-by: Marcus van Dam <marcus@marcusvandam.nl>

#### What this PR does / why we need it:

This PR corrects the indentation of the `volumes` property to be member of the **PodSpec** instead of the **PodTemplateSpec**. Resolving the following validation error:
```
katafygio/templates/deployment.yaml contains an invalid Deployment (RELEASE-NAME-katafygio) - volumes: Additional property volumes is not allowed
``` 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
