### PR TITLE
[stable/cockroachdb] Built-in cert-manager support

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 3.0.7
+version: 3.1.0
 appVersion: 19.2.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -136,8 +136,6 @@ By enabling `tls.certs.tlsSecret` the tls secrets are projected on to the correc
 If you wish to supply certificates with [cert-manager][3], set
 
 * `tls.certs.certManager` to `yes`/`true`
-* `tls.certs.tlsSecret` to `yes`/`true`
-* `tls.certs.provided` to `yes`/`true`
 * `tls.certs.certManagerIssuer` to an IssuerRef (as they appear in certificate resources) pointing to a clusterIssuer or issuer, you have set up in the cluster
 
 Example issuer:

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -227,80 +227,82 @@ Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will
 The following table lists the configurable parameters of the CockroachDB chart and their default values.
 For details see the [`values.yaml`](values.yaml) file.
 
-| Parameter                                | Description                                                     | Default                                          |
-| ---------                                | -----------                                                     | -------                                          |
-| `clusterDomain`                          | Cluster's default DNS domain                                    | `cluster.local`                                  |
-| `conf.attrs`                             | CockroachDB node attributes                                     | `[]`                                             |
-| `conf.cache`                             | Size of CockroachDB's in-memory cache                           | `25%`                                            |
-| `conf.cluster-name`                      | Name of CockroachDB cluster                                     | `""`                                             |
-| `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification                   | `no`                                             |
-| `conf.join`                              | List of already-existing CockroachDB instances                  | `[]`                                             |
-| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `0`                                              |
-| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `500ms`                                          |
-| `conf.max-sql-memory`                    | Max memory to use processing SQL querie                         | `25%`                                            |
-| `conf.locality`                          | Locality attribute for this deployment                          | `""`                                             |
-| `conf.single-node`                       | Disable CockroachDB clustering (standalone mode)                | `no`                                             |
-| `conf.sql-audit-dir`                     | Directory for SQL audit log                                     | `""`                                             |
-| `conf.port`                              | CockroachDB primary serving port in Pods                        | `26257`                                          |
-| `conf.http-port`                         | CockroachDB HTTP port in Pods                                   | `8080`                                           |
-| `image.repository`                       | Container image name                                            | `cockroachdb/cockroach`                          |
-| `image.tag`                              | Container image tag                                             | `v19.2.5`                                        |
-| `image.pullPolicy`                       | Container pull policy                                           | `IfNotPresent`                                   |
-| `image.credentials`                      | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
-| `statefulset.replicas`                   | StatefulSet replicas number                                     | `3`                                              |
-| `statefulset.updateStrategy`             | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                      |
-| `statefulset.podManagementPolicy`        | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                       |
-| `statefulset.budget.maxUnavailable`      | k8s PodDisruptionBudget parameter                               | `1`                                              |
-| `statefulset.args`                       | Extra command-line arguments                                    | `[]`                                             |
-| `statefulset.env`                        | Extra env vars                                                  | `[]`                                             |
-| `statefulset.secretMounts`               | Additional Secrets to mount at cluster members                  | `[]`                                             |
-| `statefulset.labels`                     | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `statefulset.annotations`                | Additional annotations of StatefulSet Pods                      | `{}`                                             |
-| `statefulset.nodeAffinity`               | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
-| `statefulset.podAffinity`                | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
-| `statefulset.podAntiAffinity`            | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
-| `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
-| `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
-| `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
-| `statefulset.tolerations`                | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
-| `statefulset.resources`                  | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
-| `service.ports.grpc.external.port`       | CockroachDB primary serving port in Services                    | `26257`                                          |
-| `service.ports.grpc.external.name`       | CockroachDB primary serving port name in Services               | `grpc`                                           |
-| `service.ports.grpc.internal.port`       | CockroachDB inter-communication port in Services                | `26257`                                          |
-| `service.ports.grpc.internal.name`       | CockroachDB inter-communication port name in Services           | `grpc-internal`                                  |
-| `service.ports.http.port`                | CockroachDB HTTP port in Services                               | `8080`                                           |
-| `service.ports.http.name`                | CockroachDB HTTP port name in Services                          | `http`                                           |
-| `service.public.type`                    | Public Service type                                             | `ClusterIP`                                      |
-| `service.public.labels`                  | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.public.annotations`             | Additional annotations of public Service                        | `{}`                                             |
-| `service.discovery.labels`               | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.discovery.annotations`          | Additional annotations of discovery Service                     | `{}`                                             |
-| `storage.hostPath`                       | Absolute path on host to store data                             | `""`                                             |
-| `storage.persistentVolume.enabled`       | Whether to use PersistentVolume to store data                   | `yes`                                            |
-| `storage.persistentVolume.size`          | PersistentVolume size                                           | `100Gi`                                          |
-| `storage.persistentVolume.storageClass`  | PersistentVolume class                                          | `""`                                             |
-| `storage.persistentVolume.labels`        | Additional labels of PersistentVolumeClaim                      | `{}`                                             |
-| `storage.persistentVolume.annotations`   | Additional annotations of PersistentVolumeClaim                 | `{}`                                             |
-| `init.labels`                            | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`        |
-| `init.annotations`                       | Additional labels of the Pod of init Job                        | `{}`                                             |
-| `init.affinity`                          | [Affinity rules][2] of init Job Pod                             | `{}`                                             |
-| `init.nodeSelector`                      | Node labels for init Job Pod assignment                         | `{}`                                             |
-| `init.tolerations`                       | Node taints to tolerate by init Job Pod                         | `[]`                                             |
-| `init.resources`                         | Resource requests and limits for the Pod of init Job            | `{}`                                             |
-| `tls.enabled`                            | Whether to run securely using TLS certificates                  | `no`                                             |
-| `tls.serviceAccount.create`              | Whether to create a new RBAC service account                    | `yes`                                            |
-| `tls.serviceAccount.name`                | Name of RBAC service account to use                             | `""`                                             |
-| `tls.certs.provided`                     | Bring your own certs scenario, i.e certificates are provided    | `no`                                             |
-| `tls.certs.clientRootSecret`             | If certs are provided, secret name for client root cert         | `cockroachdb-root`                               |
-| `tls.certs.nodeSecret`                   | If certs are provided, secret name for node cert                | `cockroachdb-node`                               |
-| `tls.certs.tlsSecret`                    | Own certs are stored in TLS secret                              | `no`                                             |
-| `tls.init.image.repository`              | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
-| `tls.init.image.tag`                     | Image tag to use for requesting TLS certificates                | `0.4`                                            |
-| `tls.init.image.pullPolicy`              | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |
-| `tls.init.image.credentials`             | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
-| `networkPolicy.enabled`                  | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
-| `networkPolicy.ingress.grpc`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
-| `networkPolicy.ingress.http`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| Parameter                                | Description                                                     | Default                                                            |
+| ---------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `clusterDomain`                          | Cluster's default DNS domain                                    | `cluster.local`                                                    |
+| `conf.attrs`                             | CockroachDB node attributes                                     | `[]`                                                               |
+| `conf.cache`                             | Size of CockroachDB's in-memory cache                           | `25%`                                                              |
+| `conf.cluster-name`                      | Name of CockroachDB cluster                                     | `""`                                                               |
+| `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification                   | `no`                                                               |
+| `conf.join`                              | List of already-existing CockroachDB instances                  | `[]`                                                               |
+| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `0`                                                                |
+| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `500ms`                                                            |
+| `conf.max-sql-memory`                    | Max memory to use processing SQL querie                         | `25%`                                                              |
+| `conf.locality`                          | Locality attribute for this deployment                          | `""`                                                               |
+| `conf.single-node`                       | Disable CockroachDB clustering (standalone mode)                | `no`                                                               |
+| `conf.sql-audit-dir`                     | Directory for SQL audit log                                     | `""`                                                               |
+| `conf.port`                              | CockroachDB primary serving port in Pods                        | `26257`                                                            |
+| `conf.http-port`                         | CockroachDB HTTP port in Pods                                   | `8080`                                                             |
+| `image.repository`                       | Container image name                                            | `cockroachdb/cockroach`                                            |
+| `image.tag`                              | Container image tag                                             | `v19.2.5`                                                          |
+| `image.pullPolicy`                       | Container pull policy                                           | `IfNotPresent`                                                     |
+| `image.credentials`                      | `registry`, `user` and `pass` credentials to pull private image | `{}`                                                               |
+| `statefulset.replicas`                   | StatefulSet replicas number                                     | `3`                                                                |
+| `statefulset.updateStrategy`             | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                                        |
+| `statefulset.podManagementPolicy`        | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                                         |
+| `statefulset.budget.maxUnavailable`      | k8s PodDisruptionBudget parameter                               | `1`                                                                |
+| `statefulset.args`                       | Extra command-line arguments                                    | `[]`                                                               |
+| `statefulset.env`                        | Extra env vars                                                  | `[]`                                                               |
+| `statefulset.secretMounts`               | Additional Secrets to mount at cluster members                  | `[]`                                                               |
+| `statefulset.labels`                     | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}`                   |
+| `statefulset.annotations`                | Additional annotations of StatefulSet Pods                      | `{}`                                                               |
+| `statefulset.nodeAffinity`               | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                                               |
+| `statefulset.podAffinity`                | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                                               |
+| `statefulset.podAntiAffinity`            | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                                               |
+| `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                                             |
+| `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                                              |
+| `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                                               |
+| `statefulset.tolerations`                | Node taints to tolerate by StatefulSet Pods                     | `[]`                                                               |
+| `statefulset.resources`                  | Resource requests and limits for StatefulSet Pods               | `{}`                                                               |
+| `service.ports.grpc.external.port`       | CockroachDB primary serving port in Services                    | `26257`                                                            |
+| `service.ports.grpc.external.name`       | CockroachDB primary serving port name in Services               | `grpc`                                                             |
+| `service.ports.grpc.internal.port`       | CockroachDB inter-communication port in Services                | `26257`                                                            |
+| `service.ports.grpc.internal.name`       | CockroachDB inter-communication port name in Services           | `grpc-internal`                                                    |
+| `service.ports.http.port`                | CockroachDB HTTP port in Services                               | `8080`                                                             |
+| `service.ports.http.name`                | CockroachDB HTTP port name in Services                          | `http`                                                             |
+| `service.public.type`                    | Public Service type                                             | `ClusterIP`                                                        |
+| `service.public.labels`                  | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}`                   |
+| `service.public.annotations`             | Additional annotations of public Service                        | `{}`                                                               |
+| `service.discovery.labels`               | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}`                   |
+| `service.discovery.annotations`          | Additional annotations of discovery Service                     | `{}`                                                               |
+| `storage.hostPath`                       | Absolute path on host to store data                             | `""`                                                               |
+| `storage.persistentVolume.enabled`       | Whether to use PersistentVolume to store data                   | `yes`                                                              |
+| `storage.persistentVolume.size`          | PersistentVolume size                                           | `100Gi`                                                            |
+| `storage.persistentVolume.storageClass`  | PersistentVolume class                                          | `""`                                                               |
+| `storage.persistentVolume.labels`        | Additional labels of PersistentVolumeClaim                      | `{}`                                                               |
+| `storage.persistentVolume.annotations`   | Additional annotations of PersistentVolumeClaim                 | `{}`                                                               |
+| `init.labels`                            | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`                          |
+| `init.annotations`                       | Additional labels of the Pod of init Job                        | `{}`                                                               |
+| `init.affinity`                          | [Affinity rules][2] of init Job Pod                             | `{}`                                                               |
+| `init.nodeSelector`                      | Node labels for init Job Pod assignment                         | `{}`                                                               |
+| `init.tolerations`                       | Node taints to tolerate by init Job Pod                         | `[]`                                                               |
+| `init.resources`                         | Resource requests and limits for the Pod of init Job            | `{}`                                                               |
+| `tls.enabled`                            | Whether to run securely using TLS certificates                  | `no`                                                               |
+| `tls.serviceAccount.create`              | Whether to create a new RBAC service account                    | `yes`                                                              |
+| `tls.serviceAccount.name`                | Name of RBAC service account to use                             | `""`                                                               |
+| `tls.certs.provided`                     | Bring your own certs scenario, i.e certificates are provided    | `no`                                                               |
+| `tls.certs.clientRootSecret`             | If certs are provided, secret name for client root cert         | `cockroachdb-root`                                                 |
+| `tls.certs.nodeSecret`                   | If certs are provided, secret name for node cert                | `cockroachdb-node`                                                 |
+| `tls.certs.tlsSecret`                    | Own certs are stored in TLS secret                              | `no`                                                               |
+| `tls.certs.certManager`                  | Provision certificates with cert-manager                        | `no`                                                               |
+| `tls.certs.certManagerIssuer`            | IssuerRef to use when generating certificates                   | `{"group":"cert-manager.io","kind":"Issuer","name":"cockroachdb"}` |
+| `tls.init.image.repository`              | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`                           |
+| `tls.init.image.tag`                     | Image tag to use for requesting TLS certificates                | `0.4`                                                              |
+| `tls.init.image.pullPolicy`              | Requesting TLS certificates container pull policy               | `IfNotPresent`                                                     |
+| `tls.init.image.credentials`             | `registry`, `user` and `pass` credentials to pull private image | `{}`                                                               |
+| `networkPolicy.enabled`                  | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                                               |
+| `networkPolicy.ingress.grpc`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                                               |
+| `networkPolicy.ingress.http`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                                               |
 
 Override the default parameters using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/certificate.client.yaml
+++ b/stable/cockroachdb/templates/certificate.client.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.tls.enabled .Values.tls.certs.certManager }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ template "cockroachdb.fullname" . }}-root-client
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "cockroachdb.chart" . }}
+    app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  duration: 672h
+  renewBefore: 48h
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
+  keySize: 2048
+  keyAlgorithm: rsa
+  commonName: root
+  organization:
+    - Cockroach
+  secretName: {{ .Values.tls.certs.clientRootSecret }}
+  issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
+{{- end }}

--- a/stable/cockroachdb/templates/certificate.node.yaml
+++ b/stable/cockroachdb/templates/certificate.node.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.tls.enabled .Values.tls.certs.certManager }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ template "cockroachdb.fullname" . }}-node
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "cockroachdb.chart" . }}
+    app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  duration: 8760h
+  renewBefore: 168h
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  keySize: 2048
+  keyAlgorithm: rsa
+  commonName: node
+  organization:
+    - Cockroach
+  dnsNames:
+    - "localhost"
+    - "127.0.0.1"
+    - {{ printf "%s-public" (include "cockroachdb.fullname" .) | quote }}
+    - {{ printf "%s-public.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
+    - {{ printf "%s-public.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
+    - {{ printf "*.%s" (include "cockroachdb.fullname" .) | quote }}
+    - {{ printf "*.%s.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
+    - {{ printf "*.%s.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
+  secretName: {{ .Values.tls.certs.nodeSecret }}
+  issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
+{{- end }}

--- a/stable/cockroachdb/templates/clusterrole.yaml
+++ b/stable/cockroachdb/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) }}
+{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/stable/cockroachdb/templates/clusterrolebinding.yaml
+++ b/stable/cockroachdb/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) }}
+{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/stable/cockroachdb/templates/job.init.yaml
+++ b/stable/cockroachdb/templates/job.init.yaml
@@ -30,16 +30,16 @@ spec:
     spec:
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 0
-    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided)) }}
+    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
       {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) }}
+      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
         - name: {{ template "cockroachdb.fullname" . }}.init-certs.registry
       {{- end }}
     {{- end }}
-    {{- if and .Values.tls.enabled (not .Values.tls.certs.provided)}}
+    {{- if and .Values.tls.enabled (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
       serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
       initContainers:
         # The init-certs container sends a CSR (certificate signing request) to
@@ -126,8 +126,8 @@ spec:
     {{- if .Values.tls.enabled }}
       volumes:
         - name: client-certs
-          {{- if .Values.tls.certs.provided }}
-          {{- if .Values.tls.certs.tlsSecret }}
+          {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
+          {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager }}
           projected:
             sources:
             - secret:

--- a/stable/cockroachdb/templates/role.yaml
+++ b/stable/cockroachdb/templates/role.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    {{- if .Values.tls.certs.provided }}
+    {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
     verbs: ["get"]
     {{- else }}
     verbs: ["create", "get"]

--- a/stable/cockroachdb/templates/statefulset.yaml
+++ b/stable/cockroachdb/templates/statefulset.yaml
@@ -41,18 +41,18 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
-    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided)) }}
+    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
       {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) }}
+      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
         - name: {{ template "cockroachdb.fullname" . }}.init-certs.registry
       {{- end }}
     {{- end }}
     {{- if .Values.tls.enabled }}
       serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
-      {{- if not .Values.tls.certs.provided }}
+      {{- if and (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
       initContainers:
         # The init-certs container sends a CSR (certificate signing request) to
         # the Kubernetes cluster.
@@ -270,8 +270,8 @@ spec:
         {{- end }}
       {{- if .Values.tls.enabled }}
         - name: certs
-          {{- if .Values.tls.certs.provided }}
-          {{- if .Values.tls.certs.tlsSecret }}
+          {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
+          {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager }}
           projected:
             sources:
             - secret:

--- a/stable/cockroachdb/templates/tests/client.yaml
+++ b/stable/cockroachdb/templates/tests/client.yaml
@@ -15,10 +15,10 @@ spec:
   imagePullSecrets:
     - name: {{ template "cockroachdb.fullname" . }}.db.registry
 {{- end }}
-  {{- if .Values.tls.certs.provided }}
+  {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager}}
   volumes:
     - name: client-certs
-      {{- if .Values.tls.certs.tlsSecret }}
+      {{- if or .Values.tls.certs.certManager .Values.tls.certs.tlsSecret }}
       projected:
         sources:
         - secret:
@@ -43,7 +43,7 @@ spec:
     - name: client-test
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-      {{- if .Values.tls.certs.provided }}
+      {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
       volumeMounts:
       - name: client-certs
         mountPath: /cockroach-certs
@@ -51,7 +51,7 @@ spec:
       command:
         - /cockroach/cockroach
         - sql
-        {{- if .Values.tls.certs.provided }}
+        {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
         - --certs-dir
         - /cockroach-certs
         {{- else }}

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -328,6 +328,15 @@ tls:
     # Enable if the secret is a dedicated TLS.
     # TLS secrets are created by cert-mananger, for example.
     tlsSecret: no
+    # Use cert-manager to issue certificates for mTLS.
+    certManager: no
+    # Specify an Issuer or a ClusterIssuer to use, when issuing
+    # node and client certificates. The values correspond to the
+    # issuerRef specified in the certificate.
+    certManagerIssuer:
+      group: cert-manager.io
+      kind: Issuer
+      name: cockroachdb
 
   init:
     # Image to use for requesting TLS certificates.


### PR DESCRIPTION
#### What this PR does / why we need it:

- Add cert-manager certificate resources to the helm chart, to avoid users having to manually match subject alternative names in certificate resources
- Update documentation on setting up secure clusters

#### Special notes for your reviewer:

- The implementation of this is made with maximum backwards compatibility in mind. I've tested that the new templates render to the same result as the old ones, when using the same values. The right thing to do here, seems to be to rework the template a bit, but it'll break backwards compatibility, and require a major version bump.
- The implementation only covers the certificates, but it could be easily expanded to include the certificate authority and the issuer, with inspiration from #22838 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
