### PR TITLE
[stable/airflow] Typo fix in values.yaml of airflow chart

### DIFF
--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -759,7 +759,7 @@ dags:
     ##   url: "https://github.com/torvalds/linux.git"
     ##
     ## EXAMPLE: (SSH)
-    ##   url: "ssh://git@github.com:torvalds/linux.git"
+    ##   url: "git@github.com:torvalds/linux.git"
     ##
     url: ""
 


### PR DESCRIPTION
Signed-off-by: Praveen Yalagandula <ypraveen@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
