### PR TITLE
[stable/kube2iam] Increase default quota to prevent throttling and OOM

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.5.0
+version: 2.5.1
 appVersion: 0.10.9
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -85,11 +85,11 @@ rbac:
 
 resources: {}
   # limits:
-  #   cpu: 4m
-  #   memory: 16Mi
+  #   cpu: 50m
+  #   memory: 64Mi
   # requests:
-  #   cpu: 4m
-  #   memory: 16Mi
+  #   cpu: 20m
+  #   memory: 64Mi
 
 ## Strategy for DaemonSet updates (requires Kubernetes 1.6+)
 ## Ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/


### PR DESCRIPTION
### What this PR does / why we need it:

I have been running kube2iam in prod for years and I found some folks agreeing about credentials issue because of kube2iam when in fact the problem was... throttling. For old kernel version I do not recommend cpu limits but increase it at least up to 50m is needed.
Also the memory usage in >0.10 version is always higher than 35Mi so increase to 64 is needed too.
Having this a bit higher values as defaults will prevent people that don't monitor throttling properly (or directly doesn't) face this kind of issues that are usually appearing just when they start putting pressure on it.