### PR TITLE
[stable/seq] Support ingesting GELF

### DIFF
--- a/stable/seq/Chart.yaml
+++ b/stable/seq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: seq
-version: 2.0.0
+version: 2.1.0
 appVersion: 5
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:

--- a/stable/seq/README.md
+++ b/stable/seq/README.md
@@ -62,6 +62,13 @@ The following table lists the configurable parameters of the Seq chart and their
 | `ingestion.ingress.enabled`          | Enable ingress on the ingestion-only API                                                              | `false`                               |
 | `ingestion.ingress.path`             | Ingress path                                                                                          | `/`                                   |
 | `ingestion.ingress.hosts`            | Ingress accepted hostnames                                                                            | `[]`                                  |
+| `gelf.enabled`                       | Enable log ingestion using the GELF protocol                                                          | `false`                               |
+| `gelf.apiKey`                        | The API key to use when forwarding events into Seq                                                    |                                       |
+| `gelf.image.repository`              | Image repository                                                                                      | `datalust/sqelf`                      |
+| `gelf.image.tag`                     | Sqelf image tag                                                                                       | `2`                                   |
+| `gelf.image.pullPolicy`              | Image pull policy                                                                                     | `IfNotPresent`                        |
+| `gelf.service.port`                  | The port to listen for GELF events on                                                                 | `12201`                               |
+| `gelf.service.protocol`              | The protocol to listen for GELF events on. Can be either `UDP` or `TCP`.                              | `TCP`                                 |
 | `persistence.enabled`                | Use persistent volume to store data                                                                   | `true`                                |
 | `persistence.size`                   | Size of persistent volume claim                                                                       | `8Gi`                                 |
 | `persistence.existingClaim`          | Use an existing PVC to persist data                                                                   | `nil`                                 |

--- a/stable/seq/templates/deployment.yaml
+++ b/stable/seq/templates/deployment.yaml
@@ -38,14 +38,14 @@ spec:
             - name: ui
               containerPort: 80
               protocol: TCP
-          {{- if .Values.podSecurityPolicy.create }}
+{{- if .Values.podSecurityPolicy.create }}
           securityContext:
             runAsUser: 0
             capabilities:
               add:
                 - NET_BIND_SERVICE
-          {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
+{{- end }}
+{{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
@@ -55,8 +55,8 @@ spec:
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+{{- end }}
+{{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
@@ -66,22 +66,45 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.startupProbe.enabled }}
+{{- end }}
+{{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /
               port: ui
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-          {{- end }}
+{{- end }}
           volumeMounts:
           - name: seq-data
             mountPath: {{ .Values.persistence.path }}
             subPath: {{ .Values.persistence.subPath }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+{{- if .Values.gelf.enabled }}
+        - name: {{ .Chart.Name }}-gelf
+          image: "{{ .Values.gelf.image.repository }}:{{ .Values.gelf.image.tag }}"
+          imagePullPolicy: {{ .Values.gelf.image.pullPolicy }}
+          env:
+            - name: "SEQ_ADDRESS"
+              value: "http://{{ template "seq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.ingestion.service.port }}"
+            - name: "SEQ_API_KEY"
+              value: "{{ .Values.gelf.apiKey }}"
+            - name: "GELF_ADDRESS"
+              value: "{{ .Values.gelf.service.protocol | lower }}://0.0.0.0:12201"
+            - name: "GELF_ENABLE_DIAGNOSTICS"
+              value: "True"
+          ports:
+            - name: gelf
+              containerPort: 12201
+              protocol: {{ .Values.gelf.service.protocol }}
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+{{- end }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -96,9 +119,9 @@ spec:
       serviceAccountName: "{{ template "seq.serviceAccountName" . }}"
       volumes:
       - name: seq-data
-      {{- if .Values.persistence.enabled }}
+{{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "seq.fullname" .) }}
-      {{- else }}
+{{- else }}
         emptyDir: {}
-      {{- end -}}
+{{- end -}}

--- a/stable/seq/templates/psp.yaml
+++ b/stable/seq/templates/psp.yaml
@@ -23,7 +23,7 @@ spec:
   # but we can provide it for defense in depth.
   requiredDropCapabilities:
     - ALL
-  # Allow core volume typ.
+  # Allow core volume types.
   volumes:
     - 'secret'
     - 'persistentVolumeClaim'

--- a/stable/seq/templates/service.yaml
+++ b/stable/seq/templates/service.yaml
@@ -18,6 +18,12 @@ spec:
       targetPort: ingestion
       protocol: TCP
       name: ingestion
+{{- if .Values.gelf.enabled }}
+    - port: {{ .Values.gelf.service.port }}
+      targetPort: gelf
+      protocol: {{ .Values.gelf.service.protocol }}
+      name: gelf
+{{- end }}
   selector:
     app: {{ template "seq.name" . }}
     release: {{ .Release.Name }}

--- a/stable/seq/values.yaml
+++ b/stable/seq/values.yaml
@@ -40,6 +40,18 @@ ingestion:
     path: /
     hosts: []
 
+# Accept events in the GELF format and forward them to Seq.
+gelf:
+  enabled: false
+  image:
+    repository: datalust/sqelf
+    tag: 2
+    pullPolicy: IfNotPresent
+  service:
+    port: 12201
+    # GELF can be ingested through either TCP or UDP
+    protocol: TCP
+
 service:
   type: ClusterIP
 
@@ -76,8 +88,7 @@ affinity: {}
 persistence:
   enabled: true
 
-  ## The path the volume will be mounted at, useful when using different
-  ## Redis images.
+  ## The path the volume will be mounted at
   path: /data
 
   ## The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services.


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

This PR adds an optional (default disabled) [`datalust/sqelf`](https://github.com/datalust/sqelf) forwarder to the Seq pod that can ingest events with Graylog's GELF protocol and forward them to Seq. This is helpful for users that want to ingest Kubernetes logs into Seq using something like `fluent-bit`, which has out-of-the-box support for GELF.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
