### PR TITLE
[stable/unifi] adding functionality to mount extra volumes

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.8.1
+version: 0.8.2
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.8.2
+version: 0.9.0
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -114,8 +114,8 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `persistence.existingClaim`                     | `nil`                        | Use an existing PVC to persist data                                                                                    |
 | `persistence.subPath`                           | ``                           | Store data in a subdirectory of PV instead of at the root directory                                                    |
 | `persistence.storageClass`                      | `-`                          | Type of persistent volume claim                                                                                        |
-| `extraVolumes`                                  | `{}`                         | Additional volumes to be used by extraVolumeMounts                                                                     |
-| `extraVolumeMounts`                             | `{}`                         | Additional volume mounts to be mounted in unifi container                                                              |
+| `extraVolumes`                                  | `[]`                         | Additional volumes to be used by extraVolumeMounts                                                                     |
+| `extraVolumeMounts`                             | `[]`                         | Additional volume mounts to be mounted in unifi container                                                              |
 | `persistence.accessModes`                       | `[]`                         | Persistence access modes                                                                                               |
 | `extraConfigFiles`                              | `{}`                         | Dictionary containing files mounted to `/configmap` inside the pod (See [values.yaml](values.yaml) for examples)       |
 | `extraJvmOpts`                                  | `[]`                         | List of additional JVM options, e.g. `["-Dlog4j.configurationFile=file:/configmap/log4j2.xml"]`                        |

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -114,6 +114,8 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `persistence.existingClaim`                     | `nil`                        | Use an existing PVC to persist data                                                                                    |
 | `persistence.subPath`                           | ``                           | Store data in a subdirectory of PV instead of at the root directory                                                    |
 | `persistence.storageClass`                      | `-`                          | Type of persistent volume claim                                                                                        |
+| `extraVolumes`                                  | `{}`                         | Additional volumes to be used by extraVolumeMounts                                                                     |
+| `extraVolumeMounts`                             | `{}`                         | Additional volume mounts to be mounted in unifi container                                                              |
 | `persistence.accessModes`                       | `[]`                         | Persistence access modes                                                                                               |
 | `extraConfigFiles`                              | `{}`                         | Dictionary containing files mounted to `/configmap` inside the pod (See [values.yaml](values.yaml) for examples)       |
 | `extraJvmOpts`                                  | `[]`                         | List of additional JVM options, e.g. `["-Dlog4j.configurationFile=file:/configmap/log4j2.xml"]`                        |

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -130,6 +130,7 @@ spec:
             - name: extra-config
               mountPath: /configmap
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
@@ -150,6 +151,7 @@ spec:
           secret:
             secretName: "{{ .Values.customCert.certSecret }}"
         {{- end }}
+        {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -218,6 +218,18 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
+extraVolumes: []
+  ## specify additional volume to be used by extraVolumeMounts inside unifi container
+  # - name: additional-volume
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+
+extraVolumeMounts: []
+  ## specify additional VolumeMount to be mounted inside unifi container
+  # - name: additional-volume
+  #   mountPath: /path/in/container
+
 extraJvmOpts: []
   ## Extra java options
   ## Here are some examples of valid JVM options:


### PR DESCRIPTION
#### Is this a new chart
existing chart [stable/unifi]

#### What this PR does / why we need it:
This PR allows to specify additional volumes to be mounted to unifi container during deployment of Unifi Controller. So for example - my environment is using a single
Unifi switch between my k8s cluster and my NAS (volumes are exposed via iSCSI). If I use `persistence.existingClaim=iscsi-pvc-for-unifi` and during normal operations of Unifi I do 
a firmware upgrade of that switch I'm disrupting connectivity between Unifi Controller
and remote storage potentially causing corruption of controller's database stored on remote 
volume. With this PR I can specify `persistence.existingClaim=unifi-pvc-on-local-node-disk` which will allow me to rebuild/upgrade Controller POD without loosing data and mount additional remote volume for example a backup dir. This way I only store backups on remote drive and a short network disruption doesn't have that big impact on Unifi controller.
Another benefit of this PR is that it also allows to specify another extra volume and mount a configmap serving a custom config.gatewy.json. 
 
#### Which issue this PR fixes
No issue reported for this feature

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
