### PR TITLE
[stable/sematext-agent] Use agent defaults for JOURNAL_DIR

### DIFF
--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.25
+version: 1.0.26
 description: Helm chart for deploying Sematext Agent and Logagent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/values.yaml
+++ b/stable/sematext-agent/values.yaml
@@ -7,7 +7,6 @@ agent:
     port: 80
     type: ClusterIP
   config:
-    JOURNAL_DIR: /opt/spm/st-agent
     PIPELINE_CONSOLE_OUTPUT: false
     PIPELINE_NULL_OUTPUT: false
     API_SERVER_HOST: 0.0.0.0


### PR DESCRIPTION
Signed-off-by: Ciprian Hacman <ciprian.hacman@sematext.com>

#### What this PR does / why we need it:
Switches the value of JOURNAL_DIR to default.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
