### PR TITLE
[stable/prometheus] gRPC port on headless svc

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.4.0
+version: 11.5.0
 appVersion: 2.18.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -336,6 +336,9 @@ Parameter | Description | Default
 `server.statefulSet.headless.annotations` | annotations for Prometheus server headless service | `{}`
 `server.statefulSet.headless.labels` | labels for Prometheus server headless service | `{}`
 `server.statefulSet.headless.servicePort` | Prometheus server headless service port | `80`
+`server.statefulSet.headless.gRPC.enabled` | If true, open a second port on the service for gRPC | `false`
+`server.statefulSet.headless.gRPC.servicePort` | Prometheus service gRPC port, (ignored if `server.service.gRPC.enabled` is not `true`) | `10901`
+`server.statefulSet.headless.gRPC.nodePort` | Port to be used as gRPC nodePort in the prometheus service | `0`
 `server.resources` | Prometheus server resource requests and limits | `{}`
 `server.verticalAutoscaler.enabled` | If true a VPA object will be created for the controller (either StatefulSet or Deployemnt, based on above configs) | `false`
 `server.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for server containers | `{}`

--- a/stable/prometheus/templates/server-service-headless.yaml
+++ b/stable/prometheus/templates/server-service-headless.yaml
@@ -21,6 +21,16 @@ spec:
       port: {{ .Values.server.statefulSet.headless.servicePort }}
       protocol: TCP
       targetPort: 9090
+    {{- if .Values.server.statefulSet.headless.gRPC.enabled }}
+    - name: grpc
+      port: {{ .Values.server.statefulSet.headless.gRPC.servicePort }}
+      protocol: TCP
+      targetPort: 10901
+    {{- if .Values.server.statefulSet.headless.gRPC.nodePort }}
+      nodePort: {{ .Values.server.statefulSet.headless.gRPC.nodePort }}
+    {{- end }}
+    {{- end }}
+
   selector:
     {{- include "prometheus.server.matchLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -838,6 +838,11 @@ server:
       annotations: {}
       labels: {}
       servicePort: 80
+      ## Enable gRPC port on service to allow auto discovery with thanos-querier
+      gRPC:
+        enabled: false
+        servicePort: 10901
+        # nodePort: 10901
 
   ## Prometheus server readiness and liveness probe initial delay and timeout
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/


### PR DESCRIPTION
Signed-off-by: Carlos Juan Gómez Peñalver <carlosjuangp@gmail.com>

#### What this PR does / why we need it:
Add the Thanos gRPC port to the headless service when deploying Prometheus Server using `StatefulSet`

#### Which issue this PR fixes
  - fixes #22783 

#### Special notes for your reviewer:
@gianrubio @zanhsieh

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
