### PR TITLE
[stable/prometheus-blackbox-exporter] Fix broken protmetheusrule

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.1.0
+version: 4.1.1
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -11,8 +11,8 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" $ }}
-    {{- with .Values.prometheusRule.additionalLabels }}
-{{- toYaml . | indent 4 }}
+    {{- with .Values.prometheusRule.additionalLabels -}}
+{{- toYaml . | nindent 4 -}}
     {{- end }}
 spec:
   {{- with .Values.prometheusRule.rules }}


### PR DESCRIPTION
The additional labels would start in the same line as the last label. This fixes the behavior by using `nindent` instead of `indent` so it will start in the next line.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
