### PR TITLE
[stable/coredns] - add all options to cluster-proportional-autoscaler

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.10.1
+version: 1.11.0
 appVersion: 1.6.9
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -79,6 +79,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaler.enabled`                    | Optionally enabled a cluster-proportional-autoscaler for CoreDNS                      | `false`                                                     |
 | `autoscaler.coresPerReplica`            | Number of cores in the cluster per CoreDNS replica                                    | `256`                                                       |
 | `autoscaler.nodesPerReplica`            | Number of nodes in the cluster per CoreDNS replica                                    | `16`                                                        |
+| `autoscaler.min`                        | Min size of replicaCount                                                              | 0                                                           |
+| `autoscaler.max`                        | Max size of replicaCount                                                              | 0  (aka no max)                                             |
+| `autoscaler.includeUnschedulableNodes`  | Should the replicas scale based on the total number or only schedulable nodes         | `false`                                                     |
+| `autoscaler.preventSinglePointFailure`  | If true does not allow single points of failure to form                               | `true`                                                      |
 | `autoscaler.image.repository`           | The image repository to pull autoscaler from                                          | k8s.gcr.io/cluster-proportional-autoscaler-amd64            |
 | `autoscaler.image.tag`                  | The image tag to pull autoscaler from                                                 | `1.7.1`                                                     |
 | `autoscaler.image.pullPolicy`           | Image pull policy for the autoscaler                                                  | IfNotPresent                                                |

--- a/stable/coredns/templates/configmap-autoscaler.yaml
+++ b/stable/coredns/templates/configmap-autoscaler.yaml
@@ -29,6 +29,9 @@ data:
     {
       "coresPerReplica": {{ .Values.autoscaler.coresPerReplica | float64 }},
       "nodesPerReplica": {{ .Values.autoscaler.nodesPerReplica | float64 }},
-      "preventSinglePointFailure": true
+      "preventSinglePointFailure": {{ .Values.autoscaler.preventSinglePointFailure }},
+      "min": {{ .Values.autoscaler.min | int }},
+      "max": {{ .Values.autoscaler.max | int }},
+      "includeUnschedulableNodes": {{ .Values.autoscaler.includeUnschedulableNodes }}
     }
 {{- end }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -163,10 +163,18 @@ autoscaler:
   coresPerReplica: 256
   # Number of nodes in the cluster per coredns replica
   nodesPerReplica: 16
+  # Min size of replicaCount
+  min: 0
+  # Max size of replicaCount (default of 0 is no max)
+  max: 0
+  # Whether to include unschedulable nodes in the nodes/cores calculations - this requires version 1.8.0+ of the autoscaler
+  includeUnschedulableNodes: false
+  # If true does not allow single points of failure to form
+  preventSinglePointFailure: true
 
   image:
     repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
-    tag: "1.7.1"
+    tag: "1.8.0"
     pullPolicy: IfNotPresent
 
   # Optional priority class to be used for the autoscaler pods. priorityClassName used if not set.


### PR DESCRIPTION
Signed-off-by: Alex Williams <alex.williams@skyscanner.net>

#### Is this a new chart
No

#### What this PR does / why we need it:
This adds additional options to the cluster-proportional-autoscaler. The most important being `min` which helps with resiliency.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
I made sure that all of the options are available, including the new `includeUnschedulableNodes` which requires `1.8.0` of `cluster-proportional-autoscaler`. Before `preventSinglePointFailure` was hard coded to `true` which seems very sensible, but I have made it configurable just incase.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
