### PR TITLE
stable/grafana Grafana statefulset pod labels

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.3.2
+version: 5.3.3
 appVersion: 7.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/statefulset.yaml
+++ b/stable/grafana/templates/statefulset.yaml
@@ -20,6 +20,9 @@ spec:
     metadata:
       labels:
         {{- include "grafana.selectorLabels" . | nindent 8 }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/dashboards-json-config: {{ include (print $.Template.BasePath "/dashboards-json-configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
What this PR does / why we need it:

Statefulset does not use the podLabels variable, unlike deployments. 

New PR for #21874 which got closed as i had not DCO signed..

Checklist

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
