### PR TITLE
[stable/jenkins] Add support for installing additional plugins

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.25.0
+
+Add support for installing plugins in addition to the chart's default plugins via `master.additionalPlugins`
+
+## 1.24.0
+
+Allow configuration of yamlMergeStrategy via `agent.yamlMergeStrategy`
+
 ## 1.23.2
 
 In the `jenkins.xml.podTemplate` helper function, allow templating of all string values under `agent.volumes` except `type` by rendering them with the `tpl` function

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.24.0
+version: 1.25.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -164,6 +164,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.jobs`                     | Jenkins XML job configs              | `{}`                                      |
 | `master.overwriteJobs`            | Replace jobs w/ ConfigMap on boot    | `false`                                   |
 | `master.installPlugins`           | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.18.2 workflow-aggregator:2.6 credentials-binding:1.19 git:3.11.0 workflow-job:2.33` |
+| `master.additionalPlugins`        | List of Jenkins plugins to install in addition to those listed in master.installPlugins | `[]` |
 | `master.overwritePlugins`         | Overwrite installed plugins on start.| `false`                                   |
 | `master.overwritePluginsFromImage` | Keep plugins that are already installed in the master image.| `true`            |
 | `master.enableRawHtmlMarkupFormatter` | Enable HTML parsing using (see below) | false                                |

--- a/stable/jenkins/ci/casc-values.yaml
+++ b/stable/jenkins/ci/casc-values.yaml
@@ -20,13 +20,7 @@ master:
   enableXmlConfig: false
   healthProbeLivenessInitialDelay: 10
   healthProbeReadinessInitialDelay: 10
-  installPlugins:
-    - kubernetes:1.25.3
-    - workflow-job:2.38
-    - workflow-aggregator:2.6
-    - credentials-binding:1.21
-    - git:4.2.2
-    - configuration-as-code:1.39
+  additionalPlugins:
     - ldap:1.24
 persistence:
   enabled: false

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -256,9 +256,21 @@ data:
 {{- end }}
   plugins.txt: |-
 {{- if .Values.master.installPlugins }}
-{{- range $index, $val := .Values.master.installPlugins }}
-{{ $val | indent 4 }}
-{{- end }}
+  {{- range $installPlugin := .Values.master.installPlugins }}
+    {{- $installPlugin | nindent 4 }}
+  {{- end }}
+  {{- range $addlPlugin := .Values.master.additionalPlugins }}
+    {{- /* duplicate plugin check */}}
+    {{- range $installPlugin := $.Values.master.installPlugins }}
+      {{- if eq (splitList ":" $addlPlugin | first) (splitList ":" $installPlugin | first) }}
+        {{- $message := print "[PLUGIN CONFLICT] master.additionalPlugins contains '" $addlPlugin "'" }}
+        {{- $message := print $message " but master.installPlugins already contains '" $installPlugin "'." }}
+        {{- $message := print $message " Override master.installPlugins to use '" $addlPlugin "' plugin." }}
+        {{- fail $message }}
+      {{- end }}
+    {{- end }}
+    {{- $addlPlugin | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{ else }}
 {{ include "override_config_map" . }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -233,6 +233,9 @@ master:
     - git:4.2.2
     - configuration-as-code:1.39
 
+  # List of plugins to install in addition to those listed in master.installPlugins
+  additionalPlugins: []
+
   # Enable to always override the installed plugins with the values of 'master.installPlugins' on upgrade or redeployment.
   # overwritePlugins: true
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Add support for installing plugins in addition to the chart's default plugins via `master.additionalPlugins`. 

Currently, in order to add plugins via `master.installPlugins`, a user has to duplicate the chart's default plugins in the user's values file since `master.installPlugins` is an array and isn't appendable. Users must then manually update the versions of these default plugins rather than allow the chart to update the versions as part of a chart upgrade.
##### chart's values
```yaml
master
  installPlugins:
    - kubernetes:1.25.3
    - workflow-job:2.38
    - workflow-aggregator:2.6
    - credentials-binding:1.21
    - git:4.2.2
    - configuration-as-code:1.39
```
##### user's values - add ldap plugin
```yaml
master:
  installPlugins:
    - kubernetes:1.25.3
    - workflow-job:2.38
    - workflow-aggregator:2.6
    - credentials-binding:1.21
    - git:4.2.2
    - configuration-as-code:1.39
    - ldap:1.24
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

### Examples of user's values with `master.additionalPlugins`
#### Add plugins
```yaml
master:
  additionalPlugins:
    - antisamy-markup-formatter:2.0
    - basic-branch-build-strategies:1.3.2
    - job-dsl:1.77
    - kubernetes-credentials-provider:0.14
    - ldap:1.24
```
#### Override `master.installPlugins` - do not install plugins
```yaml
master:
  installPlugins: []
  additionalPlugins: []
```
or
```yaml
master:
  installPlugins: []
  # this would be ignored since master.installPlugins=[]
  additionalPlugins:
    - antisamy-markup-formatter:2.0
```
#### Override `master.installPlugins` - alternate versions for default plugins
```yaml
master:
  installPlugins:
    - kubernetes:1.25.0
    - workflow-job:2.38
    - workflow-aggregator:2.6
    - credentials-binding:1.20
    - git:4.2.0
    - configuration-as-code:1.39
  additionalPlugins:
    - antisamy-markup-formatter:2.0
    - basic-branch-build-strategies:1.3.2
    - job-dsl:1.77
    - kubernetes-credentials-provider:0.14
    - ldap:1.24
```
or
```yaml
master:
  installPlugins:
    - kubernetes:1.25.0
    - workflow-job:2.38
    - workflow-aggregator:2.6
    - credentials-binding:1.20
    - git:4.2.0
    - configuration-as-code:1.39
    # additional plugins
    - antisamy-markup-formatter:2.0
    - basic-branch-build-strategies:1.3.2
    - job-dsl:1.77
    - kubernetes-credentials-provider:0.14
    - ldap:1.24
```
#### Conflicting plugins
attempt to upgrade `configuration-as-code` plugin from 1.39 will cause chart rendering to fail

user-values.yaml
```yaml
master:
  additionalPlugins:
    - configuration-as-code:1.40
```
```bash
$ helm template stable/jenkins \
--show-only templates/config.yaml \
--values user-values.yaml
```

> ...executing "jenkins/templates/config.yaml" at <fail $message>: error calling fail: [PLUGIN CONFLICT] master.additionalPlugins contains 'configuration-as-code:1.40' but master.installPlugins already contains 'configuration-as-code:1.39'. Override master.installPlugins to use 'configuration-as-code:1.40' plugin.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
