### PR TITLE
[stable/minecraft] Deprecating minecraft chart

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.2.4
+version: 1.2.5
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server
@@ -10,10 +10,4 @@ keywords:
 sources:
 - https://hub.docker.com/r/itzg/minecraft-server/~/dockerfile/
 - https://github.com/itzg/dockerfiles
-maintainers:
-- name: gtaylor
-  email: gtaylor@gc-taylor.com
-- name: billimek
-  email: jeff@billimek.com
-- name: itzg
-  email: itzgeoff@gmail.com
+deprecated: true

--- a/stable/minecraft/README.md
+++ b/stable/minecraft/README.md
@@ -1,4 +1,10 @@
-# Minecraft
+# DEPRECATED - Minecraft
+
+**This chart has been deprecated and moved to its new home:**
+
+**Github repo:** https://github.com/itzg/minecraft-server-charts
+
+**Charts repo:** https://itzg.github.io/minecraft-server-charts/
 
 [Minecraft](https://minecraft.net/en/) is a game about placing blocks and going on adventures.
 


### PR DESCRIPTION
#### Which issue this PR fixes

This deprecates the minecraft chart and references the new home.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
