### PR TITLE
[stable/sentry] Sentry add hook pod tolerations

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 4.2.1
+version: 4.2.3
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -194,6 +194,7 @@ Parameter                                            | Description              
 `metrics.serviceMonitor.interval`                    | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                     | `nil`
 `metrics.serviceMonitor.selector`                    | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install | `{ prometheus: kube-prometheus }`
 `hooks.affinity`                                     | Affinity settings for hooks pods                                                                           | `{}`
+`hooks.tolerations`                                  | Toleration labels for hook pod assignment                                                                  | `[]`
 `hooks.dbInit.enabled`                               | Boolean to enable the dbInit job using a hook                                                              | `true`
 `hooks.dbInit.resources.limits`                      | Hook job resource limits                                                                                   | `{memory: 3200Mi}`
 `hooks.dbInit.resources.requests`                    | Hook job resource requests                                                                                 | `{memory: 3000Mi}`

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -32,6 +32,10 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -31,6 +31,10 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- if .Values.hooks.tolerations }}
+      tolerations:
+{{ toYaml .Values.hooks.tolerations | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -315,6 +315,7 @@ metrics:
 # Provide affinity for hooks if needed
 hooks:
   affinity: {}
+  tolerations: []
   dbInit:
     enabled: true
     resources:


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Adds hook pod tolerations. I ran into a problem about assigning hook job pod toleration values. This is to fix the issue. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
