### PR TITLE
stable/hl-composer Hyperledger images gone from Dockerhub; redeploy

### DIFF
--- a/stable/hl-composer/Chart.yaml
+++ b/stable/hl-composer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Hyperledger Composer REST Server chart
 name: hl-composer
-version: 1.0.12
-appVersion: 0.20.0
+version: 1.1.0
+appVersion: 0.20.10
 keywords:
   - blockchain
   - hyperledger

--- a/stable/hl-composer/OWNERS
+++ b/stable/hl-composer/OWNERS
@@ -1,8 +1,4 @@
 approvers:
 - alexvicegrab
-- inzamam-iqbal
-- dbandin
 reviewers:
 - alexvicegrab
-- inzamam-iqbal
-- dbandin

--- a/stable/hl-composer/values.yaml
+++ b/stable/hl-composer/values.yaml
@@ -19,8 +19,8 @@ persistence:
 
 cli:
   image:
-    repository: hyperledger/composer-cli
-    tag: 0.20.0
+    repository: alexvicegrab/composer-cli
+    tag: 0.20.10
     pullPolicy: IfNotPresent
 
   secrets: {}
@@ -52,8 +52,8 @@ cli:
 
 rest:
   image:
-    repository: hyperledger/composer-rest-server
-    tag: 0.20.0
+    repository: alexvicegrab/composer-rest-server
+    tag: 0.20.10
     pullPolicy: IfNotPresent
 
   service:
@@ -103,8 +103,8 @@ pg:
   enabled: true
 
   image:
-    repository: hyperledger/composer-playground
-    tag: 0.20.0
+    repository: alexvicegrab/composer-playground
+    tag: 0.20.10
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
#### What this PR does / why we need it:

The Hyperledger Composer tools was deprecated, and eventually the Docker images on DockerHub have disappeared. Some are still using HL Composer for POCs, hence I am hosting the Docker images in my own DockerHub.

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
