### PR TITLE
[stable/stolon] Allow password files to be used

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.16.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -53,7 +53,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `replicationSecret.passwordKey`         | Password key of Postgres replication in secret | `pg_repl_password`                                           |
 | `replicationUsername`                   | Replication username                           | `repluser`                                                   |
 | `replicationPasswordFile`                     | File where to read the replication password                   |               |
-| `replicationPassword`                   | Replication password                           | (Required if `replicationSecret.name` is not set)            |
+| `replicationPassword`                   | Replication password                           | (Required if `replicationSecret.name` and `replicationPasswordFile` are not set)            |
 | `store.backend`                         | Store backend (kubernetes/consul/etcd)         | `kubernetes`                                                 |
 | `store.endpoints`                       | Store backend endpoints                        | `nil`                                                        |
 | `store.kubeResourceKind`                | Kubernetes resource kind (only for kubernetes) | `configmap`                                                  |

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -46,11 +46,13 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `superuserSecret.usernameKey`           | Username key of Postgres superuser in secret   | `pg_su_username`                                             |
 | `superuserSecret.passwordKey`           | Password key of Postgres superuser in secret   | `pg_su_password`                                             |
 | `superuserUsername`                     | Postgres superuser username                    | `stolon`                                                     |
-| `superuserPassword`                     | Postgres superuser password                    | (Required if `superuserSecret.name` is not set)              |
+| `superuserPasswordFile`                     | File where to read the Postgres superuser password                   |               |
+| `superuserPassword`                     | Postgres superuser password                    | (Required if `superuserSecret.name` and `superuserPasswordFile` are not set)              |
 | `replicationSecret.name`                | Postgres replication credential secret name    | `""`                                                         |
 | `replicationSecret.usernameKey`         | Username key of Postgres replication in secret | `pg_repl_username`                                           |
 | `replicationSecret.passwordKey`         | Password key of Postgres replication in secret | `pg_repl_password`                                           |
 | `replicationUsername`                   | Replication username                           | `repluser`                                                   |
+| `replicationPasswordFile`                     | File where to read the replication password                   |               |
 | `replicationPassword`                   | Replication password                           | (Required if `replicationSecret.name` is not set)            |
 | `store.backend`                         | Store backend (kubernetes/consul/etcd)         | `kubernetes`                                                 |
 | `store.endpoints`                       | Store backend endpoints                        | `nil`                                                        |

--- a/stable/stolon/templates/NOTES.txt
+++ b/stable/stolon/templates/NOTES.txt
@@ -1,8 +1,10 @@
 Stolon cluster installed and initialized.
 
+{{ if empty .Values.superuserPasswordFile }}
 To get superuser password run
 {{ if not (empty .Values.superuserSecret.name) }}
     PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ .Values.superuserSecret.name }} -o jsonpath="{.data.{{.Values.superuserSecret.passwordKey}}}" | base64 --decode; echo)
 {{ else }}
     PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "stolon.fullname" . }} -o jsonpath="{.data.pg_su_password}" | base64 --decode; echo)
+{{ end }}
 {{ end }}

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -87,6 +87,8 @@ spec:
             - name: STKEEPER_PG_REPL_PASSWORDFILE
 {{ if not (empty .Values.replicationSecret.name) }}
               value: /etc/secrets/stolon-{{ .Values.replicationSecret.name }}/{{ .Values.replicationSecret.passwordKey }}
+{{ else if not (empty .Values.replicationPasswordFile) }}
+              value: {{ .Values.replicationPasswordFile }}
 {{ else }}
               value: "/etc/secrets/stolon/pg_repl_password"
 {{ end }}
@@ -102,6 +104,8 @@ spec:
             - name: STKEEPER_PG_SU_PASSWORDFILE
 {{ if not (empty .Values.superuserSecret.name) }}
               value: /etc/secrets/stolon-{{ .Values.superuserSecret.name }}/{{ .Values.superuserSecret.passwordKey }}
+{{ else if not (empty .Values.superuserPasswordFile) }}
+              value: {{ .Values.superuserPasswordFile }}
 {{ else }}
               value: "/etc/secrets/stolon/pg_su_password"
 {{ end }}
@@ -130,7 +134,7 @@ spec:
           - name: certs
             mountPath: /certs
 {{- end }}
-{{ if or (empty .Values.superuserSecret.name) (empty .Values.replicationSecret.name) }}
+{{ if and (or (empty .Values.superuserSecret.name) (empty .Values.replicationSecret.name)) (or (empty .Values.superuserPasswordFile) (empty .Values.replicationPasswordFile)) }}
           - name: stolon-secrets
             mountPath: /etc/secrets/stolon
 {{ end }}

--- a/stable/stolon/templates/secret.yaml
+++ b/stable/stolon/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if or (empty .Values.superuserSecret.name) (empty .Values.replicationSecret.name) }}
+{{ if or (and (empty .Values.superuserSecret.name) (empty .Values.superuserPasswordFile)) (and (empty .Values.replicationSecret.name) (empty .Values.replicationPasswordFile)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,10 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-{{ if empty .Values.superuserSecret.name }}
+{{ if and (empty .Values.superuserSecret.name) (empty .Values.superuserPasswordFile) }}
   pg_su_password: {{ required "A valid .Values.superuserPassword entry is required!" .Values.superuserPassword | b64enc | quote }}
 {{ end }}
-{{ if empty .Values.replicationSecret.name }}
+{{ if and (empty .Values.replicationSecret.name) (empty .Values.replicationPasswordFile) }}
   pg_repl_password: {{ required "A valid .Values.replicationPassword entry is required!" .Values.replicationPassword | b64enc | quote }}
 {{ end }}
 {{ end }}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -50,12 +50,16 @@ replicationSecret:
   usernameKey: pg_repl_username
   passwordKey: pg_repl_password
 
+superuserPasswordFile:
+
 superuserUsername: "stolon"
-## password for the superuser (REQUIRED if superuserSecret is not set)
+## password for the superuser (REQUIRED if superuserSecret and superuserPasswordFile are not set)
 superuserPassword:
 
+replicationPasswordFile:
+
 replicationUsername: "repluser"
-## password for the replication user (REQUIRED if replicationSecret is not set)
+## password for the replication user (REQUIRED if replicationSecret and replicationPasswordFile are not set)
 replicationPassword:
 
 ## backend could be one of the following: consul, etcdv2, etcdv3 or kubernetes


### PR DESCRIPTION
#### What this PR does / why we need it:
The goal of this PR is for the Stolon chart to provide a way for the superuser and replication passwords to be provided via a file, instead of via secret or env var. This is useful to load passwords from a tool such as HashiCorp Vault.

Signed-off-by: Tiago Posse <tiagoposse@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
