### PR TITLE
[stable/janusgraph] Allow configuration of gremlin server from values.yaml

### DIFF
--- a/stable/janusgraph/Chart.yaml
+++ b/stable/janusgraph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Open source, scalable graph database.
 name: janusgraph
-version: 0.2.1
+version: 0.2.2
 home: http://janusgraph.org
 icon: https://raw.githubusercontent.com/JanusGraph/janusgraph/master/janusgraph.png
 sources:

--- a/stable/janusgraph/templates/configmap.yaml
+++ b/stable/janusgraph/templates/configmap.yaml
@@ -18,43 +18,5 @@ data:
     index.search.hostname={{ $eshostname }}
     {{- end }}
   gremlin-server.yaml: |-
-    host: 0.0.0.0
-    port: 8182
-    scriptEvaluationTimeout: 30000
-    channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
-    graphs: {
-      graph: conf/gremlin-server/janusgraph.properties
-    }
-    plugins:
-      - janusgraph.imports
-    scriptEngines: {
-      gremlin-groovy: {
-        imports: [java.lang.Math],
-        staticImports: [java.lang.Math.PI],
-        scripts: [scripts/empty-sample.groovy]}}
-    serializers:
-      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
-      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
-    processors:
-      - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
-      - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
-    metrics: {
-      consoleReporter: {enabled: true, interval: 180000},
-      csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
-      jmxReporter: {enabled: true},
-      slf4jReporter: {enabled: true, interval: 180000},
-      gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
-      graphiteReporter: {enabled: false, interval: 180000}}
-    maxInitialLineLength: 4096
-    maxHeaderSize: 8192
-    maxChunkSize: 8192
-    maxContentLength: 65536
-    maxAccumulationBufferComponents: 1024
-    resultIterationBatchSize: 64
-    writeBufferLowWaterMark: 32768
-    writeBufferHighWaterMark: 65536
-    {{- end -}}
+{{ toYaml .Values.gremlinServer | indent 4 }}
+{{- end -}}

--- a/stable/janusgraph/values.yaml
+++ b/stable/janusgraph/values.yaml
@@ -68,6 +68,52 @@ properties:
   # cache.db-cache-time: 180000
   # cache.db-cache-size: 0.5
 
+
+gremlinServer:
+  ## use this section to configure settings for the gremlin server
+  ## available settings under this section will be added to the gremlin-server.yaml file
+  ## to be used for starting the gremlin server
+  ## for more information, see: http://tinkerpop.apache.org/docs/current/reference/#_configuring_2
+  host: 0.0.0.0
+  port: 8182
+  scriptEvaluationTimeout: 30000
+  channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+  graphs: {
+    graph: conf/gremlin-server/janusgraph.properties
+  }
+  plugins:
+    - janusgraph.imports
+  scriptEngines: {
+    gremlin-groovy: {
+      imports: [java.lang.Math],
+      staticImports: [java.lang.Math.PI],
+      scripts: [scripts/empty-sample.groovy]}}
+  serializers:
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+  processors:
+    - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+    - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+  metrics: {
+    consoleReporter: {enabled: true, interval: 180000},
+    csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+    jmxReporter: {enabled: true},
+    slf4jReporter: {enabled: true, interval: 180000},
+    gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
+    graphiteReporter: {enabled: false, interval: 180000}}
+  maxInitialLineLength: 4096
+  maxHeaderSize: 8192
+  maxChunkSize: 8192
+  maxContentLength: 65536
+  maxAccumulationBufferComponents: 1024
+  resultIterationBatchSize: 64
+  writeBufferLowWaterMark: 32768
+  writeBufferHighWaterMark: 65536
+
 ## when using local storage and indexing, choose whether to persist day
 persistence:
   enabled: true  # set to false if you are testing and do not want to persist data

--- a/stable/janusgraph/values.yaml
+++ b/stable/janusgraph/values.yaml
@@ -89,15 +89,15 @@ gremlinServer:
       staticImports: [java.lang.Math.PI],
       scripts: [scripts/empty-sample.groovy]}}
   serializers:
-    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-    - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
-    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-    - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+    - {className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]}}
+    - {className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]}}
+    - {className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: {serializeResultToString: true}}
+    - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: {ioRegistries: [orgjanusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0]}}
+    - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: {ioRegistries: [orgjanusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]}}
+    - {className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0]}}
   processors:
-    - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
-    - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+    - {className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: {sessionTimeout: 28800000}}
+    - {className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: {cacheExpirationTime: 600000, cacheMaxSize: 1000}}
   metrics: {
     consoleReporter: {enabled: true, interval: 180000},
     csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Currently, `gremlin-server.yaml` of janusgraph cannot be configured from `values.yaml` in this helm chart. Added a new field in `values.yaml` called `gremlinServer` to allow configuration of the gremlin server used to front janusgraph. Default values of `gremlin-server.yaml` are placed under `values.yaml`, and users can configure the settings (both `janusgraph.properties` & `gremlin-server.yaml`) from a single place.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
