### PR TITLE
[stable/prometheus-adapter] Pod Security Policy and URL path support

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.3.1
+version: 2.3.2
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -18,7 +18,9 @@ This command deploys the prometheus adapter with the default configuration. The 
 
 ## Using the Chart
 
-To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. If Prometheus is exposed under HTTPS the host's CA Bundle must be exposed to the container using `extraVolumes` and `extraVolumeMounts`.
+To use the chart, ensure the `prometheus.url`, `prometheus.port` and `prometheus.path` are configured with the correct Prometheus service endpoint. If Prometheus is exposed under HTTPS the host's CA Bundle must be exposed to the container using `extraVolumes` and `extraVolumeMounts`.
+
+To provide a pod security policy (PSP) name for the cluster role ensure `rbac.psp.name` has been configured with an existing resource name.
 
 Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/config.md) for the proper format).
 

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         {{- end }}
         - --cert-dir=/tmp/cert
         - --logtostderr=true
-        - --prometheus-url={{ .Values.prometheus.url }}{{ if .Values.prometheus.port }}:{{ .Values.prometheus.port }}{{end}}
+        - --prometheus-url={{ .Values.prometheus.url }}{{ if .Values.prometheus.port }}:{{ .Values.prometheus.port }}{{end}}{{ if .Values.prometheus.path }}{{ .Values.prometheus.path }}{{end}}
         - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
         - --v={{ .Values.logLevel }}
         - --config=/etc/adapter/config.yaml

--- a/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
@@ -21,3 +21,13 @@ rules:
   - list
   - watch
 {{- end -}}
+{{- if .Values.rbac.psp }}
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  {{ toYaml .Values.rbac.psp.name | indent 2}}
+{{- end -}}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -20,12 +20,16 @@ priorityClassName: ""
 prometheus:
   url: http://prometheus.default.svc
   port: 9090
+  # path: /prometheus
 
 replicas: 1
 
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  # psp:
+  #   name: 
+  #   - policyname
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -28,7 +28,7 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
   # psp:
-  #   name: 
+  #   name:
   #   - policyname
 
 serviceAccount:


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds the ability to provide an existing pod security policy name to the cluster role definition for use in clusters that enforce pod security.

As well, it allows the user to provide a path to the prometheus url for prometheus deployments that serve metrics on a custom path (eg: http://prometheus.default.svc:9090/prometheus) which is more desirable than misusing the `prometheus.port` value for this purpose.

Both additions are optional and therefore commented out by default.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
