### PR TITLE
[stable/unifi] Add ingress for Unifi controller sevice

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.9.0
+version: 0.10.0
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -69,6 +69,12 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `controllerService.loadBalancerIP`              | `{}`                         | Loadbalance IP for the Unifi Controller                                                                                |
 | `controllerService.loadBalancerSourceRanges`    | None                         | List of IP CIDRs allowed access to load balancer (if supported)                                                        |
 | `controllerService.externalTrafficPolicy`       | `Cluster`                    | Set the externalTrafficPolicy in the Service to either Cluster or Local                                                |
+| `controllerService.ingress.enabled`             | `false`                      | Enables Ingress for the controller                                                                                     |
+| `controllerService.ingress.annotations`         | `{}`                         | Ingress annotations for the controller                                                                                 |
+| `controllerService.ingress.labels`              | `{}`                         | Custom labels for the controller                                                                                       |
+| `controllerService.ingress.path`                | `/`                          | Ingress path for the controller                                                                                        |
+| `controllerService.ingress.hosts`               | `chart-example.local`        | Ingress accepted hostnames for the controller                                                                          |
+| `controllerService.ingress.tls`                 | `[]`                         | Ingress TLS configuration for the controller                                                                           |
 | `stunService.type`                              | `NodePort`                   | Kubernetes service type for the Unifi STUN                                                                             |
 | `stunService.port`                              | `3478`                       | Kubernetes UDP port where the Unifi STUN is exposed                                                                    |
 | `stunService.annotations`                       | `{}`                         | Service annotations for the Unifi STUN                                                                                 |

--- a/stable/unifi/templates/controller-ingress.yaml
+++ b/stable/unifi/templates/controller-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if (and .Values.controllerService.ingress.enabled (not .Values.unifiedService.enabled)) }}
+{{- $fullName := include "unifi.fullname" . -}}
+{{- $ingressPath := .Values.controllerService.ingress.path -}}
+{{- $unifiedServiceEnabled := .Values.unifiedService.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-controller
+  labels:
+    app.kubernetes.io/name: {{ include "unifi.name" . }}
+    helm.sh/chart: {{ include "unifi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.controllerService.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.controllerService.ingress.tls }}
+  tls:
+  {{- range .Values.controllerService.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.controllerService.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}-controller
+              servicePort: controller
+  {{- end }}
+{{- end }}

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -117,6 +117,15 @@ controllerService:
   # loadBalancerSourceRanges: []
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
   # externalTrafficPolicy: Cluster
+  ##
+  # Ingress settings only for the controller
+  ingress:
+    enabled: false
+    annotations: {}
+    path: /
+    hosts:
+      - chart-example.local
+    tls: []
 
 stunService:
   type: NodePort


### PR DESCRIPTION
Signed-off-by: Stephen Liang <stephenliang@users.noreply.github.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No.

#### What this PR does / why we need it:

Adds an ingress for the Unifi HTTP-only controller "/inform" path. Without this change, the standard controller would attempt to pass to "/inform" using TLS and since the inform path is HTTP only, will fail. 

In addition, in the unified service mode specified in this helm chart, an external load balancer could be used to specify a port to the controller service, however without an external load balancer, an ingress to the controller would be needed. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #21887 

#### Special notes for your reviewer:

@billimek @mcronce

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
