### PR TITLE
[stable/coredns] add extraHostPathVolumes

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.11.0
+version: 1.12.0
 appVersion: 1.6.9
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -74,6 +74,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tolerations`                           | Tolerations for pod assignment                                                        | []                                                          |
 | `zoneFiles`                             | Configure custom Zone files                                                           | []                                                          |
 | `extraSecrets`                          | Optional array of secrets to mount inside the CoreDNS container                       | []                                                          |
+| `extraHostPathVolumes`                  | Optional array of hostPath to mount inside the CoreDNS container                      | []                                                          |
 | `customLabels`                          | Optional labels for Deployment(s), Pod, Service, ServiceMonitor objects               | {}                                                          |
 | `podDisruptionBudget`                   | Optional PodDisruptionBudget                                                          | {}                                                          |
 | `autoscaler.enabled`                    | Optionally enabled a cluster-proportional-autoscaler for CoreDNS                      | `false`                                                     |

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -74,6 +74,11 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
+{{- range  .Values.extraHostPathVolumes }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          readOnly: true
+{{- end }}
         - name: config-volume
           mountPath: /etc/coredns
 {{- range .Values.extraSecrets }}
@@ -119,4 +124,11 @@ spec:
           secret:
             secretName: {{ .name }}
             defaultMode: 400
+{{- end }}
+{{- range .Values.extraHostPathVolumes }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .path }}
+            type: {{ .type }}
+              defaultMode: 400
 {{- end }}

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
-{{- range  .Values.extraHostPathVolumes }}
+{{- range .Values.extraHostPathVolumes }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
           readOnly: true
@@ -130,5 +130,4 @@ spec:
           hostPath:
             path: {{ .path }}
             type: {{ .type }}
-              defaultMode: 400
 {{- end }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -150,6 +150,12 @@ extraSecrets: []
 # - name: some-fancy-secret
 #   mountPath: /etc/wherever
 
+extraHostPathVolumes: []
+#  - name: etc-hosts
+#    path: /etc/hosts
+#    type: FileOrCreate
+#    mountPath: /etc/hostsFromNode
+
 # Custom labels to apply to Deployment, Pod, Service, ServiceMonitor. Including autoscaler if enabled.
 customLabels: {}
 


### PR DESCRIPTION
Signed-off-by: olivier beyler <olivier.beyler@orange.com>


#### Is this a new chart
no
#### What this PR does / why we need it:
If you want to use hosts plugin (https://coredns.io/plugins/hosts/) to point by example the /etc/host file of your local machine you need to be able to add new volume on the deployment. It's particulary interresting in case of CFCR (kubernetes installed by bosh) as Bosh populate the /etc/hosts by every vm hosted inside a bosh deployment ( not managed by K8S)

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
