### PR TITLE
[stable/minecraft] Use mc-monitor instead of deprecated mcstatus command.

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -27,9 +27,9 @@ securityContext:
 # https://hub.docker.com/r/itzg/minecraft-server/
 livenessProbe:
   command:
-    - mcstatus
-    - localhost:25565
+    - mc-monitor
     - status
+    - localhost:25565
   initialDelaySeconds: 30
   periodSeconds: 5
   failureThreshold: 10
@@ -37,9 +37,9 @@ livenessProbe:
   timeoutSeconds: 1
 readinessProbe:
   command:
-    - mcstatus
-    - localhost:25565
+    - mc-monitor
     - status
+    - localhost:25565
   initialDelaySeconds: 30
   periodSeconds: 5
   failureThreshold: 10


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Updates command used for liveness/readiness probes to use non-deprecated command for minecraft chart.

#### Which issue this PR fixes

  - fixes #22517

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)