### PR TITLE
[stable/prometheus-couch-updater] Fix deprecated apis, use new image version, and user/password

### DIFF
--- a/stable/prometheus-couchdb-exporter/Chart.yaml
+++ b/stable/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v27.2.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.1
+version: 0.1.2
 keywords:
 - couchdb-exporter
 sources:

--- a/stable/prometheus-couchdb-exporter/Chart.yaml
+++ b/stable/prometheus-couchdb-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "v27.2.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter

--- a/stable/prometheus-couchdb-exporter/README.md
+++ b/stable/prometheus-couchdb-exporter/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters and their default values.
 | `couchdb.databases`    | comma separated databases to monitor                | `_all_dbs`                              |
 | `couchdb.username`     | username for couchdb                                |                                         |
 | `couchdb.password`     | password for couchdb                                |                                         |
+| `secretName`           | secret to pull adminUsername and adminPassword      |                                         |
 
 
 For more information please refer to the [couchdb-prometheus-exporter]https://github.com/gesellix/couchdb-prometheus-exporter) documentation.

--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -43,12 +43,12 @@ spec:
             httpGet:
               path: /
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -56,14 +56,17 @@ spec:
               containerPort: 9984
           livenessProbe:
             httpGet:
-              path: /
+              path: /status
               port: http
             initialDelaySeconds: 60
           readinessProbe:
             httpGet:
-              path: /
+              path: /status
               port: http
-            initialDelaySeconds: 60
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -36,6 +36,21 @@ spec:
           {{- if .Values.couchdb.password }}
             - "-couchdb.password={{ .Values.couchdb.password }}"
           {{- end }}
+
+          {{- if .Values.secretName }}
+          env:
+            - name: COUCHDB.USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: adminUsername
+            - name: COUCHDB.PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: adminPassword
+          {{- end }}
+
           ports:
             - name: http
               containerPort: 9984

--- a/stable/prometheus-couchdb-exporter/templates/ingress.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "prometheus-couchdb-exporter.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-couchdb-exporter.fullname" . }}

--- a/stable/prometheus-couchdb-exporter/templates/service.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "prometheus-couchdb-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/port: "9984"
+    prometheus.io/scrape: "true"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/prometheus-couchdb-exporter/values.yaml
+++ b/stable/prometheus-couchdb-exporter/values.yaml
@@ -18,7 +18,7 @@ replicaCount: 1
 
 image:
   repository: gesellix/couchdb-prometheus-exporter
-  tag: 16
+  tag: v27.2.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
- Updated some removed `apiVersion`
- Added prometheus scrape annotations to work with [annotations](https://github.com/helm/charts/tree/master/stable/prometheus#scraping-pod-metrics-via-annotations)
- Added user/password via values or via secrets
- Updated the underlying image to v27.2

#### Special notes for your reviewer:
I can't tell whether this or https://github.com/gkarthiks/helm-charts/tree/master/charts/prometheus-couchdb-exporter is the current version. I this version is obsolete, I'd prefer we delete it instead of merge this changes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
