### PR TITLE
[stable/airflow] documentation fixes

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.1.3
+version: 7.1.4
 appVersion: 1.10.10
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -1,4 +1,4 @@
-# Airflow / Celery
+# Airflow Helm Chart
 
 [Airflow](https://airflow.apache.org/) is a platform to programmatically author, schedule and monitor workflows.
 
@@ -92,7 +92,7 @@ We expose the `scheduler.connections` value to allow specifying [Airflow Connect
 
 For example, to add a connection called `my_aws`:
 ```yaml
-airflow:
+scheduler:
   connections:
     - id: my_aws
       type: aws
@@ -114,18 +114,18 @@ We expose the `scheduler.variables` value to allow specifying [Airflow Variables
 
 For example, to specify a variable called `environment`:
 ```yaml
-airflow:
+scheduler:
   variables: |
     { "environment": "dev" }
 ```
 
 ### Airflow-Configs/Pools
 
-We expose the `airflow.pools` value to allow specifying [Airflow Variables](https://airflow.apache.org/docs/stable/concepts.html#pools) at deployment time, these pools will be automatically imported by the Airflow scheduler when it starts up.
+We expose the `scheduler.pools` value to allow specifying [Airflow Variables](https://airflow.apache.org/docs/stable/concepts.html#pools) at deployment time, these pools will be automatically imported by the Airflow scheduler when it starts up.
 
 For example, to create a pool called `example`:
 ```yaml
-airflow:
+scheduler:
   pools: |
     {
       "example": {
@@ -326,9 +326,9 @@ extraManifests:
 
 ### Database-Configs/Initialization
 
-If the value `airflow.initdb` is set to `true`, the airflow-scheduler container will run `airflow initdb` before starting the scheduler as part of its startup script.
+If the value `scheduler.initdb` is set to `true`, the airflow-scheduler container will run `airflow initdb` before starting the scheduler as part of its startup script.
 
-If the value `airflow.preinitdb` is set to `true`, the airflow-scheduler pod will run `airflow initdb` as an initContainer, before the git-clone initContainer (if that is enabled).  
+If the value `scheduler.preinitdb` is set to `true`, the airflow-scheduler pod will run `airflow initdb` as an initContainer, before the git-clone initContainer (if that is enabled).  
 This is rarely necessary but can be so under certain conditions if your synced DAGs include custom database hooks that prevent `initdb` from running successfully.
 For example, if they have dependencies on variables that won't be present yet.
 The initdb initcontainer will retry up to 5 times before giving up.
@@ -624,7 +624,7 @@ __Airflow DAGs Values:__
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| `dags.path` | the airflow dags folder | `/opt/airflow/logs` |
+| `dags.path` | the airflow dags folder | `/opt/airflow/dags` |
 | `dags.doNotPickle` | whether to disable pickling dags from the scheduler to workers | `false` |
 | `dags.installRequirements` | install any Python `requirements.txt` at the root of `dags.path` automatically | `false` |
 | `dags.persistence.*` | configs for the dags PVC | `<see values.yaml>` |

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -706,6 +706,10 @@ dags:
 
   ## install any Python `requirements.txt` at the root of `dags.path` automatically
   ##
+  ## WARNING:
+  ## - if set to true, and you are using `dags.git.gitSync`, you must also enable
+  ## `dags.initContainer` to ensure the requirements.txt is available at Pod start
+  ##
   installRequirements: false
 
   ## configs for the dags PVC
@@ -850,7 +854,8 @@ dags:
     ##
     ## NOTE:
     ## - this is NOT required for the git-sync sidecar to work
-    ## - in most environments, you can leave this as false
+    ## - this is mostly used for when `dags.installRequirements` is true to ensure that
+    ##   requirements.txt is available at Pod start
     ##
     enabled: false
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This contains a few documentation fixes:

1. Update the default value of dags.path in the README to match the actual default value in values.yaml file
2. The main title on line 1 of the stable/airflow README is "Airflow / Celery" which is misleading because the Airflow chart can be used for either CeleryExecutor or KubernetesExecutor. Changing it to "Airflow Helm Chart"
3. Warnings and Notes for `installRequirements`:
    1. add a WARNING docstring in the `values.yaml` for `dags.installRequirements` which says:
        - "if set to `true`, and you are using `dags.git.gitSync`, you must also enable `dags.initContainer` to ensure the requirements.txt is available at Pod start"
    2. add a NOTE docstring under `values.yaml` for `dags.initContainer.enabled` which says:
        - "this is mostly used for when `dags.installRequirements` is `true` to ensure that requirements.txt is available at Pod start"
(also remove the "in most environments, you can leave this as false" NOTE)
4. In the "Airflow-Configs/Connections" and "Airflow-Configs/Variables" sections, the first sentence correctly states the values are `scheduler.connections` and `scheduler.variables` but for both of the code blocks they need to be updated to show `connections` and `variables` under `scheduler` instead of `airflow`
5. Also a few more places where `pools`, `initdb`, and `preinitdb` needed to be changed from `airflow` to `scheduler`

#### Which issue this PR fixes
  - fixes #22601

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
