### PR TITLE
[stable/prometheus-operator] Upgrade subcharts kube-state-metrics to 2.8.8 and grafana to 5.2.4

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.13.12
+version: 8.14.0
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.8.4
+  version: 2.8.8
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.9.1
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.18
-digest: sha256:ae93b2266b7083b6b5d74b0fd5e224a93572766b97e1ba74bca0e6f3c69ed094
-generated: "2020-04-29T11:40:21.286237214+02:00"
+  version: 5.1.4
+digest: sha256:4975da922d5d1aac00ac643bd04f7aae191f8c1fb8dd596acf1a5bdefe717e9c
+generated: "2020-06-05T08:37:07.832022+02:00"

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: "5.0.*"
+    version: "5.1.*"
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: grafana.enabled


### PR DESCRIPTION
Upgrade subcharts:
- kube-state-metrics to 2.8.8
- grafana to 5.2.4 (new Grafana 7.0.3)