### PR TITLE
[stable/datadog] Fix templating errors when passing the cluster agent config as yaml

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.8
+
+* Fix templating errors when `clusterAgent.datadog_cluster_yaml` is being used.
+
 ## 2.3.7
 
 * Fix an agent warning at startup because of a deprecated parameter

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.7
+version: 2.3.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/cluster-agent-config-configmap.yaml
+++ b/stable/datadog/templates/cluster-agent-config-configmap.yaml
@@ -12,9 +12,10 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   annotations:
     checksum/clusteragent-config: {{ tpl (toYaml .Values.clusterAgent.datadog_cluster_yaml) . | sha256sum }}
 data:
-{{tpl (toYaml .Values.clusterAgent.datadog_cluster_yaml) . | indent 2}}
+  datadog-cluster.yaml: |
+{{ tpl (toYaml .Values.clusterAgent.datadog_cluster_yaml) . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Wrap `clusterAgent.datadog_cluster_yaml` under a file key instead of passing it directly as the configmap data since non-flat yaml is not valid here.

For instance:

```yaml
clusterAgent:
  datadog_cluster_yaml:
    key: value
```

would work, but:
 
```yaml
clusterAgent:
  datadog_cluster_yaml:
    key:
      another_key: value
```

would not.

Also, caught missing quotes that would yield another error

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
