### PR TITLE
[stable/prometheus-operator] Template grafana.additionalDataSources

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.14.0
+version: 8.14.1
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -443,7 +443,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `grafana.additionalDataSources` | Configure additional grafana datasources | `[]` |
+| `grafana.additionalDataSources` | Configure additional grafana datasources (passed through tpl) | `[]` |
 | `grafana.adminPassword` | Admin password to log into the grafana UI | "prom-operator" |
 | `grafana.defaultDashboardsEnabled` | Deploy default dashboards. These are loaded using the sidecar | `true` |
 | `grafana.enabled` | If true, deploy the grafana sub-chart | `true` |

--- a/stable/prometheus-operator/templates/grafana/configmaps-datasources.yaml
+++ b/stable/prometheus-operator/templates/grafana/configmaps-datasources.yaml
@@ -33,6 +33,6 @@ data:
 {{- end }}
 {{- end }}
 {{- if .Values.grafana.additionalDataSources }}
-{{ toYaml .Values.grafana.additionalDataSources | indent 4}}
+{{ tpl (toYaml .Values.grafana.additionalDataSources | indent 4) . }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -538,7 +538,7 @@ grafana:
   #   configMap: certs-configmap
   #   readOnly: true
 
-  ## Configure additional grafana datasources
+  ## Configure additional grafana datasources (passed through tpl)
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources
   additionalDataSources: []
   # - name: prometheus-sample
@@ -551,7 +551,7 @@ grafana:
   #       tlsSkipVerify: true
   #   orgId: 1
   #   type: prometheus
-  #   url: https://prometheus.svc:9090
+  #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
   #   version: 1
 
   ## Passed to grafana subchart and used by servicemonitor below


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Passes `grafana.additionalDataSources` through tpl. This is necessary because datasources contain URLs that usually reference Kubernetes services and those can contain dynamic information like Helm release names. For example:

```yaml
  grafana:
    additionalDataSources:
      - name: Loki
        type: loki
        access: proxy
        url: http://{{ printf "%s-loki" .Release.Name }}:3100
        jsonData:
          maxLines: 500
```

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
