### PR TITLE
[stable/elasticsearch] add podAffinity to deployments

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.32.4
+version: 1.32.5
 appVersion: 6.8.6
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.32.5
+version: 1.33.0
 appVersion: 6.8.6
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |
 | `client.nodeAffinity`                | Client node affinity policy                                         | `{}`                                                |
+| `client.podAffinity`                 | Client pod affinity policy                                          | `{}`                                                |
 | `client.initResources`               | Client initContainer resources requests & limits                    | `{}`                                                |
 | `client.hooks.preStop`               | Client nodes: Lifecycle hook script to execute prior the pod stops  | `nil`                                               |
 | `client.hooks.preStart`              | Client nodes: Lifecycle hook script to execute after the pod starts | `nil`                                               |
@@ -136,6 +137,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.readinessProbe`              | Master container readiness probes                                   | see `values.yaml` for defaults                      |
 | `master.antiAffinity`                | Master anti-affinity policy                                         | `soft`                                              |
 | `master.nodeAffinity`                | Master node affinity policy                                         | `{}`                                                |
+| `master.podAffinity`                 | Master pod affinity policy                                          | `{}`                                                |
 | `master.podManagementPolicy`         | Master pod creation strategy                                        | `OrderedReady`                                      |
 | `master.updateStrategy`              | Master node update strategy policy                                  | `{type: "onDelete"}`                                |
 | `master.hooks.preStop`               | Master nodes: Lifecycle hook script to execute prior the pod stops  | `nil`                                               |
@@ -162,6 +164,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                                              |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                                              |
 | `data.nodeAffinity`                  | Data node affinity policy                                           | `{}`                                                |
+| `data.podAffinity`                   | Data pod affinity policy                                            | `{}`                                                |
 | `data.podManagementPolicy`           | Data pod creation strategy                                          | `OrderedReady`                                      |
 | `data.updateStrategy`                | Data node update strategy policy                                    | `{type: "onDelete"}`                                |
 | `sysctlInitContainer.enabled`        | If true, the sysctl init container is enabled (does not stop chownInitContainer or extraInitContainers from running) | `true`                                              |

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -33,7 +33,7 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if or .Values.client.antiAffinity .Values.client.nodeAffinity }}
+      {{- if or .Values.client.antiAffinity .Values.client.nodeAffinity .Values.client.podAffinity }}
       affinity:
       {{- end }}
       {{- if eq .Values.client.antiAffinity "hard" }}
@@ -59,6 +59,10 @@ spec:
       {{- end }}
       {{- with .Values.client.nodeAffinity }}
         nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      {{- with .Values.client.podAffinity }}
+        podAffinity:
 {{ toYaml . | indent 10 }}
       {{- end }}
 {{- if .Values.client.nodeSelector }}

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -43,7 +43,7 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if or .Values.data.antiAffinity .Values.data.nodeAffinity }}
+      {{- if or .Values.data.antiAffinity .Values.data.nodeAffinity .Values.data.podAffinity }}
       affinity:
       {{- end }}
       {{- if eq .Values.data.antiAffinity "hard" }}
@@ -69,6 +69,10 @@ spec:
       {{- end }}
       {{- with .Values.data.nodeAffinity }}
         nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      {{- with .Values.data.podAffinity }}
+        podAffinity:
 {{ toYaml . | indent 10 }}
       {{- end }}
 {{- if .Values.data.nodeSelector }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -43,7 +43,7 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if or .Values.master.antiAffinity .Values.master.nodeAffinity }}
+      {{- if or .Values.master.antiAffinity .Values.master.nodeAffinity .Values.master.podAffinity }}
       affinity:
       {{- end }}
       {{- if eq .Values.master.antiAffinity "hard" }}
@@ -69,6 +69,10 @@ spec:
       {{- end }}
       {{- with .Values.master.nodeAffinity }}
         nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      {{- with .Values.master.podAffinity }}
+        podAffinity:
 {{ toYaml . | indent 10 }}
       {{- end }}
 {{- if .Values.master.nodeSelector }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -122,6 +122,7 @@ client:
   # additionalJavaOpts: "-XX:MaxRAM=512m"
   antiAffinity: "soft"
   nodeAffinity: {}
+  podAffinity: {}
   nodeSelector: {}
   tolerations: []
   # terminationGracePeriodSeconds: 60
@@ -187,6 +188,7 @@ master:
     initialDelaySeconds: 5
   antiAffinity: "soft"
   nodeAffinity: {}
+  podAffinity: {}
   nodeSelector: {}
   tolerations: []
   # terminationGracePeriodSeconds: 60
@@ -242,6 +244,7 @@ data:
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
   nodeAffinity: {}
+  podAffinity: {}
   nodeSelector: {}
   tolerations: []
   initResources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds ability to set `podAffinity` for Elasticsearch deployments

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
