### PR TITLE
[stable/spinnaker] Add psp option

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc5
+version: 2.0.0-rc6
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -19,6 +19,14 @@ spec:
       labels:
 {{ include "spinnaker.standard-labels" . | indent 8 }}
     spec:
+      {{- if .Values.serviceAccount.halyardName }}
+      serviceAccountName: {{ .Values.serviceAccount.halyardName }}
+      {{- else }}
+      serviceAccountName: {{ template "spinnaker.fullname" . }}-halyard
+      {{- end }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/spinnaker/templates/rbac/psp-halyard-role.yaml
+++ b/stable/spinnaker/templates/rbac/psp-halyard-role.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-halyard-psp
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "spinnaker.fullname" . }}-halyard
+{{- end }}

--- a/stable/spinnaker/templates/rbac/psp-halyard-rolebinding.yaml
+++ b/stable/spinnaker/templates/rbac/psp-halyard-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-halyard-psp
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "spinnaker.fullname" . }}-halyard-psp
+subjects:
+- kind: ServiceAccount
+  {{- if .Values.serviceAccount.halyardName }}
+  name: {{ .Values.serviceAccount.halyardName }}
+  {{- else }}
+  name: {{ template "spinnaker.fullname" . }}-halyard
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/spinnaker/templates/rbac/psp-halyard.yaml
+++ b/stable/spinnaker/templates/rbac/psp-halyard.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-halyard
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'persistentVolumeClaim'
+  - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -306,6 +306,8 @@ azs:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  # Specifies whether PSP resources should be created
+  pspEnabled: false
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
What this PR does / why we need it:
* add psp objects to hal install job and hal statefulset. this is needed when deploying on clusters with psp enabled.
