### PR TITLE
[stable/kube-state-metrics] Set runAsGroup

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.7
+version: 2.8.8
 appVersion: 1.9.6
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -32,7 +32,8 @@ $ helm install stable/kube-state-metrics
 | `podSecurityPolicy.annotations`              | Specify pod annotations in the pod security policy                                    | {}                                         |
 | `podSecurityPolicy.additionalVolumes`        | Specify allowed volumes in the pod security policy (`secret` is always allowed)       | []                                         |
 | `securityContext.enabled`                    | Enable security context                                                               | `true`                                     |
-| `securityContext.fsGroup`                    | Group ID for the container                                                            | `65534`                                    |
+| `securityContext.fsGroup`                    | Group ID for the filesystem                                                           | `65534`                                    |
+| `securityContext.runAsGroup`                 | Group ID for the container                                                            | `65534`                                    |
 | `securityContext.runAsUser`                  | User ID for the container                                                             | `65534`                                    |
 | `priorityClassName`                          | Name of Priority Class to assign pods                                                 | `nil`                                      |
 | `nodeSelector`                               | Node labels for pod assignment                                                        | {}                                         |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
     {{- if .Values.priorityClassName }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -66,6 +66,7 @@ podSecurityPolicy:
 
 securityContext:
   enabled: true
+  runAsGroup: 65534
   runAsUser: 65534
   fsGroup: 65534
 


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Sets `securityContext.runAsGroup=65534` so the process does not run with root group level permission.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
