### PR TITLE
[stable/fluent-bit] Added `backend.match` parameter

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.17
+version: 2.8.18
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -31,6 +31,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | -----------------------    | ---------------------------------- | ----------------------- |
 | **Backend Selection**      |
 | `backend.type`             | Set the backend to which Fluent-Bit should flush the information it gathers | `forward` |
+| **Backend Match**          |
+| `backend.match`            | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | **Forward Backend**        |
 | `backend.forward.host`     | Target host where Fluent-Bit or Fluentd are listening for Forward messages | `fluentd` |
 | `backend.forward.port`     | TCP Port of the target service | `24284` |

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -31,9 +31,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | -----------------------    | ---------------------------------- | ----------------------- |
 | **Backend Selection**      |
 | `backend.type`             | Set the backend to which Fluent-Bit should flush the information it gathers | `forward` |
-| **Backend Match**          |
-| `backend.match`            | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | **Forward Backend**        |
+| `backend.forward.match`    | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | `backend.forward.host`     | Target host where Fluent-Bit or Fluentd are listening for Forward messages | `fluentd` |
 | `backend.forward.port`     | TCP Port of the target service | `24284` |
 | `backend.forward.shared_key`       | A key string known by the remote Fluentd used for authorization. | `` |
@@ -41,6 +40,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.forward.tls_verify`       | Force certificate validation  | `on` |
 | `backend.forward.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | **ElasticSearch Backend**  |
+| `backend.es.match`         | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | `backend.es.host`          | IP address or hostname of the target Elasticsearch instance | `elasticsearch` |
 | `backend.es.port`          | TCP port of the target Elasticsearch instance. | `9200` |
 | `backend.es.index`         | Elastic Index name | `kubernetes_cluster` |
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.es.tls_ca`           | TLS CA certificate for the Elastic instance (in PEM format). Specify if tls: on. | `` |
 | `backend.es.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | **HTTP Backend**              |
+| `backend.http.match`          | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | `backend.http.host`           | IP address or hostname of the target HTTP Server | `127.0.0.1` |
 | `backend.http.port`           | TCP port of the target HTTP Server | `80` |
 | `backend.http.uri`            | Specify an optional HTTP URI for the target web server, e.g: /something | `"/"`
@@ -75,6 +76,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.http.tls_verify`       | Force certificate validation  | `on` |
 | `backend.http.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | **Splunk Backend**              |
+| `backend.splunk.match`          | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | `backend.splunk.host`           | IP address or hostname of the target Splunk Server | `127.0.0.1` |
 | `backend.splunk.port`           | TCP port of the target Splunk Server | `8088` |
 | `backend.splunk.token`            | Specify the Authentication Token for the HTTP Event Collector interface. | `` |
@@ -84,6 +86,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.splunk.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | `backend.splunk.message_key`           | Tag applied to all incoming logs | `kubernetes` |
 | **Stackdriver Backend**              |
+| `backend.stackdriver.match`          | Set the backend match tag Fluent-Bit makes use of to gather information  | `*` |
 | `backend.stackdriver.google_service_credentials`           | Contents of a Google Cloud credentials JSON file. | `` |
 | `backend.stackdriver.service_account_email`           | Account email associated to the service. Only available if no credentials file has been provided. | `` |
 | `backend.stackdriver.service_account_secret`            | Private key content associated with the service account. Only available if no credentials file has been provided. | `` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -105,12 +105,12 @@ data:
 {{ if eq .Values.backend.type "test" }}
     [OUTPUT]
         Name  file
-        Match {{ .Values.backend.match }}   
+        Match *
         Path /tmp/fluent-bit.log
 {{ else if eq .Values.backend.type "forward" }}
     [OUTPUT]
         Name          forward
-        Match {{ .Values.backend.match }}
+        Match         {{ .Values.backend.forward.match }}
         Host          {{ .Values.backend.forward.host }}
         Port          {{ .Values.backend.forward.port }}
         Retry_Limit False
@@ -129,7 +129,7 @@ data:
 {{ else if eq .Values.backend.type "es" }}
     [OUTPUT]
         Name  es
-        Match {{ .Values.backend.match }}
+        Match {{ .Values.backend.es.match }}
         Host  {{ .Values.backend.es.host }}
         Port  {{ .Values.backend.es.port }}
         Logstash_Format {{ default "On" .Values.backend.es.logstash_format  }}
@@ -171,7 +171,7 @@ data:
 {{ else if eq .Values.backend.type "splunk" }}
     [OUTPUT]
         Name  splunk
-        Match {{ .Values.backend.match }}
+        Match {{ .Values.backend.splunk.match }}
         Host  {{ .Values.backend.splunk.host }}
         Port  {{ .Values.backend.splunk.port }}
         Splunk_Token  {{ .Values.backend.splunk.token }}
@@ -183,7 +183,7 @@ data:
 {{ else if eq .Values.backend.type "stackdriver" }}
     [OUTPUT]
         Name  stackdriver
-        Match {{ .Values.backend.match }}
+        Match {{ .Values.backend.stackdriver.match }}
         resource global
 {{- if .Values.backend.stackdriver.google_service_credentials }}
         google_service_credentials /secure/google_service_credentials.json
@@ -194,7 +194,7 @@ data:
 {{ else if eq .Values.backend.type "http" }}
     [OUTPUT]
         Name  http
-        Match {{ .Values.backend.match }}
+        Match {{ .Values.backend.http.match }}
         Host {{ .Values.backend.http.host }}
         Port {{ .Values.backend.http.port }}
         URI {{ .Values.backend.http.uri }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -105,12 +105,12 @@ data:
 {{ if eq .Values.backend.type "test" }}
     [OUTPUT]
         Name  file
-        Match *
+        Match {{ .Values.backend.match }}   
         Path /tmp/fluent-bit.log
 {{ else if eq .Values.backend.type "forward" }}
     [OUTPUT]
         Name          forward
-        Match         *
+        Match {{ .Values.backend.match }}
         Host          {{ .Values.backend.forward.host }}
         Port          {{ .Values.backend.forward.port }}
         Retry_Limit False
@@ -129,7 +129,7 @@ data:
 {{ else if eq .Values.backend.type "es" }}
     [OUTPUT]
         Name  es
-        Match *
+        Match {{ .Values.backend.match }}
         Host  {{ .Values.backend.es.host }}
         Port  {{ .Values.backend.es.port }}
         Logstash_Format {{ default "On" .Values.backend.es.logstash_format  }}
@@ -171,7 +171,7 @@ data:
 {{ else if eq .Values.backend.type "splunk" }}
     [OUTPUT]
         Name  splunk
-        Match *
+        Match {{ .Values.backend.match }}
         Host  {{ .Values.backend.splunk.host }}
         Port  {{ .Values.backend.splunk.port }}
         Splunk_Token  {{ .Values.backend.splunk.token }}
@@ -183,7 +183,7 @@ data:
 {{ else if eq .Values.backend.type "stackdriver" }}
     [OUTPUT]
         Name  stackdriver
-        Match *
+        Match {{ .Values.backend.match }}
         resource global
 {{- if .Values.backend.stackdriver.google_service_credentials }}
         google_service_credentials /secure/google_service_credentials.json
@@ -194,7 +194,7 @@ data:
 {{ else if eq .Values.backend.type "http" }}
     [OUTPUT]
         Name  http
-        Match *
+        Match {{ .Values.backend.match }}
         Host {{ .Values.backend.http.host }}
         Port {{ .Values.backend.http.port }}
         URI {{ .Values.backend.http.uri }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -50,8 +50,8 @@ priorityClassName: ""
 
 backend:
   type: forward
-  match: "*"
   forward:
+    match: "*"
     host: fluentd
     port: 24284
     tls: "off"
@@ -59,6 +59,7 @@ backend:
     tls_debug: 1
     shared_key:
   es:
+    match: "*"
     host: elasticsearch
     port: 9200
     # Elastic Index Name
@@ -81,6 +82,7 @@ backend:
     # TLS debugging levels = 1-4
     tls_debug: 1
   splunk:
+    match: "*"
     host: 127.0.0.1
     port: 8088
     token: ""
@@ -89,12 +91,14 @@ backend:
     tls_verify: "off"
     tls_debug: 1
     message_key: "kubernetes"
-  stackdriver: {}
+  stackdriver:
+    match: "*"
 
   ##
   ## Ref: http://fluentbit.io/documentation/current/output/http.html
   ##
   http:
+    match: "*"
     host: 127.0.0.1
     port: 80
     uri: "/"

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -50,6 +50,7 @@ priorityClassName: ""
 
 backend:
   type: forward
+  match: "*"
   forward:
     host: fluentd
     port: 24284


### PR DESCRIPTION
Signed-off-by: Luis Specian <luis.specian@olx.com>

#### What this PR does / why we need it:
This PR provides a parameter to configure the Match for fluent-bit outputs, this parameter is useful for example on a situation where we don't want to have all of the information sent to one output but shipped partially to a alternative output after tagging the information with a filter

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
