### PR TITLE
[stable/airflow] Add requirements.txt file availability check to install-requirements script

### DIFF
--- a/stable/airflow/templates/configmap-scripts.yaml
+++ b/stable/airflow/templates/configmap-scripts.yaml
@@ -16,11 +16,17 @@ data:
     fi
 
     cd {{ .Values.dags.path | quote }}
-    if [ -f requirements.txt ]; then
-      pip install --user -r requirements.txt
-    else
-      exit 0
-    fi
+    COUNT=0
+    while [ "${COUNT}" -lt 10 ]; do
+      if [ -f requirements.txt ]; then
+        pip install --user -r requirements.txt
+        exit 0
+      else
+        ((COUNT++))
+        echo "*** File requirements.txt not found: waiting 5s before retry #${COUNT}"
+        wait 5
+      fi
+    done
   graceful-stop-celery-worker.sh: |
     #!/bin/bash -e
     echo "*** starting graceful worker shutdown"


### PR DESCRIPTION
#### What this PR does / why we need it:

With version 7.1.0 we stop waiting for 60s before running the scripts for workers. Instead we use `workers.initialStartupDelay` which is 0 by default. I faced an issue where with `git-sync` where the check for `requirements.txt` file is made before the first complete run of `git-sync` in `install-requirements.sh`, so I propose to wait for its existence. 

Since the script is only executed when `dag.installRequirements` is `true`, I believe this check is always required with `git-sync`:
https://github.com/helm/charts/blob/10c341f488e668a18beedffcee3afcd60afd0bcb/stable/airflow/templates/statefulsets-workers.yaml#L213

#### Which issue this PR fixes
  - related to the following change https://github.com/helm/charts/commit/10c341f488e668a18beedffcee3afcd60afd0bcb#diff-5a0766fabc7c2a405992f3f99aa52303L196

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
