### PR TITLE
Added cacert option to Cerebro

### DIFF
--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.9.1
+version: 1.9.2
 appVersion: 0.9.2
 apiVersion: v1
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -75,7 +75,10 @@ The following table lists the configurable parameters of the cerebro chart and t
 | `config.hosts`                      | A list of known hosts               | `[]`                                      |
 | `config.secret`                     | Secret used to sign session cookies | `(random alphanumeric 64 length string)`  |
 | `config.tlsVerify`                  | Validate Elasticsearch cert         | `true`                                    |
+| `config.tlsCaCert`                  | CA cert to use for cert validation  | `See values.yaml`                         |
 | `securityContext`                   | Security context for pod            | `See values.yaml`                         |
+| `volumes`                           | Volumes defintion                   | `See values.yaml`                         |
+| `volumemounts`                      | Volume mount defintion              | `See values.yaml`                         |
 
 
 

--- a/stable/cerebro/templates/configmap.yaml
+++ b/stable/cerebro/templates/configmap.yaml
@@ -20,6 +20,15 @@ data:
     {{- else }}
     play.ws.ssl.loose.acceptAnyCertificate = true
     {{- end }}
+    {{- if .Values.config.tlsCaCert }}
+    play.ws.ssl {
+      trustManager = {
+        stores = [
+          { type = "PEM", path = {{ .Values.config.tlsCaCert | quote }} }
+        ]
+      }
+    }
+    {{- end }}
 
     basePath = {{ .Values.config.basePath | quote }}
 

--- a/stable/cerebro/templates/deployment.yaml
+++ b/stable/cerebro/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
               mountPath: /opt/cerebro/logs/
             - name: tmp
               mountPath: /tmp
+          {{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+          {{- end }}
           {{- if .Values.env }}
           env:
           {{- range $index, $element := .Values.env }}
@@ -104,6 +107,9 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+    {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -71,3 +71,15 @@ config:
   # random 64 length string
   secret: ''
   tlsVerify: true
+  # tlsCaCert: /opt/cerebro/conf/certs/ca.crt
+
+# volumeMounts:
+#   - mountPath: /opt/cerebro/conf/certs/
+#     name: ca_cert_volume
+#     readOnly: true
+# volumes:
+#   - name: ca_cert_volume
+#     secret:
+#       defaultMode: 420
+#       optional: false
+#       secretName: cerebro_ca_cert_secret


### PR DESCRIPTION
Needed a way to communicate with Elasticsearch over TLS using a self-signed certificate, without just reverting to "tlsVerify: false" to make it work.

So I added a way to mount a folder containing the ca.crt, and the necessary changes to tell Cerebro to use the certificate for TLS validation.

Signed-off-by: Anders Nyvang <github@nanders.com>