### PR TITLE
[incubator/sso-buzzfeed] Add default interval the group cache should refresh at

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -101,6 +101,8 @@ spec:
             - name: PROVIDER_GOOGLE_GOOGLE_CREDENTIALS
               value: /creds/sso-serviceaccount.json
           {{- end }}
+            - name: PROVIDER_GOOGLE_GROUPCACHE_INTERVAL_REFRESH
+              value: 10m
             - name: PROVIDER_GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -100,9 +100,9 @@ spec:
               value: {{ .adminEmail | quote }}
             - name: PROVIDER_GOOGLE_GOOGLE_CREDENTIALS
               value: /creds/sso-serviceaccount.json
-          {{- end }}
             - name: PROVIDER_GOOGLE_GROUPCACHE_INTERVAL_REFRESH
               value: 10m
+          {{- end }}
             - name: PROVIDER_GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
#### What this PR does / why we need it:
Sets the default group cache interval to 10m. This should be default per this PR https://github.com/buzzfeed/sso/pull/246, but SSO in my case was pretty slow (almost useless) without this env variable.

More info on the variable here https://github.com/buzzfeed/sso/blob/master/docs/google_provider_setup.md#configuring-sso-to-use-the-service-account-credentials

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
