### PR TITLE
[stable/airflow] fixed flower extraConfigmapMounts

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.1.4
+version: 7.1.5
 appVersion: 1.10.10
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -51,7 +51,7 @@ There are many ways to deploy this chart, but here are some starting points for 
 
 | Name | File | Description |
 | --- | --- | --- |
-| (CeleryExecutor) Minimal | [examples/minikube/custom-values.yaml](examples/minikube/custom-values.yaml) | a __non-production__ starting point | 
+| (CeleryExecutor) Minimal | [examples/minikube/custom-values.yaml](examples/minikube/custom-values.yaml) | a __non-production__ starting point |
 | (CeleryExecutor) Google Cloud | [examples/google-gke/custom-values.yaml](examples/google-gke/custom-values.yaml) | a __production__ starting point for GKE on Google Cloud |
 
 ## Airflow-Configs
@@ -104,7 +104,7 @@ scheduler:
         }
 ```
 
-__NOTE:__ As connections may include sensitive data, we store the bash script which generates the connections in a Kubernetes Secret, and mount this to the pods. 
+__NOTE:__ As connections may include sensitive data, we store the bash script which generates the connections in a Kubernetes Secret, and mount this to the pods.
 
 __WARNING:__ Because some values are sensitive, you should take care to store your custom `values.yaml` securely before passing it to helm with: `helm -f <my-secret-values.yaml>`
 
@@ -121,7 +121,7 @@ scheduler:
 
 ### Airflow-Configs/Pools
 
-We expose the `scheduler.pools` value to allow specifying [Airflow Variables](https://airflow.apache.org/docs/stable/concepts.html#pools) at deployment time, these pools will be automatically imported by the Airflow scheduler when it starts up.
+We expose the `scheduler.pools` value to allow specifying [Airflow Pools](https://airflow.apache.org/docs/stable/concepts.html#pools) at deployment time, these pools will be automatically imported by the Airflow scheduler when it starts up.
 
 For example, to create a pool called `example`:
 ```yaml
@@ -204,8 +204,8 @@ When customizing this, please note:
 We use a Kubernetes StatefulSet for the Celery workers, this allows the webserver to requests logs from each workers individually, with a fixed DNS name.
 
 Celery workers can be scaled using the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
-To enable autoscaling, you must set `workers.autoscaling.enabled=true`, then provide `workers.autoscaling.maxReplicas`, and `workers.replicas` for the minimum amount. 
-Make sure to set a resource request in `workers.resources`, and `dags.git.gitSync.resources`, otherwise worker pods will not scale. 
+To enable autoscaling, you must set `workers.autoscaling.enabled=true`, then provide `workers.autoscaling.maxReplicas`, and `workers.replicas` for the minimum amount.
+Make sure to set a resource request in `workers.resources`, and `dags.git.gitSync.resources`, otherwise worker pods will not scale.
 (For git-sync, `64Mi` should be enough.)
 
 Assume every task a worker executes consumes approximately `200Mi` memory, that means memory is a good metric for utilisation monitoring.
@@ -248,7 +248,7 @@ dags:
           memory: "64Mi"
 ```
 
-__NOTE:__ With this config if a worker consumes `80%` of `2Gi` (which will happen if it runs 9-10 tasks at the same time), an autoscale event will be triggered, and a new worker will be added. 
+__NOTE:__ With this config if a worker consumes `80%` of `2Gi` (which will happen if it runs 9-10 tasks at the same time), an autoscale event will be triggered, and a new worker will be added.
 If you have many tasks in a queue, Kubernetes will keep adding workers until maxReplicas reached, in this case `16`.
 
 ### Kubernetes-Configs/Worker-Secrets
@@ -487,11 +487,11 @@ dags:
 
 #### Option 2a -- Single PVC for DAGs & Logs
 
-You may want to store DAGs and logs on the same volume and configure Airflow to use subdirectories for them. 
+You may want to store DAGs and logs on the same volume and configure Airflow to use subdirectories for them.
 One reason is that mounting the same volume multiple times with different subPaths can cause problems in Kubernetes, e.g. one of the mounts gets stuck during container initialisation.
 
 Here's an approach that achieves this:
-* Configure `airflow.extraVolume` and `airflow.extraVolumeMount` to put a volume at `/opt/airflow/efs` 
+* Configure `airflow.extraVolume` and `airflow.extraVolumeMount` to put a volume at `/opt/airflow/efs`
 * Configure `dags.persistence.enabled` and `logs.persistence.enabled` to be `false`
 * Configure `dags.path` to be `/opt/airflow/efs/dags`
 * Configure `logs.path` to be `/opt/airflow/efs/logs`

--- a/stable/airflow/examples/google-gke/custom-values.yaml
+++ b/stable/airflow/examples/google-gke/custom-values.yaml
@@ -125,7 +125,7 @@ scheduler:
       type: google_cloud_platform
       extra: '{"extra__google_cloud_platform__num_retries": "5"}'
 
-  ## custom airflow pools for the airflow scheduler
+  ## custom airflow variables for the airflow scheduler
   ##
   variables: |
     { "environment": "prod" }

--- a/stable/airflow/examples/minikube/custom-values.yaml
+++ b/stable/airflow/examples/minikube/custom-values.yaml
@@ -50,7 +50,7 @@ scheduler:
           "region_name":"eu-central-1"
         }
 
-  ## custom airflow pools for the airflow scheduler
+  ## custom airflow variables for the airflow scheduler
   ##
   variables: |
     { "environment": "dev" }

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -81,7 +81,14 @@ spec:
               protocol: TCP
           {{- if .Values.flower.extraConfigmapMounts }}
           volumeMounts:
-            {{- toYaml .Values.flower.extraConfigmapMounts | nindent 12 }}
+            {{- range .Values.flower.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
+            {{- end }}
           {{- end }}
           command:
             - "/usr/bin/dumb-init"
@@ -120,4 +127,12 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.flower.resources | nindent 12 }}
+      {{- if .Values.flower.extraConfigmapMounts }}
+      volumes:
+        {{- range .Values.flower.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
In addition to some minor documentation fixes:

This fixes `flower.extraConfigmapMounts`. It was not set up the same way as `airflow.extraConfigmapMounts` and instead it was importing the entire YAML from the value into `volumeMounts` for the flower deployment, this did not work because the example shows the following:
```
extraConfigmapMounts:
  - name: extra-cert
    mountPath: /etc/ssl/certs/extra-cert.pem
    configMap: extra-certificates
    readOnly: true
    subPath: extra-cert.pem
```
however `configMap` is not a valid field for a `volumeMount`.

This PR splits up the `extraConfigmapMounts` value keys between the `volumeMounts` (not using the `configMap` key) and the `volumes` (using the `configMap` key) and makes `extraConfigmapMounts` work for the "flower" container.

#### Which issue this PR fixes
No issues, but partially related to the old open PR #21226 (but this only fixes `extraConfigmapMounts` and does not add or replace it with `flower.extraEnv`)
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
