### PR TITLE
[stable/spinnaker] The kubernetes account may not have access to all the namespaces.

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc6
+version: 2.0.0-rc7
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc6
+version: 2.0.0-rc8
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/_helpers.tpl
+++ b/stable/spinnaker/templates/_helpers.tpl
@@ -37,6 +37,13 @@ release: {{ .Release.Name | quote }}
 {{- end -}}
 
 {{/*
+Create comma separated list of namespaces in Kubernetes
+*/}}
+{{- define "nameSpaces" -}}
+{{- join "," .Values.kubeConfig.nameSpaces }}
+{{- end -}}
+
+{{/*
 Create comma separated list of omitted namespaces in Kubernetes
 */}}
 {{- define "omittedNameSpaces" -}}

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -121,7 +121,8 @@ data:
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
                 {{ if not $.Values.kubeConfig.checkPermissionsOnStartup }}--check-permissions-on-startup false{{ end }} \
-                --omit-namespaces={{ template "omittedNameSpaces" $ }} \
+                {{ if $.Values.kubeConfig.nameSpaces }}--namespaces={{ template "nameSpaces" $ }}{{ end }} \
+                {{ if not $.Values.kubeConfig.nameSpaces }}--omit-namespaces={{ template "omittedNameSpaces" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.omittedKinds }}--omit-kinds={{ template "omittedKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
                 --provider-version v2

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -175,6 +175,12 @@ kubeConfig:
   contexts:
   - default
   deploymentContext: default
+  # Use this to limit the namespaces this kubernetes account will access.
+  # Note, if you use nameSpaces, omittedNameSpaces will not be used.
+  # Note, the casing of the nameSpace variable here.
+  # nameSpaces:
+  # - namespace1
+  # - namespace2
   omittedNameSpaces:
   - kube-system
   - kube-public


### PR DESCRIPTION
This will allow a user to set the namespaces the account can access.

There is a hal command to set this for kubernetes accounts. Adding
that capabiity to the helm chart to do the same for the default
kubernetes account.

Note, Spinnaker does not allow both namespaces and omittedNamespaces
to be set. Clouddriver fails if both are set. That is also handled here.

Signed-off-by: Nirmalyasen <nirmalya@opsmx.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
The capability to limit the namespaces to accessible namespaces is not there in the Spinnaker helm chart. This PR enables that feature. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
