### PR TITLE
[stable/jenkins] Only render authorizationStrategy and securityRealm if set

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 2.0.1
+
+Only render authorizationStrategy and securityRealm when values are set.
+
 ## 2.0.0 Configuration as Code now default + container does not run as root anymore
 
 The README contains more details for this update.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.0.0
+version: 2.0.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -74,11 +74,11 @@ Returns configuration as code default config
 jenkins:
 {{- if eq .Values.master.enableXmlConfig false }}
   {{- $configScripts := toYaml .Values.master.JCasC.configScripts }}
-  {{- if not (contains "authorizationStrategy:" $configScripts) }}
+  {{- if and (.Values.master.JCasC.authorizationStrategy) (not (contains "authorizationStrategy:" $configScripts)) }}
   authorizationStrategy:
     {{- tpl .Values.master.JCasC.authorizationStrategy . | nindent 4 }}
   {{- end }}
-  {{- if not (contains "securityRealm:" $configScripts) }}
+  {{- if and (.Values.master.JCasC.securityRealm) (not (contains "securityRealm:" $configScripts)) }}
   securityRealm:
     {{- tpl .Values.master.JCasC.securityRealm . | nindent 4 }}
   {{- end }}

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -171,7 +171,9 @@ Returns kubernetes pod template configuration as code
   - name: "{{ .Values.agent.sideContainerName }}"
     alwaysPullImage: {{ .Values.agent.alwaysPullImage }}
     args: "{{ .Values.agent.args | replace "$" "^$" }}"
+    {{- if .Values.agent.command }}
     command: {{ .Values.agent.command }}
+    {{- end }}
     envVars:
     - containerEnvVar:
         key: "JENKINS_URL"

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -17,16 +17,16 @@ metadata:
 {{ toYaml .Values.master.serviceAnnotations | indent 4 }}
 {{- end }}
 spec:
-  {{if (and (eq .Values.master.serviceType "ClusterIP") (not (empty .Values.master.clusterIP)))}}
+  {{- if (and (eq .Values.master.serviceType "ClusterIP") (not (empty .Values.master.clusterIP))) }}
   clusterIP: {{.Values.master.clusterIP}}
-  {{end}}
+  {{- end }}
   ports:
     - port: {{.Values.master.servicePort}}
       name: http
       targetPort: {{ .Values.master.targetPort }}
-      {{if (and (eq .Values.master.serviceType "NodePort") (not (empty .Values.master.nodePort)))}}
+      {{- if (and (eq .Values.master.serviceType "NodePort") (not (empty .Values.master.nodePort))) }}
       nodePort: {{.Values.master.nodePort}}
-      {{end}}
+      {{- end }}
 {{- range $index, $port := .Values.master.extraPorts }}
     - port: {{ $port.port }}
       name: {{ $port.name }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows people to unset bothe values in case that they don't want those without having to disable XML configuation.

One use case for this if these fields need more templating than what is allowed within values.yaml. In that case one could supply a config map which is annotated with the correct label, so that JCasC / the sidecar container picks it up, but that is not part of the chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
