### PR TITLE
[stable/kubernetes-dashboard] Deprecate chart.

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,17 +1,13 @@
 apiVersion: v1
 name: kubernetes-dashboard
-version: 1.11.0
+version: 1.11.1
 appVersion: 1.10.1
-description: General-purpose web UI for Kubernetes clusters
+description: DEPRECATED! - General-purpose web UI for Kubernetes clusters
 keywords:
 - kubernetes
 - dashboard
 home: https://github.com/kubernetes/dashboard
 sources:
 - https://github.com/kubernetes/dashboard
-maintainers:
-- name: kfox1111
-  email: Kevin.Fox@pnnl.gov
-- name: desaintmartin
-  email: cdesaintmartin@wiremind.fr
 icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+deprecated: true

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -1,4 +1,7 @@
-# kubernetes-dashboard
+# DEPRECATED - kubernetes-dashboard
+
+This chart is deprecated as we move to our own repo (https://kubernetes.github.io/dashboard/)
+The chart source can be found here: https://github.com/kubernetes/dashboard/tree/master/aio/deploy/helm-chart/kubernetes-dashboard
 
 [Kubernetes Dashboard](https://github.com/kubernetes/dashboard) is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself.
 


### PR DESCRIPTION
It's time to say goodbye to the stable/kubernetes-dashboard chart.
Thanks to all contributors, and see you at https://github.com/kubernetes/dashboard!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x]  Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
