### PR TITLE
[stable/prometheus-redis-exporter] fix targetLabels

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.4.0
+version: 3.4.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
@@ -32,8 +32,8 @@ spec:
       app: {{ template "prometheus-redis-exporter.name" . }}
       release: {{ .Release.Name }}
 {{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
 {{- range .Values.serviceMonitor.targetLabels }}
-  targetLabels: 
     - {{ . }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

Adding multiple values to the `targetLabels` would result in only the last item in the array being used. I've moved the `targetLabels` out of `range` to fix this

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
