### PR TITLE
[stable/nfs-server-provisioner] "statdNodePort" is not used in services.yaml

### DIFF
--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.0.0
+version: 1.0.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/stable/nfs-server-provisioner/templates/service.yaml
+++ b/stable/nfs-server-provisioner/templates/service.yaml
@@ -85,14 +85,14 @@ spec:
       protocol: TCP
       name: statd
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
-      nodePort: {{ .Values.service.statdPort }}
+      nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
     - port: {{ .Values.service.statdPort }}
       targetPort: statd-udp
       protocol: UDP
       name: statd-udp
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
-      nodePort: {{ .Values.service.statdPort }}
+      nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
  - "statdNodePort" is not used in services.yaml
#### Which issue this PR fixes
  - no issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
