### PR TITLE
[stable/nginx-ingress] Add support for an internal load balancer along with an external one

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.39.1
+version: 1.40.0
 appVersion: 0.32.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -120,6 +120,8 @@ Parameter | Description | Default
 `controller.service.nodePorts.https` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
 `controller.service.nodePorts.tcp` | Sets the nodePort for an entry referenced by its key from `tcp` | `{}`
 `controller.service.nodePorts.udp` | Sets the nodePort for an entry referenced by its key from `udp` | `{}`
+`controller.service.internal.enabled` | Enables an (additional) internal load balancer | false
+`controller.service.internal.annotations` | Annotations for configuring the additional internal load balancer | `{}`
 `controller.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 10
 `controller.livenessProbe.periodSeconds` | How often to perform the probe | 10
 `controller.livenessProbe.timeoutSeconds` | When the probe times out | 5
@@ -345,6 +347,47 @@ controller:
     annotations:
       domainName: "kubernetes-example.com"
 ```
+
+## Additional internal load balancer
+
+This setup is useful when you need both external and internal load balancers but don't want to have multiple ingress controllers and multiple ingress objects per application.
+
+By default, the ingress object will point to the external load balancer address, but if correctly configured, you can make use of the internal one if the URL you are looking up resolves to the internal load balancer's URL.
+
+You'll need to set both the following values:
+
+`controller.service.internal.enabled`
+`controller.service.internal.annotations`
+
+If one of them is missing the internal load balancer will not be daployed. Example you may have `controller.service.internal.enabled=true` but no annotations set, in this case no action will be taken.
+
+`controller.service.internal.annotations` varies with the cloud service you're using.
+
+Example for AWS
+```
+controller:
+  service:
+    internal:
+      enabled: true
+      annotations:
+        # Create internal ELB
+        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+        # Any other annotation can be declared here.
+```
+
+Example for GCE
+```
+controller:
+  service:
+    internal:
+      enabled: true
+      annotations:
+        # Create internal LB
+        cloud.google.com/load-balancer-type: "Internal"
+        # Any other annotation can be declared here.
+```
+
+An use case for this scenario is having a split-view DNS setup where the public zone CNAME records point to the external balancer URL while the private zone CNAME records point to the internal balancer URL. This way, you only need one ingress kubernetes object.
 
 ## Ingress Admission Webhooks
 

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -359,7 +359,7 @@ You'll need to set both the following values:
 `controller.service.internal.enabled`
 `controller.service.internal.annotations`
 
-If one of them is missing the internal load balancer will not be daployed. Example you may have `controller.service.internal.enabled=true` but no annotations set, in this case no action will be taken.
+If one of them is missing the internal load balancer will not be deployed. Example you may have `controller.service.internal.enabled=true` but no annotations set, in this case no action will be taken.
 
 `controller.service.internal.annotations` varies with the cloud service you're using.
 

--- a/stable/nginx-ingress/ci/daemonset-internal-lb-values.yaml
+++ b/stable/nginx-ingress/ci/daemonset-internal-lb-values.yaml
@@ -1,0 +1,7 @@
+controller:
+  kind: DaemonSet
+  service:
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0

--- a/stable/nginx-ingress/ci/deployment-internal-lb-values.yaml
+++ b/stable/nginx-ingress/ci/deployment-internal-lb-values.yaml
@@ -1,0 +1,6 @@
+controller:
+  service:
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0

--- a/stable/nginx-ingress/templates/controller-service-internal.yaml
+++ b/stable/nginx-ingress/templates/controller-service-internal.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.controller.service.enabled .Values.controller.service.internal.enabled .Values.controller.service.internal.annotations}}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  {{- range $key, $value := .Values.controller.service.internal.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+{{- if .Values.controller.service.labels }}
+{{ toYaml .Values.controller.service.labels | indent 4 }}
+{{- end }}
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ template "nginx-ingress.chart" . }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}-internal
+spec:
+  ports:
+    {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
+    {{- if .Values.controller.service.enableHttp }}
+    - name: http
+      port: {{ .Values.controller.service.ports.http }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.controller.service.enableHttps }}
+    - name: https
+      port: {{ .Values.controller.service.ports.https }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
+      {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
+      {{- end }}
+    {{- end }}
+  selector:
+    app: {{ template "nginx-ingress.name" . }}
+    release: {{ template "nginx-ingress.releaseLabel" . }}
+    app.kubernetes.io/component: controller
+  type: "{{ .Values.controller.service.type }}"
+{{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -294,6 +294,12 @@ controller:
       tcp: {}
       udp: {}
 
+    ## Enables an additional internal load balancer (besides the external one).
+    ## Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
+    internal:
+      enabled: false
+      annotations: {}
+
   extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.


### PR DESCRIPTION
Signed-off-by: Luis Garnica Guilarte <luisgarnica42@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
My team and people from other companies have found uses cases where they have a DNS in split-view configuration and need two ingress to handle internal and external requests for the same deployment. A way for doing this is having a second nginx ignress controller with a different class name like "nginx-internal" which handles these internal connections. This requires like mentioned to have two separate controllers and also two ingress objects per deployment.

With this method (which is proven to work and is being used in production by several people) an identical load balancer to the existing external is deployed with the same ingress controller, but the last one having annotations for being an internal load balancer.

By default ingress objects created will point to the external load balancer address. But if within the private network (AWS VPC, etc..) a host URL can be resolved to the internal load balancer address, the existing ingress controller will handle this request.

Example: (suppose an AWS VPC with Route53 split-view setup)

After chart deployment two LoadBalancers are created:
```
kube-system    nginx-ingress-controller            LoadBalancer   172.20.163.235   a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com           80:31838/TCP,443:32682/TCP   16h
kube-system    nginx-ingress-controller-internal   LoadBalancer   172.20.18.98     internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com   80:30460/TCP,443:32104/TCP   5s
```

And we also create a sample app with an ingress object:

```
$ kubectl get ing
NAME                HOSTS                          ADDRESS                                                                   PORTS     AGE
guestbook-ingress   guestbook-app.domain.tld   a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com   80, 443   6s
```

In Route53 we set a record in the public zone
```
guestbook-app.domain.tld CNAME a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com
```
Then in the private zone
```
guestbook-app.domain.tld CNAME internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com
```
If doing a request to `guestbook-app.domain.tld` from outside the VPC, the external LoadBalancer will handle. While if making the request to the same domain within the VPC the internal LoadBalancer will handle hit, But in both cases hitting the same and single nginx ingress controller.

Example of DNS resolution with the previous setup
*outside the VPC*
```
$ nslookup guestbook-app.domain.tld
Server:		192.168.1.1
Address:	192.168.1.1#53

Non-authoritative answer:
guestbook-app.domain.tld	canonical name = a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com.
Name:	a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com
Address: 51.11.248.22
Name:	a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com
Address: 61.52.15.25
```
*within the VPC*
```
[ec2-user@ip-10-30-1-221 ~]$ nslookup guestbook-app.domain.tld
Server:		10.30.0.2
Address:	10.30.0.2#53

Non-authoritative answer:
guestbook-app.domain.tld	canonical name = internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com.
Name:	internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com Address: 10.30.2.93
Name:	internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com Address: 10.30.3.142
```

#### Which issue this PR fixes
None.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
