### PR TITLE
[stable/kube-ops-view] Allow for securityContext at container-level i…

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.1.5
+version: 1.2.0
 appVersion: 20.4.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
@@ -52,6 +52,9 @@ spec:
         {{- if .Values.redis.enabled }}
         args:
         - --redis-url=redis://{{ .Release.Name }}-redis-master:{{ .Values.redis.master.port }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext: {{ toYaml . | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/stable/kube-ops-view/values.yaml
+++ b/stable/kube-ops-view/values.yaml
@@ -46,6 +46,9 @@ tolerations: []
 # Add securityContext
 securityContext: {}
 
+# Add securityContext at pod level:
+podSecurityContext: {}
+
 # Defaults for Redis
 redis:
   enabled: false


### PR DESCRIPTION
…n addition to pod

Signed-off-by: David Karlsen <david@davidkarlsen.com>

#### What this PR does / why we need it:
Allow for security context at both pod and container level. Often these were only configured at pod-level which does not allow for container level attributes - but this went unnoticed in helm 2.x since it did not validate at the same level as in helm 3 where wrong attribs will fail the install.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/helm/charts/22688)
<!-- Reviewable:end -->
