### PR TITLE
[stable/airflow] Adding a secretMap instead of adding multiple secrets

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.1.1
+version: 7.1.2
 appVersion: 1.10.10
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -572,6 +572,7 @@ __Airflow WebUI Values:__
 | `web.livenessProbe.*` | configs for the web Service liveness probe | `<see values.yaml>` |
 | `web.secretsDir` | the directory in which to mount secrets on web containers | `/var/airflow/secrets` |
 | `web.secrets` | secret names which will be mounted as a file at `{web.secretsDir}/<secret_name>` | `[]` |
+| `web.secretsMap` | you can use secretsMap to specify a map and all the secrets will be stored within it secrets will be mounted as files at `{web.secretsDir}/<secrets_in_map>`. If you use web.secretsMap, then it overrides `web.secrets`.| `""` |
 
 __Airflow Worker Values:__
 
@@ -593,6 +594,7 @@ __Airflow Worker Values:__
 | `workers.terminationPeriod` | how many seconds to wait for tasks on a worker to finish before SIGKILL | `60` |
 | `workers.secretsDir` | directory in which to mount secrets on worker containers | `/var/airflow/secrets` |
 | `workers.secrets` | secret names which will be mounted as a file at `{workers.secretsDir}/<secret_name>` | `[]` |
+| `workers.secretsMap` | you can use secretsMap to specify a map and all the secrets will be stored within it secrets will be mounted as files at `{workers.secretsDir}/<secrets_in_map>`. If you use workers.secretsMap, then it overrides `workers.secrets`.| `""` |
 
 __Airflow Flower Values:__
 

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -154,10 +154,16 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /home/airflow/scripts
+            {{- if .Values.web.secretsMap }}
+            - name: {{ .Values.web.secretsMap }}-volume
+              readOnly: true
+              mountPath: {{ $.Values.web.secretsDir }}
+            {{- else }}
             {{- range .Values.web.secrets }}
             - name: {{ . }}-volume
               readOnly: true
               mountPath: {{ $.Values.web.secretsDir }}/{{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.dags.persistence.enabled }}
             - name: dags-data
@@ -255,10 +261,16 @@ spec:
           configMap:
             name: {{ include "airflow.fullname" . }}-scripts
             defaultMode: 0755
+        {{- if .Values.web.secretsMap }}
+        - name: {{ .Values.web.secretsMap }}-volume
+          secret:
+            secretName: {{ .Values.web.secretsMap }}
+        {{- else }}
         {{- range .Values.web.secrets }}
         - name: {{ . }}-volume
           secret:
             secretName: {{ . }}
+        {{- end }}
         {{- end }}
         {{- if .Values.dags.persistence.enabled }}
         - name: dags-data

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -159,10 +159,16 @@ spec:
             - name: scripts
               mountPath: /home/airflow/scripts
             {{- $secretsDir := .Values.workers.secretsDir }}
+            {{- if .Values.workers.secretsMap }}
+            - name: {{ .Values.workers.secretsMap }}-volume
+              readOnly: true
+              mountPath: {{ $secretsDir }}
+            {{- else }}
             {{- range .Values.workers.secrets }}
             - name: {{ . }}-volume
               readOnly: true
               mountPath: {{ $secretsDir }}/{{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.dags.persistence.enabled }}
             - name: dags-data
@@ -234,10 +240,16 @@ spec:
           configMap:
             name: {{ include "airflow.fullname" . }}-scripts
             defaultMode: 0755
+        {{- if .Values.workers.secretsMap }}
+        - name: {{ .Values.workers.secretsMap }}-volume
+          secret:
+            secretName: {{ .Values.workers.secretsMap }}
+        {{- else }}
         {{- range .Values.workers.secrets }}
         - name: {{ . }}-volume
           secret:
             secretName: {{ . }}
+        {{- end }}
         {{- end }}
         {{- if .Values.dags.persistence.enabled }}
         - name: dags-data

--- a/stable/airflow/values-test.yaml
+++ b/stable/airflow/values-test.yaml
@@ -104,7 +104,25 @@ airflow:
   ##           name: airflow-ldap-password
   ##           key: value
   ##
-  extraEnv: []
+  extraEnv:
+    - name: AIRFLOW__GOOGLE__CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: airflow
+          key: google_client_id
+    - name: AIRFLOW__GOOGLE__CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: airflow
+          key: google_client_secret
+    - name: AIRFLOW__GOOGLE__OAUTH_CALLBACK_ROUTE
+      value: "/oauth2callback"
+    - name: AIRFLOW__GOOGLE__DOMAIN
+      value: "tractable.ai"
+    - name: AIRFLOW__WEBSERVER__AUTHENTICATE
+      value: "True"
+    - name: AIRFLOW__WEBSERVER__AUTH_BACKEND
+      value: airflow.contrib.auth.backends.google_auth
 
   ## extra configMap volumeMounts for the web/scheduler/worker Pods
   ##
@@ -136,7 +154,13 @@ airflow:
   ##   extraPipPackages:
   ##     - "airflow-exporter==1.3.1"
   ##
-  extraPipPackages: []
+  extraPipPackages:
+    - "airflow-exporter"
+    - "apache-airflow[aws]"
+    - "apache-airflow[mysql]"
+    - "apache-airflow[postgres]"
+    - "apache-airflow[slack]"
+    - "apache-airflow[statsd]"
 
   ## extra volumeMounts for the web/scheduler/worker Pods
   ##
@@ -366,7 +390,7 @@ web:
   ## NOTE:
   ## - should be compatible with `ingress.web.path` config
   ##
-  baseUrl: "http://localhost:8080"
+  baseUrl: "https://airflow.dev.k8s.tractable.io"
 
   ## sets `AIRFLOW__CORE__STORE_SERIALIZED_DAGS`
   ##
@@ -382,7 +406,8 @@ web:
   ##   extraPipPackages:
   ##     - "apache-airflow[google_auth]==1.10.10"
   ##
-  extraPipPackages: []
+  extraPipPackages:
+    - "apache-airflow[google_auth]==1.10.10"
 
   ## the number of seconds to wait (in bash) before starting the web container
   ##
@@ -431,15 +456,7 @@ web:
   ##     - airflow-web-secret
   ##
   secrets: []
-
-  ## you can use secretsMap to specify a map and all the secrets will be stored within it
-  ## secrets will be mounted as files at `{web.secretsDir}/<secrets_in_map>`
-  ## If you use web.secretsMap, then it overrides web.secrets.
-  ##
-  ## EXAMPLE:
-  ## secretsMap: airflow-secrets
-  ##
-  secretsMap:
+  # secretsMap: "airflow"
 
 ###################################
 # Airflow - Worker Configs
@@ -552,15 +569,6 @@ workers:
   ##     - airflow-worker-secret
   ##
   secrets: []
-
-  ## you can use secretsMap to specify a map and all the secrets will be stored within it
-  ## secrets will be mounted as files at `{workers.secretsDir}/<secrets_in_map>`
-  ## If you use web.secretsMap, then it overrides workers.secrets.
-  ##
-  ## EXAMPLE:
-  ## secretsMap: airflow-secrets
-  ##
-  secretsMap:
 
 ###################################
 # Airflow - Flower Configs
@@ -749,15 +757,7 @@ dags:
   ## configs for the DAG git repository & sync container
   ##
   git:
-    ## url of the git repository
-    ##
-    ## EXAMPLE: (HTTP)
-    ##   url: "https://github.com/torvalds/linux.git"
-    ##
-    ## EXAMPLE: (SSH)
-    ##   url: "ssh://git@github.com:torvalds/linux.git"
-    ##
-    url: ""
+    url: "ssh://git@bitbucket.org/xmachinas/tractable.airflow.git"
 
     ## the branch/tag/sha1 which we clone
     ##
@@ -770,7 +770,7 @@ dags:
     ## - the secret commonly includes files: id_rsa, id_rsa.pub, known_hosts
     ## - known_hosts is NOT NEEDED if `git.sshKeyscan` is true
     ##
-    secret: ""
+    secret: airflow
 
     ## if we should implicitly trust [git.repoHost]:git.repoPort, by auto creating a ~/.ssh/known_hosts
     ##
@@ -782,7 +782,7 @@ dags:
     ## - this is not needed if known_hosts is provided in `git.secret`
     ## - git.repoHost and git.repoPort ARE REQUIRED for this to work
     ##
-    sshKeyscan: false
+    sshKeyscan: true
 
     ## the name of the private key file in your `git.secret`
     ##
@@ -799,7 +799,7 @@ dags:
     ## EXAMPLE:
     ##   repoHost: "github.com"
     ##
-    repoHost: ""
+    repoHost: "bitbucket.org"
 
     ## the port of the git repo
     ##
@@ -852,7 +852,7 @@ dags:
     ## - this is NOT required for the git-sync sidecar to work
     ## - in most environments, you can leave this as false
     ##
-    enabled: false
+    enabled: true
 
     ## resource requests/limits for the git-clone container
     ##
@@ -887,134 +887,7 @@ dags:
     ## EXAMPLE:
     ##   syncSubPath: "/subdirWithDags"
     ##
-    syncSubPath: ""
-
-###################################
-# Kubernetes - Ingress Configs
-###################################
-ingress:
-  ## if we should deploy Ingress resources
-  ##
-  ## NOTE:
-  ## - if you want to change url prefix for web ui or flower (even if you do not use this Ingress),
-  ##   you can change `web.baseUrl` and `flower.urlPrefix`
-  ##
-  enabled: false
-
-  ## configs for the Ingress of the web Service
-  ##
-  web:
-    ## annotations for the web Ingress
-    ##
-    annotations: {}
-
-    ## the path for the web Ingress
-    ##
-    ## WARNING:
-    ## - do NOT include the trailing slash (for root, set an empty string)
-    ##
-    ## NOTE:
-    ## - should be compatible with `web.baseUrl` config
-    ##
-    ## EXAMPLE: (if set to "/airflow")
-    ## - UI:     http://example.com/airflow/admin
-    ## - API:    http://example.com/airflow/api
-    ## - HEALTH: http://example.com/airflow/health
-    ##
-    path: ""
-
-    ## the hostname for the web Ingress
-    ##
-    host: ""
-
-    ## the livenessPath for the web Ingress
-    ##
-    ## NOTE:
-    ## - if set to "", defaults to: `{ingress.web.path}/health`
-    ##
-    livenessPath: ""
-
-    ## configs for web Ingress TLS
-    ##
-    tls:
-      ## enable TLS termination for the web Ingress
-      ##
-      enabled: false
-
-      ## the name of a pre-created Secret containing a TLS private key and certificate
-      ##
-      ## NOTE:
-      ## - this MUST be specified if `ingress.web.tls.enabled` is true
-      ##
-      secretName: ""
-
-    ## http paths to add to the web Ingress before the default path
-    ##
-    ## EXAMPLE:
-    ##   precedingPaths:
-    ##     - path: "/*"
-    ##       serviceName: "ssl-redirect"
-    ##       servicePort: "use-annotation"
-    ##
-    precedingPaths: []
-
-    ## http paths to add to the web Ingress after the default path
-    ##
-    ## EXAMPLE:
-    ##   succeedingPaths:
-    ##     - path: "/extra-service"
-    ##       serviceName: "extra-service"
-    ##       servicePort: "use-annotation"
-    ##
-    succeedingPaths: []
-
-  ## configs for the Ingress of the flower Service
-  ##
-  flower:
-    ## annotations for the flower Ingress
-    ##
-    annotations: {}
-
-    ## the path for the flower Ingress
-    ##
-    ## WARNING:
-    ## - do NOT include the trailing slash (for root, set an empty string)
-    ##
-    ## NOTE:
-    ## - should match `flower.urlPrefix` config
-    ##
-    ## EXAMPLE: (if set to "/airflow/flower")
-    ## - UI: http://example.com/airflow/flower
-    ##
-    path: ""
-
-    ## the hostname for the flower Ingress
-    ##
-    host: ""
-
-    ## the livenessPath for the flower Ingress
-    ##
-    ## WARNING:
-    ## - keep the trailing slash
-    ##
-    ## NOTE:
-    ## - if set to "", defaults to: `{ingress.flower.path}/`
-    ##
-    livenessPath: ""
-
-    ## configs for flower Ingress TLS
-    ##
-    tls:
-      ## enable TLS termination for the flower Ingress
-      ##
-      enabled: false
-
-      ## the name of a pre-created Secret containing a TLS private key and certificate
-      ##
-      ## NOTE:
-      ## - this MUST be specified if `ingress.flower.tls.enabled` is true
-      ##
-      secretName: ""
+    syncSubPath: "/src/dags"
 
 ###################################
 # Kubernetes - RBAC


### PR DESCRIPTION
#### What this PR does / why we need it:
This will allow you to specify a kubernetes Secret kind which will load all it's values in the map instead of having to specify each secret individually. You can use the `secrets: []` and can switch to `secretsMap:` when ready.
#### Which issue this PR fixes
N/A
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
