### PR TITLE
[stable/datadog] Fix an agent warning at startup because of a deprecated parameter

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.7
+
+* Fix an agent warning at startup because of a deprecated parameter
+
 ## 2.3.6
 
 * Add `affinity` parameter in `values.yaml` for cluster agent deployment

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.6
+version: 2.3.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -2,7 +2,7 @@
 - name: agent
   image: "{{ .Values.agents.image.repository }}:{{ .Values.agents.image.tag }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["agent", "start"]
+  command: ["agent", "run"]
   resources:
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}
   ports:


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

Launch the agent with `agent run` instead of `agent start`

#### Which issue this PR fixes

The agent logged the following warning at startup:
```
Command "start" is deprecated, Use "run" instead to start the Agent
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
