### PR TITLE
Typo fix: targetLabel => target_label

### DIFF
--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1773,7 +1773,7 @@ prometheus:
     #     regex: __meta_kubernetes_node_label_(.+)
     #   - source_labels: [__address__]
     #     action: replace
-    #     targetLabel: __address__
+    #     target_label: __address__
     #     regex: ([^:;]+):(\d+)
     #     replacement: ${1}:2379
     #   - source_labels: [__meta_kubernetes_node_name]
@@ -1781,7 +1781,7 @@ prometheus:
     #     regex: .*mst.*
     #   - source_labels: [__meta_kubernetes_node_name]
     #     action: replace
-    #     targetLabel: node
+    #     target_label: node
     #     regex: (.*)
     #     replacement: ${1}
     #   metric_relabel_configs:


### PR DESCRIPTION
#### What this PR does / why we need it:
The following error will be encountered if we use `targetLabel` in `additionalScrapeConfigs.relabel_configs` field.

> level=error ts=2020-05-26T04:53:50.865Z caller=main.go:736 err="error loading config from \"/etc/prometheus/config_out/prometheus.env.yaml\": couldn't load configuration (--config.file=\"/etc/prometheus/config_out/prometheus.env.yaml\"): parsing YAML file /etc/prometheus/config_out/prometheus.env.yaml: yaml: unmarshal errors:\n  line 733: field targetLabel not found in type relabel.plain"

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
Signed-off-by: Fujia Luo <fujia.l@technotialabs.com>

