### PR TITLE
[incubator/rundeck] add pvc, sa, common labels, upgrade app and chart version

### DIFF
--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 0.1.3
-appVersion: 3.1.12
+version: 0.2.0
+appVersion: 3.2.7
 keywords:
 - rundeck
 - jobs

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -10,14 +10,15 @@ Rundeck lets you turn your operations procedures into self-service jobs. Safely 
 
 ## Configuration
 
-The following configurations may be set. It is recommended to use values.yaml for overwriting the Riemann config.
+The following configurations may be set. It is recommended to use values.yaml for overwriting the Rundeck config.
 
 Parameter | Description | Default
 --------- | ----------- | -------
-replicaCount | How many replicas to run. Riemann can really only work with one. | 1
-annotations | You can pass annotations inside .spec.template.metadata.annotations. Every value under this is iterated as a key/value and used as a parameter. Useful for KIAM/Kube2IAM and others for example. | ""
+replicaCount | How many replicas to run. Rundeck can really only work with one. | 1
+deployment.annotations | You can pass annotations inside deployment.spec.template.metadata.annotations. Useful for KIAM/Kube2IAM and others for example. | {}
+deployment.rolloutStrategy | Sets the K8s rollout strategy for the Rundeck deployment | { type: RollingUpdate }
 image.repository | Name of the image to run, without the tag. | [rundeck/rundeck](https://github.com/rundeck/rundeck)
-image.tag | The image tag to use. | 3.0.16
+image.tag | The image tag to use. | 3.2.7
 image.pullPolicy | The kubernetes image pull policy. | IfNotPresent
 service.type | The kubernetes service type to use. | ClusterIP
 service.port | The tcp port the service should listen on. | 80
@@ -27,5 +28,11 @@ rundeck.adminUser | The config to set up the admin user that should be placed at
 rundeck.env | The rundeck environment variables that you would want to set | Default variables provided in docker file
 rundeck.sshSecrets | A reference to the Kubernetes Secret that contains the ssh keys. | ""
 rundeck.awsCredentialsSecret | A reference to the Kubernetes Secret that contains the aws credentials. | ""
-rundeck.awsVolumeId | A Volume ID from a pre-existent AWS EBS volume to persist Rundeck data from /home/rundeck/server/data path. | "" 
 nginxConfOverride | An optional multi-line value that can replace the default nginx.conf. | ""
+persistence.enabled | Whether or not to attach persistent storage to the Rundeck pod | false
+persistence.claim.create | Whether the helm chart should create a persistent volume claim. See the values.yaml for more claim options | false
+persistence.awsVolumeId | A Volume ID from a pre-existent AWS EBS volume to persist Rundeck data from /home/rundeck/server/data path. | None
+persistence.existingClaim | Name of an existing volume claim | None
+serviceAccount.create | Set to true to create a service account for the Rundeck pod | false
+serviceAccount.annotations | A map of annotations to attach to the service account (eg: AWS IRSA) | {}
+serviceAccount.name | Name of the service account the Rundeck pod should use | ""

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -14,7 +14,7 @@ The following configurations may be set. It is recommended to use values.yaml fo
 
 Parameter | Description | Default
 --------- | ----------- | -------
-replicaCount | How many replicas to run. Rundeck can really only work with one. | 1
+deployment.replicaCount | How many replicas to run. Rundeck can really only work with one. | 1
 deployment.annotations | You can pass annotations inside deployment.spec.template.metadata.annotations. Useful for KIAM/Kube2IAM and others for example. | {}
 deployment.rolloutStrategy | Sets the K8s rollout strategy for the Rundeck deployment | { type: RollingUpdate }
 image.repository | Name of the image to run, without the tag. | [rundeck/rundeck](https://github.com/rundeck/rundeck)

--- a/incubator/rundeck/files/nginx/nginx.conf
+++ b/incubator/rundeck/files/nginx/nginx.conf
@@ -4,7 +4,10 @@ events {
 
 http {
     server {
-        
+        location /healthz {
+            return 204;
+            access_log off;
+        }
         location / {
             recursive_error_pages on;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/incubator/rundeck/templates/_helpers.tpl
+++ b/incubator/rundeck/templates/_helpers.tpl
@@ -30,3 +30,22 @@ Create chart name and version as used by the chart label.
 {{- define "rundeck.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* Basic labels */}}
+{{- define "rundeck.labels" }}
+app.kubernetes.io/name: {{ template "rundeck.name" . }}
+helm.sh/chart: {{ template "rundeck.chart" . }}
+app.kubernetes.io/instance: {{.Release.Name }}
+app.kubernetes.io/managed-by: {{.Release.Service }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rundeck.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "rundeck.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -2,30 +2,32 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rundeck.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "rundeck.name" . }}
-    helm.sh/chart: {{ include "rundeck.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{ include "rundeck.labels" . | indent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.deployment.replicaCount }}
+  strategy:
+    {{- with .Values.deployment.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "rundeck.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      {{- if .Values.annotations }}
-      # Annotations iteration - Useful for KIAM and others
       annotations:
-        {{- range $key, $value := .Values.annotations }}
-        {{ $key }}: {{ $value | quote }}
+        # This will restart the rundeck pod if its environment configuration is updated by helm
+        checksum/config: {{ include (print $.Template.BasePath "/rundeck-environment-configmap.yaml") . | sha256sum }}
+        {{- with .Values.deployment.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "rundeck.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "rundeck.serviceAccountName" . }}
       securityContext:
         fsGroup: 1000
       containers:
@@ -35,20 +37,18 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-              livenessProbe:
-                httpGet:
-                  path: /
-                  port: 80
-                  scheme: HTTP
-                initialDelaySeconds: 60
-                periodSeconds: 120
-              readinessProbe:
-                httpGet:
-                  path: /
-                  port: 80
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+              scheme: HTTP
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+              scheme: HTTP
+            periodSeconds: 5
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx
@@ -108,11 +108,19 @@ spec:
               - key: nginx.conf
                 path: nginx.conf
         - name: data
-        {{- if .Values.rundeck.awsVolumeId }}
+        {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.awsVolumeId }}
           # This AWS EBS volume must already exist.
           awsElasticBlockStore:
             volumeID: {{ .Values.rundeck.awsVolumeId }}
             fsType: ext4
+        {{- else if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- else if .Values.persistence.claim.create }}
+          persistentVolumeClaim:
+            claimName: {{ include "rundeck.fullname" . }}
+        {{- end }}  
         {{- else }}
           emptyDir: {}
         {{- end }}  

--- a/incubator/rundeck/templates/ingress.yaml
+++ b/incubator/rundeck/templates/ingress.yaml
@@ -5,11 +5,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-    app.kubernetes.io/name: {{ include "rundeck.name" . }}
-    helm.sh/chart: {{ include "rundeck.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{ include "rundeck.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/incubator/rundeck/templates/nginx-configmap.yaml
+++ b/incubator/rundeck/templates/nginx-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-nginx-configmap
-type: Opaque
+  labels: {{ include "rundeck.labels" . | indent 4 }}
 data:
   nginx.conf: |-
 {{- if .Values.nginxConfOverride }}

--- a/incubator/rundeck/templates/rundeck-environment-configmap.yaml
+++ b/incubator/rundeck/templates/rundeck-environment-configmap.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-environment-configmap
-type: Opaque
+  labels: {{ include "rundeck.labels" . | indent 4 }}
 data:
 {{ toYaml .Values.rundeck.env | indent 4}}

--- a/incubator/rundeck/templates/service.yaml
+++ b/incubator/rundeck/templates/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rundeck.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "rundeck.name" . }}
-    helm.sh/chart: {{ include "rundeck.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{ include "rundeck.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/incubator/rundeck/templates/serviceAccount.yaml
+++ b/incubator/rundeck/templates/serviceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rundeck.serviceAccountName" . }}
+  labels: {{ include "rundeck.labels" . | indent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/incubator/rundeck/templates/volume.yaml
+++ b/incubator/rundeck/templates/volume.yaml
@@ -1,0 +1,20 @@
+  
+{{- if and .Values.persistence.enabled .Values.persistence.claim.create }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "rundeck.fullname" . }}
+  labels: {{ include "rundeck.labels" . | indent 4 }}
+  annotations:
+{{- with .Values.persistence.claim }}
+  {{- if .storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .storageClass | quote }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- end }}
+{{- end }}

--- a/incubator/rundeck/values.yaml
+++ b/incubator/rundeck/values.yaml
@@ -10,7 +10,7 @@ image:
 deployment:
   replicaCount: 1
   annotations: {}
-  rolloutStrategy: 
+  rolloutStrategy:
     type: RollingUpdate
     # Recreate can help when using persistent volumes
     # type: Recreate
@@ -50,7 +50,7 @@ persistence:
   # Set claim.create:true  to have the helm chart manage the creation of a new PVC for this deployment
   claim:
     create: false
-    # storageClass: 
+    # storageClass:
     # accessMode: ReadWriteOnce
     # size: 10G
 

--- a/incubator/rundeck/values.yaml
+++ b/incubator/rundeck/values.yaml
@@ -2,12 +2,18 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: rundeck/rundeck
-  tag: 3.0.16
+  tag: 3.2.7
   pullPolicy: IfNotPresent
+
+deployment:
+  replicaCount: 1
+  annotations: {}
+  rolloutStrategy: 
+    type: RollingUpdate
+    # Recreate can help when using persistent volumes
+    # type: Recreate
 
 rundeck:
   adminUser: "admin:admin,user,admin,architect,deploy,build"
@@ -26,7 +32,6 @@ rundeck:
     # RUNDECK_CONFIG_STORAGE_CONVERTER_1_CONFIG_PASSWORD: ${RUNDECK_STORAGE_PASSWORD}
   # sshSecrets: "ssh-secret"
   awsCredentialsSecret: ""
-  awsVolumeId: ""
 
 nameOverride: ""
 fullnameOverride: ""
@@ -34,6 +39,30 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 80
+
+persistence:
+  enabled: false
+  # Set existingClaim to the name of an existing PVC to reuse a volume managed outside this helm chart
+  # existingClaim:
+  # If deployed on AWS you can optionally specify an existing EBS volume by ID
+  # awsVolumeId:
+
+  # Set claim.create:true  to have the helm chart manage the creation of a new PVC for this deployment
+  claim:
+    create: false
+    # storageClass: 
+    # accessMode: ReadWriteOnce
+    # size: 10G
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  annotations: {}
+    # AWS IRSA annotation
+    # eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/rundeck
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
 ingress:
   enabled: false


### PR DESCRIPTION
FYI, PR template has broken link:
https://github.com/helm/helm/tree/master/docs/chart_best_practices
------------

#### What this PR does / why we need it:
* Upgrades the default app version set in `Chart.yaml` and default values file from 3.0.16 to 3.2.7
* Adds more flexibility around launching persistent storage for Rundeck by optionally adding a PVC or by specifying an existing claim. The existing AWS EBS volume configuration option remains but is moved under the `persistence` key in configuration values. Minor version bump of the `Chart.yaml` as a result.
* Adds support for using a k8s service account for the Rundeck pod. This opens up support for AWS IRSA as well as better supporting granting Rundeck k8s API access. Chart users may now optionally specify an externally-managed service account.
* Support for specifying annotations to add to the deployment and the rollout strategy used, which allows for specifying `Recreate` when using a PVC so the old deployment can first spin down and detach from the volume before the new one comes up. The `replicaCount` key is thus under this new parent `deployment` key.
* Adds a healthcheck handler to the default nginx config (with disabled logging) so that the readiness and liveness probes for that container don't depend on Rundeck's availability, since it's got its own probes.
* Replaced the many label set copies with a label helper template to dry things up a bit.
* Adds a configmap checksum annotation to restart the Rundeck pod in the event helm pushes new environment configuration.
* Fixes an issue in the `deployment.yaml` template where the `nginx` pod's probes are mistakenly nested under the container port keys: https://github.com/helm/charts/blob/master/incubator/rundeck/templates/deployment.yaml#L38-L51
* Removes copy-pasta references to "Riemann" in the readme.

#### Which issue this PR fixes
Overall QoL fixes for operating Rundeck in K8s using this chart.

Fixes: https://github.com/helm/charts/issues/22881

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
