### PR TITLE
stable/sealed-secrets: Fallback to Helm .Release.Namespace when .Values.namespace not defined.

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.10.1
+version: 1.10.2
 appVersion: 0.12.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -46,6 +46,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | Parameter                     | Description                                                                | Default                                     |
 |------------------------------:|:---------------------------------------------------------------------------|:--------------------------------------------|
 | **controller.create**         | `true` if Sealed Secrets controller resources should be created            | `true`                                      |
+| **namespace**                 | The name of the Namespace to deploy the controller                         | `.Release.namespace`                        |
 | **rbac.create**               | `true` if rbac resources should be created                                 | `true`                                      |
 | **rbac.pspEnabled**           | `true` if psp resources should be created                                  | `false`                                     |
 | **serviceAccount.create**     | Whether to create a service account or not                                 | `true`                                      |

--- a/stable/sealed-secrets/templates/_helpers.tpl
+++ b/stable/sealed-secrets/templates/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Expand to the namespace sealed-secrets installs into.
+*/}}
+{{- define "sealed-secrets.namespace" -}}
+{{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "sealed-secrets.chart" -}}

--- a/stable/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/stable/sealed-secrets/templates/cluster-role-binding.yaml
@@ -17,5 +17,5 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
 {{ end }}

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/templates/ingress.yaml
+++ b/stable/sealed-secrets/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/templates/networkpolicy.yaml
+++ b/stable/sealed-secrets/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/stable/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
 {{- end }}

--- a/stable/sealed-secrets/templates/role-binding.yaml
+++ b/stable/sealed-secrets/templates/role-binding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-key-admin
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -17,12 +18,13 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/templates/role.yaml
+++ b/stable/sealed-secrets/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-key-admin
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -30,6 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/templates/service-account.yaml
+++ b/stable/sealed-secrets/templates/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "sealed-secrets.serviceAccountName" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/templates/service.yaml
+++ b/stable/sealed-secrets/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -12,6 +12,9 @@ controller:
   # controller.create: `true` if Sealed Secrets controller should be created
   create: true
 
+# namespace: Namespace to deploy the controller.
+namespace: ""
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true


### PR DESCRIPTION
This commits mimics what is proposed in this other PR for a different chart: https://github.com/streamnative/charts/pull/101/files

Fallbacks to  `.Release.Namespace` when no `.Values.namespace` is defined.


Signed-off-by: Jorge Tudela <jtudelag@redhat.com>

#### Checklist
- [ X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X] Chart Version bumped
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)