### PR TITLE
[stable/traefik] use apiVersion: networking.k8s.io/v1beta1 for dashboard ingress on k8s 1.14 and above

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.1
+version: 1.87.2
 appVersion: 1.7.23
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.dashboard.enabled }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard


### PR DESCRIPTION
Signed-off-by: Cameron Attard <cameron.attard@siteminder.com>

#### Is this a new chart

No.

#### What this PR does / why we need it:

Removes usage of to-be-deprecated apiVersion if the newer apiVersion is available.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@krancour @emilevauge @dtomcej @ldez
