### PR TITLE
[stable/sentry] Add Ingress extraPaths to prepend to every host configuration

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 4.2.4
+version: 4.3.0
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -152,6 +152,7 @@ Parameter                                            | Description              
 `ingress.labels`                                     | Ingress labels                                                                                             | `{}`
 `ingress.hostname`                                   | URL to address your Sentry installation                                                                    | `sentry.local`
 `ingress.path`                                       | path to address your Sentry installation                                                                   | `/`
+`ingress.extraPaths`                                 | Ingress extra paths to prepend to every host configuration.                                                | `[]`
 `ingress.tls`                                        | Ingress TLS configuration                                                                                  | `[]`
 `postgresql.enabled`                                 | Deploy postgres server (see below)                                                                         | `true`
 `postgresql.postgresqlDatabase`                      | Postgres database name                                                                                     | `sentry`

--- a/stable/sentry/templates/ingress.yaml
+++ b/stable/sentry/templates/ingress.yaml
@@ -20,6 +20,12 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
+          {{- range .Values.ingress.extraPaths }}
+          - path: {{ .path | quote }}
+            backend:
+              serviceName: {{ .backend.serviceName }}
+              servicePort: {{ .backend.servicePort}}
+          {{- end }}
           - path: {{ default "/" .Values.ingress.path | quote }}
             backend:
               serviceName: {{ template "sentry.fullname" . }}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -198,6 +198,14 @@ ingress:
   enabled: false
   hostname: sentry.local
 
+  ## Extra paths to prepend to every host configuration. This is useful when configuring custom actions with
+  ## [AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions).
+  extraPaths: []
+    # - path: /*
+    #   backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
+
   ## Ingress annotations
   ##
   annotations: {}


### PR DESCRIPTION
Add Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions).

This helps manage to route the paths using ingress controllers. For example - alb-ingress-controller and chart ingress settings:

```
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: "alb"
    alb.ingress.kubernetes.io/scheme: "internet-facing"
    alb.ingress.kubernetes.io/backend-protocol: "HTTP"
    alb.ingress.kubernetes.io/ip-address-type: "ipv4"
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
    # Redirect rules - actions.ssl-redirect
    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
```

And ingress path settings:

```
ingress:
  enabled: true
  ...
  extraPaths:
    - path: /*
      backend:
        serviceName: ssl-redirect
        servicePort: use-annotation
```

In this case, all requests from port 80 will be redirected to 443 port. More info you can find [here](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions).


#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)