### PR TITLE
[stable/hazelcast] use new chart repo URL at deprecation notice

### DIFF
--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -3,7 +3,7 @@ name: hazelcast
 # The hazelcast chart is deprecated and no longer maintained. For details deprecation,
 # including how to un-deprecate a chart see the PROCESSES.md file.
 deprecated: true
-version: 3.3.1
+version: 3.3.2
 appVersion: "4.0.1"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.14.0-0"

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -11,7 +11,7 @@
 To install new chart, you just need to add the related repo and use `hazelcast/hazelcast` instead of `stable/hazelcast` as a chart name.
 
 ```bash
-$ helm repo add hazelcast https://hazelcast.github.io/charts
+$ helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
 $ helm install my-release hazelcast/hazelcast           # Helm 3
 $ helm install --name my-release hazelcast-hazelcast   # Helm 2
 ```


### PR DESCRIPTION
Signed-off-by: hasancelik <hasan@hazelcast.com>

#### What this PR does / why we need it:

- use new chart repo URL at deprecation notice

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
