### PR TITLE
[stable/hazelcast-jet] use new chart repo URL at deprecation notice

### DIFF
--- a/stable/hazelcast-jet/Chart.yaml
+++ b/stable/hazelcast-jet/Chart.yaml
@@ -7,7 +7,7 @@ name: hazelcast-jet
 # The hazelcast-jet chart is deprecated and no longer maintained. For details deprecation,
 # including how to un-deprecate a chart see the PROCESSES.md file.
 deprecated: true
-version: 1.6.1
+version: 1.6.2
 keywords:
   - hazelcast
   - jet

--- a/stable/hazelcast-jet/README.md
+++ b/stable/hazelcast-jet/README.md
@@ -13,7 +13,7 @@ Visit [jet-start.sh](https://jet-start.sh) to learn more about the architecture 
 To install new chart, you just need to add the related repo and use `hazelcast/hazelcast-jet ` instead of `stable/hazelcast-jet` as a chart name.
 
 ```bash
-$ helm repo add hazelcast https://hazelcast.github.io/charts
+$ helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
 $ helm install my-release hazelcast/hazelcast-jet            # Helm 3
 $ helm install --name my-release hazelcast/hazelcast-jet    # Helm 2
 ```


### PR DESCRIPTION
Signed-off-by: hasancelik <hasan@hazelcast.com>

#### What this PR does / why we need it:
- use new chart repo URL at deprecation notice

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
