### PR TITLE
[stable/node-red] deprecating node-red chart

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -12,8 +12,3 @@ sources:
   - https://github.com/node-red/node-red-docker
   - https://github.com/kubernetes/charts/stable/node-red
 deprecated: true
-maintainers:
-  - name: billimek
-    email: jeff@billimek.com
-  - name: batazor
-    email: batazor111@gmail.com

--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.4
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 1.4.2
+version: 1.4.3
 keywords:
   - nodered
   - node-red
@@ -11,6 +11,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 sources:
   - https://github.com/node-red/node-red-docker
   - https://github.com/kubernetes/charts/stable/node-red
+deprecated: true
 maintainers:
   - name: billimek
     email: jeff@billimek.com

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -1,4 +1,9 @@
-# Node-RED
+# DEPRECATED - Node-RED
+
+**This chart has been deprecated and moved to its new home:**
+
+- **GitHub repo:** https://github.com/billimek/billimek-charts/tree/master/charts/node-red
+- **Charts repo:** https://billimek.com/billimek-charts
 
 Low-code programming for event-driven applications
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This deprecates the node-red chart and references the new home.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
