### PR TITLE
[stable/spinnaker] Clean spinnaker deployment only if halyard is available.

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc6
+version: 2.0.0-rc7
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -31,7 +31,9 @@ data:
     {{- end }}
   clean.sh: |
     export HAL_COMMAND='hal --daemon-endpoint http://{{ template "spinnaker.fullname" . }}-halyard:8064'
-    $HAL_COMMAND deploy clean -q
+    if $HAL_COMMAND --ready; then
+      $HAL_COMMAND deploy clean -q
+    fi
   config.sh: |
     # Spinnaker version
     {{ if .Values.halyard.bom }}


### PR DESCRIPTION
fixes #22554

Signed-off-by: Nirmalyasen <nirmalya@opsmx.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes #22554  

In case of a failure in installation and halyard does not come up, delete of the chart hangs as it tries to clean up a non-existing installation. This fix checks if the pod is available before attempting to clean up the installation. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #22554 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
