### PR TITLE
[stable/nfs-server-provisioner] "statdNodePort" is not used in services.yaml

### DIFF
--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 1.1.0
+version: 1.1.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/stable/nfs-server-provisioner/templates/service.yaml
+++ b/stable/nfs-server-provisioner/templates/service.yaml
@@ -85,14 +85,14 @@ spec:
       protocol: TCP
       name: statd
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
-      nodePort: {{ .Values.service.statdPort }}
+      nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
     - port: {{ .Values.service.statdPort }}
       targetPort: statd-udp
       protocol: UDP
       name: statd-udp
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.statdPort))) }}
-      nodePort: {{ .Values.service.statdPort }}
+      nodePort: {{ .Values.service.statdNodePort }}
       {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:


### PR DESCRIPTION
Signed-off-by: chenlein <leichen.china@hotmail.com>


#### What this PR does / why we need it:
  - "statdNodePort" is not used in services.yaml

#### Which issue this PR fixes
  - no issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
