### PR TITLE
[stable/openvpn] Fix Go 1.14 templating

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.2.2
+version: 4.2.3
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -95,7 +95,7 @@ data:
       #!/bin/bash
       EASY_RSA_LOC="/etc/openvpn/certs"
       cd $EASY_RSA_LOC
-      ./easyrsa revoke $1 
+      ./easyrsa revoke $1
       ./easyrsa gen-crl
       cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}
       chmod 644 ${EASY_RSA_LOC}/crl.pem
@@ -209,10 +209,10 @@ data:
 {{ if .Values.openvpn.DEFAULT_ROUTE_ENABLED }}
       push "route NETWORK NETMASK"
 {{ end }}
-{{ if (.Values.openvpn.OVPN_K8S_POD_NETWORK) (.Values.openvpn.OVPN_K8S_POD_SUBNET) }}
+{{ if and (.Values.openvpn.OVPN_K8S_POD_NETWORK) (.Values.openvpn.OVPN_K8S_POD_SUBNET) }}
       push "route {{ .Values.openvpn.OVPN_K8S_POD_NETWORK }} {{ .Values.openvpn.OVPN_K8S_POD_SUBNET }}"
 {{ end }}
-{{ if (.Values.openvpn.OVPN_K8S_SVC_NETWORK) (.Values.openvpn.OVPN_K8S_SVC_SUBNET) }}
+{{ if and (.Values.openvpn.OVPN_K8S_SVC_NETWORK) (.Values.openvpn.OVPN_K8S_SVC_SUBNET) }}
       push "route {{ .Values.openvpn.OVPN_K8S_SVC_NETWORK }} {{ .Values.openvpn.OVPN_K8S_SVC_SUBNET }}"
 {{ end }}
 


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Fixes an issue when rendering the template with a Helm build that was compiled using Go 1.14.

Another chart had the same issue: https://github.com/helm/charts/pull/21888

#### Which issue this PR fixes

This is the error shown:

```
upgrade failed: template: openvpn/templates/openvpn-deployment.yaml:26:28: executing \"openvpn/templates/openvpn-deployment.yaml\" at <include (print .Template.BasePath \"/config-openvpn.yaml\") .>: error calling include: template: openvpn/templates/config-openvpn.yaml:212:6: executing \"openvpn/templates/config-openvpn.yaml\" at <(.Values.openvpn.OVPN_K8S_POD_NETWORK) (.Values.openvpn.OVPN_K8S_POD_SUBNET)>: can't give argument to non-function .Values.openvpn.OVPN_K8S_POD_NETWORK
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
