### PR TITLE
[stable/minecraft] Added option to use existing persistentVolumeClaim

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.2.3
+version: 1.2.4
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/datadir-pvc.yaml
+++ b/stable/minecraft/templates/datadir-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.dataDir.enabled -}}
+{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -201,7 +201,11 @@ spec:
       - name: datadir
       {{- if .Values.persistence.dataDir.enabled }}
         persistentVolumeClaim:
+        {{- if .Values.persistence.dataDir.existingClaim }}
+          claimName: {{ .Values.persistence.dataDir.existingClaim }}
+        {{- else }}
           claimName: {{ template "minecraft.fullname" . }}-datadir
+        {{- end }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -173,6 +173,7 @@ persistence:
   dataDir:
     # Set this to false if you don't care to persist state between restarts.
     enabled: true
+    # existingClaim: nil
     Size: 1Gi
 
 podAnnotations: {}


### PR DESCRIPTION
Signed-off-by: Joseph Stanton <jsromejoe@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
Updates deployment to allow for pre-existing persistent volume claims to be used to back the minecraft chart.

#### Which issue this PR fixes
None.
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
