### PR TITLE
[elasticsearch-curator] fix dryrun for hooks

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.7.6"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.1.5
+version: 2.1.6
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/hooks/job.install.yaml
+++ b/stable/elasticsearch-curator/templates/hooks/job.install.yaml
@@ -53,7 +53,11 @@ spec:
           command:
 {{ toYaml $.Values.command | indent 12 }}
 {{- end }}
+{{- if .Values.dryrun }}
+          args: [ "--dry-run", "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+{{- else }}
           args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+{{- end }}
           resources:
 {{ toYaml $.Values.resources | indent 12 }}
     {{- with $.Values.nodeSelector }}

--- a/stable/elasticsearch-curator/templates/hooks/job.install.yaml
+++ b/stable/elasticsearch-curator/templates/hooks/job.install.yaml
@@ -53,7 +53,7 @@ spec:
           command:
 {{ toYaml $.Values.command | indent 12 }}
 {{- end }}
-{{- if .Values.dryrun }}
+{{- if $.Values.dryrun }}
           args: [ "--dry-run", "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
 {{- else }}
           args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -41,7 +41,7 @@ hooks:
   install: false
   upgrade: false
 
-# run curator in dry-run mode
+# run curator in dry-run mode (works for cronjob and for hooks)
 dryrun: false
 
 command: ["/curator/curator"]


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The dryrun option is currently working for the normal cronjob, but not taken into account for the post-install/upgrade hooks, which is misleading and can potentially be disastrous since people could lose important Elasticsearch indices thinking they were just running it as a dryrun, whereas it was actually deleting everything. We need consistency here, it is not called "cronjob.dryrun", it is just "dryrun", a global option, so it should apply to all the jobs, hooks or cron. 
The dryrun option is actually even more important for hooks, because usually when you run the curator as a hook, it's because you want a quick test, you need to be able to run it as a dryrun.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
