### PR TITLE
[stable/elasticsearch-exporter] Improvement: Use secrets to configure elasticsearch uri

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 3.3.0
+version: 3.3.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 3.3.1
+version: 3.4.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/templates/cert-secret.yaml
+++ b/stable/elasticsearch-exporter/templates/cert-secret.yaml
@@ -11,6 +11,8 @@ metadata:
 type: Opaque
 data:
   ca.pem: {{ .Values.es.ssl.ca.pem | b64enc }}
+  {{- if .Values.es.ssl.client.enabled }}
   client.pem: {{ .Values.es.ssl.client.pem | b64enc }}
   client.key: {{ .Values.es.ssl.client.key | b64enc }}
+  {{- end }}
 {{- end }}

--- a/stable/elasticsearch-exporter/templates/configmap.yaml
+++ b/stable/elasticsearch-exporter/templates/configmap.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "elasticsearch-exporter.fullname" . }}-run-script
+  labels:
+    chart: {{ template "elasticsearch-exporter.chart" . }}
+    app: {{ template "elasticsearch-exporter.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  run.sh: |
+    #!/bin/sh
+
+    elasticsearch_exporter \
+    {{- if .Values.es.uri }}
+    --es.uri={{ .Values.es.uri }}  \
+    {{- end }}
+    {{- if .Values.es.all }}
+    --es.all \
+    {{- end }}
+    {{- if .Values.es.indices }}
+    --es.indices \
+    {{- end }}
+    {{- if .Values.es.indices_settings }}
+    --es.indices_settings \
+    {{- end }}
+    {{- if .Values.es.shards }}
+    --es.shards \
+    {{- end }}
+    {{- if .Values.es.snapshots }}
+    --es.snapshots \
+    {{- end }}
+    {{- if .Values.es.cluster_settings }}
+    --es.cluster_settings \
+    {{- end }}
+    --es.timeout={{ .Values.es.timeout }} \
+    {{- if .Values.es.sslSkipVerify }}
+    --es.ssl-skip-verify \
+    {{- end }}
+    {{- if .Values.es.ssl.enabled }}
+    --es.ca={{.Values.es.ssl.ca.path }} \
+    {{- if .Values.es.ssl.client.enabled }}
+    --es.client-cert={{ .Values.es.ssl.client.pemPath }} \
+    --es.client-private-key={{ .Values.es.ssl.client.keyPath }} \
+    {{- end }}
+    {{- end }}
+    --web.listen-address=:{{ .Values.service.httpPort }} \
+    --web.telemetry-path={{ .Values.web.path }}

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         release: "{{ .Release.Name }}"
       {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- if .Values.podAnnotations }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/cert-secret: {{ include (print $.Template.BasePath "/cert-secret.yaml") . | sha256sum }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -67,41 +67,7 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["elasticsearch_exporter",
-                    {{- if .Values.es.uri }}
-                    "--es.uri={{ .Values.es.uri }}",
-                    {{- end }}
-                    {{- if .Values.es.all }}
-                    "--es.all",
-                    {{- end }}
-                    {{- if .Values.es.indices }}
-                    "--es.indices",
-                    {{- end }}
-                    {{- if .Values.es.indices_settings }}
-                    "--es.indices_settings",
-                    {{- end }}
-                    {{- if .Values.es.shards }}
-                    "--es.shards",
-                    {{- end }}
-                    {{- if .Values.es.snapshots }}
-                    "--es.snapshots",
-                    {{- end }}
-                    {{- if .Values.es.cluster_settings }}
-                    "--es.cluster_settings",
-                    {{- end }}
-                    "--es.timeout={{ .Values.es.timeout }}",
-                    {{- if .Values.es.sslSkipVerify }}
-                    "--es.ssl-skip-verify",
-                    {{- end }}
-                    {{- if .Values.es.ssl.enabled }}
-                    "--es.ca={{.Values.es.ssl.ca.path }}",
-                    {{- if .Values.es.ssl.client.enabled }}
-                    "--es.client-cert={{ .Values.es.ssl.client.pemPath }}",
-                    "--es.client-private-key={{ .Values.es.ssl.client.keyPath }}",
-                    {{- end }}
-                    {{- end }}
-                    "--web.listen-address=:{{ .Values.service.httpPort }}",
-                    "--web.telemetry-path={{ .Values.web.path }}"]
+          command: ["sh", "/opt/run.sh"]
           securityContext:
             capabilities:
               drop:
@@ -144,6 +110,8 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "sleep 20"]
           volumeMounts:
+            - name: run-script
+              mountPath: /opt
             {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
             - mountPath: /ssl
               name: ssl
@@ -168,6 +136,9 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
       volumes:
+        - name: run-script
+          configMap:
+            name: {{ template "elasticsearch-exporter.fullname" . }}-run-script
         {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
         - name: ssl
           secret:

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -136,7 +136,7 @@ es:
     client:
       ## if true, client SSL certificate is used for authentication
       ##
-      enabled: true
+      enabled: false
 
       ## PEM that contains the client cert to connect to Elasticsearch.
       ##


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fix one problem when we enable ssl connection and at the same time we disable the ssl authentication.

This PR also improve the chart running the command like from a script. With this new change we can edit the uri variable to get the value from a file or from an environment variable, that will be mounted previously.

Example values file will use this new configuration:

```yaml
es:
  uri: "$(cat /secrets/uri)"
secretMounts:
  - name: exporter-secrets
    secretName: elasticsearch-exporter
    path: /secrets
```

The alternative (working in the current stable chart) is
```yaml
es:
  uri: https://user:password@my-elasticsearch-cluster.example.com
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
