### PR TITLE
[stable/elastalert] Support referencing ES credentials from secret

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.2.4
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -49,40 +49,43 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-| Parameter                         | Description                                                                                                                   | Default                         |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| `image.repository`                | docker image                                                                                                                  | jertel/elastalert-docker        |
-| `image.tag`                       | docker image tag                                                                                                              | 0.2.4                           |
-| `image.pullPolicy`                | image pull policy                                                                                                             | IfNotPresent                    |
-| `podAnnotations`                  | Annotations to be added to pods                                                                                               | {}                              |
-| `command`                         | command override for container                                                                                                | `NULL`                          |
-| `args`                            | args override for container                                                                                                   | `NULL`                          |
-| `replicaCount`                    | number of replicas to run                                                                                                     | 1                               |
-| `elasticsearch.host`              | elasticsearch endpoint to use                                                                                                 | elasticsearch                   |
-| `elasticsearch.port`              | elasticsearch port to use                                                                                                     | 80                              |
-| `elasticsearch.useSsl`            | whether or not to connect to es_host using SSL                                                                                | False                           |
-| `elasticsearch.username`          | Username for ES with basic auth                                                                                               | `NULL`                          |
-| `elasticsearch.password`          | Password for ES with basic auth                                                                                               | `NULL`                          |
-| `elasticsearch.verifyCerts`       | whether or not to verify TLS certificates                                                                                     | True                            |
-| `elasticsearch.clientCert`        | path to a PEM certificate to use as the client certificate                                                                    | /certs/client.pem               |
-| `elasticsearch.clientKey`         | path to a private key file to use as the client key                                                                           | /certs/client-key.pem           |
-| `elasticsearch.caCerts`           | path to a CA cert bundle to use to verify SSL connections                                                                     | /certs/ca.pem                   |
-| `elasticsearch.certsVolumes`      | certs volumes, required to mount ssl certificates when elasticsearch has tls enabled                                          | `NULL`                          |
-| `elasticsearch.certsVolumeMounts` | mount certs volumes, required to mount ssl certificates when elasticsearch has tls enabled                                    | `NULL`                          |
-| `extraConfigOptions`              | Additional options to propagate to all rules, cannot be `alert`, `type`, `name` or `index`                                    | `{}`                            |
-| `optEnv`                          | Additional pod environment variable definitions                                                                               | []                              |
-| `extraVolumes`                    | Additional volume definitions                                                                                                 | []                              |
-| `extraVolumeMounts`               | Additional volumeMount definitions                                                                                            | []                              |
-| `serviceAccount.create`           | Specifies whether a service account should be created.                                                                        | `true`                          |
-| `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
-| `serviceAccount.annotations`      | ServiceAccount annotations                                                                                                    |                                 |
-| `podSecurityPolicy.create`        | Create pod security policy resources                                                                                          | `false`                         |
-| `resources`                       | Container resource requests and limits                                                                                        | {}                              |
-| `rules`                           | Rule and alert configuration for Elastalert                                                                                   | {} example shown in values.yaml |
-| `runIntervalMins`                 | Default interval between alert checks, in minutes                                                                             | 1                               |
-| `realertIntervalMins`             | Time between alarms for same rule, in minutes                                                                                 | `NULL`                          |
-| `alertRetryLimitMins`             | Time to retry failed alert deliveries, in minutes                                                                             | 2880 (2 days)                   |
-| `bufferTimeMins`                  | Default rule buffer time, in minutes                                                                                          | 15                              |
-| `writebackIndex`                  | Name or prefix of elastalert index(es)                                                                                        | elastalert_status               |
-| `nodeSelector`                    | Node selector for deployment                                                                                                  | {}                              |
-| `tolerations`                     | Tolerations for deployment                                                                                                    | []                              |
+| Parameter                                 | Description                                                                                                                   | Default                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `image.repository`                        | docker image                                                                                                                  | jertel/elastalert-docker        |
+| `image.tag`                               | docker image tag                                                                                                              | 0.2.4                           |
+| `image.pullPolicy`                        | image pull policy                                                                                                             | IfNotPresent                    |
+| `podAnnotations`                          | Annotations to be added to pods                                                                                               | {}                              |
+| `command`                                 | command override for container                                                                                                | `NULL`                          |
+| `args`                                    | args override for container                                                                                                   | `NULL`                          |
+| `replicaCount`                            | number of replicas to run                                                                                                     | 1                               |
+| `elasticsearch.host`                      | elasticsearch endpoint to use                                                                                                 | elasticsearch                   |
+| `elasticsearch.port`                      | elasticsearch port to use                                                                                                     | 80                              |
+| `elasticsearch.useSsl`                    | whether or not to connect to es_host using SSL                                                                                | False                           |
+| `elasticsearch.username`                  | Username for ES with basic auth                                                                                               | `NULL`                          |
+| `elasticsearch.password`                  | Password for ES with basic auth                                                                                               | `NULL`                          |
+| `elasticsearch.existingSecret`            | Specifies an existing secret to be used for the ES username/password auth                                                     | `NULL`                          |
+| `elasticsearch.existingSecretUsernameKey` | The key in elasticsearch.existingSecret that stores the ES password auth                                                      | `NULL`                          |
+| `elasticsearch.existingSecretPasswordKey` | The key in elasticsearch.existingSecret that stores the ES username auth                                                      | `NULL`                          |
+| `elasticsearch.verifyCerts`               | whether or not to verify TLS certificates                                                                                     | True                            |
+| `elasticsearch.clientCert`                | path to a PEM certificate to use as the client certificate                                                                    | /certs/client.pem               |
+| `elasticsearch.clientKey`                 | path to a private key file to use as the client key                                                                           | /certs/client-key.pem           |
+| `elasticsearch.caCerts`                   | path to a CA cert bundle to use to verify SSL connections                                                                     | /certs/ca.pem                   |
+| `elasticsearch.certsVolumes`              | certs volumes, required to mount ssl certificates when elasticsearch has tls enabled                                          | `NULL`                          |
+| `elasticsearch.certsVolumeMounts`         | mount certs volumes, required to mount ssl certificates when elasticsearch has tls enabled                                    | `NULL`                          |
+| `extraConfigOptions`                      | Additional options to propagate to all rules, cannot be `alert`, `type`, `name` or `index`                                    | `{}`                            |
+| `optEnv`                                  | Additional pod environment variable definitions                                                                               | []                              |
+| `extraVolumes`                            | Additional volume definitions                                                                                                 | []                              |
+| `extraVolumeMounts`                       | Additional volumeMount definitions                                                                                            | []                              |
+| `serviceAccount.create`                   | Specifies whether a service account should be created.                                                                        | `true`                          |
+| `serviceAccount.name`                     | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
+| `serviceAccount.annotations`              | ServiceAccount annotations                                                                                                    |                                 |
+| `podSecurityPolicy.create`                | Create pod security policy resources                                                                                          | `false`                         |
+| `resources`                               | Container resource requests and limits                                                                                        | {}                              |
+| `rules`                                   | Rule and alert configuration for Elastalert                                                                                   | {} example shown in values.yaml |
+| `runIntervalMins`                         | Default interval between alert checks, in minutes                                                                             | 1                               |
+| `realertIntervalMins`                     | Time between alarms for same rule, in minutes                                                                                 | `NULL`                          |
+| `alertRetryLimitMins`                     | Time to retry failed alert deliveries, in minutes                                                                             | 2880 (2 days)                   |
+| `bufferTimeMins`                          | Default rule buffer time, in minutes                                                                                          | 15                              |
+| `writebackIndex`                          | Name or prefix of elastalert index(es)                                                                                        | elastalert_status               |
+| `nodeSelector`                            | Node selector for deployment                                                                                                  | {}                              |
+| `tolerations`                             | Tolerations for deployment                                                                                                    | []                              |

--- a/stable/elastalert/templates/deployment.yaml
+++ b/stable/elastalert/templates/deployment.yaml
@@ -54,8 +54,20 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.optEnv }}
         env:
+{{- if .Values.elasticsearch.existingSecret }}
+          - name: ES_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.elasticsearch.existingSecret }}
+                key: {{ .Values.elasticsearch.existingSecretUsernameKey }}
+          - name: ES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.elasticsearch.existingSecret }}
+                key: {{ .Values.elasticsearch.existingSecretPasswordKey }}
+{{- end }}
+{{- if .Values.optEnv }}
 {{ .Values.optEnv | toYaml | indent 10}}
 {{- end }}
       restartPolicy: Always

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -47,6 +47,12 @@ elasticsearch:
   username: ""
   # Password if authenticating to ES with basic auth
   password: ""
+  # Specifies an existing secret to be used for the ES username/password
+  existingSecret: ""
+  # The key in elasticsearch.existingSecret that stores the ES password
+  existingSecretUsernameKey: ""
+  # The key in elasticsearch.existingSecret that stores the ES username
+  existingSecretPasswordKey: ""
   # whether or not to verify TLS certificates
   verifyCerts: "True"
   # Enable certificate based authentication


### PR DESCRIPTION
Please review @olemarkus @jertel 

#### What this PR does / why we need it:
Add support for referencing ES username/password from existing secret. This is useful for example when using Elastic Stack on Kubernetes which can automatically generate the ES credentials and store them in a secret.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
