### PR TITLE
[stable/home-assistant] deprecating home-assistant chart

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.108.7
 description: Home Assistant
 name: home-assistant
-version: 0.13.3
+version: 0.13.4
 keywords:
 - home-assistant
 - hass
@@ -13,8 +13,4 @@ sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/danielperna84/hass-configurator
 - https://github.com/cdr/code-server
-maintainers:
-- name: billimek
-  email: jeff@billimek.com
-- name: runningman84
-  email: phil@hellmi.de
+deprecated: true

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -1,4 +1,9 @@
-# Home Assistant
+# DEPRECATED - Home Assistant
+
+**This chart has been deprecated and moved to its new home:**
+
+- **GitHub repo:** https://github.com/billimek/billimek-charts/tree/master/charts/home-assistant
+- **Charts repo:** https://billimek.com/billimek-charts
 
 This is a helm chart for [Home Assistant](https://www.home-assistant.io/)
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This deprecates the home-assistant chart and references the new home.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
