### PR TITLE
[stable/prometheus-blackbox-exporter] Fix blackbox target's metrics labels

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.1.1
+version: 4.2.0
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -26,10 +26,8 @@ spec:
       target:
       - {{ .url }}
     metricRelabelings:
-      - sourceLabels: [__address__]
-        targetLabel: __param_target
-      - sourceLabels: [__param_target]
-        targetLabel: instance
+      - targetLabel: instance
+        replacement: {{ .url }}
       - targetLabel: target
         replacement: {{ .name }}
   jobLabel: "{{ $.Release.Name }}"
@@ -42,4 +40,3 @@ spec:
       - {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}
-


### PR DESCRIPTION
The metrics labels currently generated does not match what is generated
by the setup described here: https://prometheus.io/docs/guides/multi-target-exporter/#querying-multi-target-exporters-with-prometheus
and https://github.com/prometheus/blackbox_exporter#prometheus-configuration

The previous metricsRelabeling is only valid if the target contains the URLs to
check.

What we need in the end is:
- `__address__` set to the blackbox exporter, and it it already the case
as the `selector` matches the blackbox exporter,
- `__param_target` set to the target to check, and it is already ensure
without relabeling,
- `instance` set to the target to check.

This patches ensures that the metrics has this labels:

```
probe_success{endpoint="http",instance="http://prometheus.io",job="blackbox-exporter-prometheus-blackbox-exporter",namespace="monitoring",pod="blackbox-exporter-prometheus-blackbox-exporter-84d9b64646-vgqcc",service="blackbox-exporter-prometheus-blackbox-exporter",target="prometheus-io"} 1
```

Without this patch, we have this (note that we lost the `instance` label):

```
probe_success{endpoint="http",job="blackbox-exporter-prometheus-blackbox-exporter",namespace="monitoring",pod="blackbox-exporter-prometheus-blackbox-exporter-84d9b64646-vgqcc",service="blackbox-exporter-prometheus-blackbox-exporter",target="prometheus-io"} 1
```

Signed-off-by: Mickaël Canévet <mickael.canevet@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
