### PR TITLE
[stable/fluent-bit] Allow extraEntries with regex parser

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.17
+version: 2.8.18
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -235,6 +235,9 @@ data:
 {{- if .timeFormat }}
         Time_Format {{ .timeFormat }}
 {{- end }}
+{{- if .extraEntries }}
+{{ .extraEntries | indent 8 }}
+{{- end }}
 {{ end }}
 {{- end }}
 {{- if .Values.parsers.json }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -112,7 +112,7 @@ parsers:
   enabled: false
   ## List the respective parsers in key: value format per entry
   ## Regex required fields are name and regex. JSON and Logfmt required field
-  ## is name.
+  ## is name, and can optionally take extraEntries analagous to json below.
   regex: []
   logfmt: []
   ##  json parser config can be defined by providing an extraEntries field.


### PR DESCRIPTION
Signed-off-by: Jason Tackaberry <tack@urandom.ca>

@kfox1111 @edsiper @hectorj2f this simple PR allows one to specify `extraEntries` for the regex parser, as it is currently allowed for `logfmt` and `json` parsers.

My particular use-case is to be able to specify [`Types`](https://docs.fluentbit.io/manual/v/1.3/parser) with some regex parsers, but of course this general purpose approach means the chart needn't play whack-a-mole with Fluent Bit as it potentially adds parameters in future.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

`extraEntries` is not documented in the README for the other parsers either, and it seems outside the purview of this PR to do that for all of them.  A comment in `values.yaml` was included however.