### PR TITLE
[stable/jenkins] Allow templating of all string values except type for kubernetes volumes plugin xml

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.21.4
+        
+In the `jenkins.xml.podTemplate` helper function, allow templating of all string values under `agent.volumes` except `type` by rendering them with the `tpl` function
+
 ## 1.21.3
 
 Render `agent.envVars` in kubernetes pod template JCasC

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.21.3
+version: 1.21.4
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -264,7 +264,7 @@ Returns kubernetes pod template xml configuration
     <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
   {{- end }}
   {{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
-      <{{ $key }}>{{ $value }}</{{ $key }}>
+      <{{ $key }}>{{ if kindIs "string" $value }}{{ tpl $value $ | quote }}{{ else }}{{ $value }}{{ end -}}</{{ $key }}>
   {{- end }}{{- end }}
   {{- if (eq $volume.type "PVC") }}
     </org.csanchez.jenkins.plugins.kubernetes.volumes.PersistentVolumeClaim>


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow templating of all string values except type for volumes list in kubernetes volumes plugin xml

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

These values are already templated for the jenkins.casc.podTemplate helper function. This PR repeats the same templating for the jenkins.xml.podTemplate helper function. 

This will allow us to gererate chart specfic names for volume mounts and configure the kubernetes plugin accordingly with xml. 

Code Snippets to illustrate the functionality that has been duplicated.

Templating already present in:
```
{{- define "jenkins.casc.podTemplate" -}}
...
        {{ $key }}: {{ if kindIs "string" $value }}{{ tpl $value $ | quote }}{{ else }}{{ $value }}{{ end }}
```

Templating introduced for:
```
{{- define "jenkins.xml.podTemplate" -}}
...
      <{{ $key }}>{{ if kindIs "string" $value }}{{ tpl $value $ | quote }}{{ else }}{{ $value }}{{ end -}}</{{ $key }}>
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
