### PR TITLE
[stable/prometheus-mysql-exporter]: fix docs typo

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.5.2
+version: 0.5.3
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the mysql exporter char
 | `cloudsqlproxy.instanceConnectionName` | Google Cloud instance connection name               | `project:us-central1:dbname`       |
 | `cloudsqlproxy.port`                   | Cloud SQL Proxy listening port                      | `3306`                             |
 | `cloudsqlproxy.credentials`            | Cloud SQL Proxy service account credentials         | `bogus credential file`            |
-| `serviceMonitor.enable`                | Integration with prometheus-operator                | `false`                            |
+| `serviceMonitor.enabled`               | Integration with prometheus-operator                | `false`                            |
 | `serviceMonitor.interval`              | Interval for polling this exporter                  |                                    |
 | `serviceMonitor.scrapeTimeout`         | Timeout where exporter is considered faulty         |                                    |
 | `serviceMonitor.jobLabel`              | Label to use to retrieve the job name from          | `""`                               |


### PR DESCRIPTION
#### What this PR does / why we need it:

fixed a typo in the docs, the template actually uses `enabled` instead of `enable`.

#### Which issue this PR fixes

nd

#### Special notes for your reviewer:

nd

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
