### PR TITLE
[stable/unbound] make anchor-file optional for internal clusters

### DIFF
--- a/stable/unbound/Chart.yaml
+++ b/stable/unbound/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Unbound is a fast caching DNS resolver
 home: https://www.unbound.net/
 name: unbound
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.6.7
 sources:
 - http://unbound.nlnetlabs.nl/svn/

--- a/stable/unbound/templates/configmap.yaml
+++ b/stable/unbound/templates/configmap.yaml
@@ -18,7 +18,9 @@ data:
         do-daemonize: no
         logfile: ""
         use-syslog: no
+        {{- if .Values.autotrust.enable }}
         auto-trust-anchor-file: "/var/lib/unbound/root.key"
+        {{- end }}
         verbosity: {{ .Values.unbound.verbosity }}
         statistics-interval: {{ .Values.unbound.statsInterval }}
         statistics-cumulative: {{ .Values.unbound.statsCumulative }}

--- a/stable/unbound/templates/deployment.yaml
+++ b/stable/unbound/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       containers:
       - name: "unbound"
         image: {{ .Values.unbound.image.repository }}:{{ .Values.unbound.image.tag }}
+    {{- if (not .Values.autotrust.enable) }}
+        command: ["unbound", "-c", "/etc/unbound/unbound.conf"]
+    {{- end }}
         imagePullPolicy: {{ .Values.unbound.image.pullPolicy | quote }}
 {{- with .Values.resources }}
         resources:
@@ -84,4 +87,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
-

--- a/stable/unbound/values.yaml
+++ b/stable/unbound/values.yaml
@@ -29,6 +29,11 @@ tolerations: []
 
 affinity: {}
 
+# auto-trust will create an anchor file (need internet access!)
+# disable to not use auto-trust-anchor-file
+autotrust:
+  enable: true
+
 # clusterIP:
 
 # Controls which IP address ranges unbound will allow queries from.


### PR DESCRIPTION
I know this is repo is going to be depreciated. but if someone face the same problem this pr may be usefull. Feel free to cherry pick this.

if you dont have inet connection, cause you use this as intercal dns cache. anchor makes it fails.
` fail: the anchor is NOT ok and could not be fixed`

this pr: makes the use of anchor optional.

https://www.claudiokuenzler.com/blog/694/get-unbound-dns-lookups-resolution-working-ubuntu-16.04-xenial