### PR TITLE
[stable/spinnaker] Add checksum for configmap in hook template

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc3
+version: 2.0.0-rc4
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -11,10 +11,11 @@ metadata:
 spec:
   template:
     metadata:
-    {{- if .Values.halyard.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap/halyard-config.yaml") . | sha256sum }}
+          {{- if .Values.halyard.annotations }}
 {{ toYaml .Values.halyard.annotations | indent 8 }}
-    {{- end }}
+          {{- end }}
       labels:
 {{ include "spinnaker.standard-labels" . | indent 8 }}
     spec:


### PR DESCRIPTION
Signed-off-by: Ben Lamm <ben.lamm@outlook.com>


#### Is this a new chart
No

#### What this PR does / why we need it:
To automatically roll the pod for `install-using-hal` I add a checksum function in the annotations if the related configmap `halyard-config.yaml`-file changes.
We need this because if we deploy the chart with Terraform we have to add the `recreate-pods` flag to roll the pod. This is required to successfully apply the some changes in the `values.yaml` (e.g. the spinnaker version). With Helm 3 this is not the recommended option (https://helm.sh/docs/howto/charts_tips_and_tricks/). Instead use the more declarative method above. Recently we moved from Terraform to Pulumi and there is no option for `recreate-pods`. So we have no chance to roll the pod after configmap changes automatically and need the checksum function.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
Successfully tested locally. 

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
