### PR TITLE
[stable/tensorflow-serving]: allow define annotations for deployment

### DIFF
--- a/stable/tensorflow-serving/Chart.yaml
+++ b/stable/tensorflow-serving/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
 version: 1.1.0
-appVersion: 1.14.0
+appVersion: 1.15.0
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:
 - https://github.com/tensorflow/serving

--- a/stable/tensorflow-serving/README.md
+++ b/stable/tensorflow-serving/README.md
@@ -147,6 +147,4 @@ chart and their default values.
 |`persistence.enabled` | enable pvc for the tensorflow serving | `false` |
 |`persistence.size`| the storage size to request | `5Gi` |
 |`persistence.matchLabels`| the selector for pv | `{}` |
-
-
-
+|`annotations`| Extra annotations for deployment | `{}` |

--- a/stable/tensorflow-serving/templates/deployment.yaml
+++ b/stable/tensorflow-serving/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "tensorflow-serving.chart" . }}
     app: {{ template "tensorflow-serving.name" . }}
+  annotations:
+{{- with .Values.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:

--- a/stable/tensorflow-serving/values.yaml
+++ b/stable/tensorflow-serving/values.yaml
@@ -40,3 +40,5 @@ persistence:
   size: 10Gi
   accessMode: ReadWriteOnce
  # matchLabels: {}
+
+annotations: {}


### PR DESCRIPTION
Common patter from other charts. Required for example to pass role in AWS deployment using kiam.

Signed-off-by: Jiri Pinkava <jiri.pinkava@rossum.ai>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
