### PR TITLE
[stable/prometheus-blackbox-exporter] fix(#22099 & #22100): prometheu…

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.1.0
+version: 4.1.1
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" $ }}
     {{- with .Values.prometheusRule.additionalLabels }}
-{{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   {{- with .Values.prometheusRule.rules }}


### PR DESCRIPTION
## Is this a new chart
No

#### What this PR does / why we need it:
```
Error: UPGRADE FAILED: YAML parse error on prometheus-blackbox-exporter/templates/prometheusrule.yaml: error converting YAML to JSON: yaml: line 9: mapping values are not allowed in this context
```

#### Which issue this PR fixes
  - 22099
  - 22100

#### Special notes for your reviewer:
See: https://github.com/helm/charts/pull/22100

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
