### PR TITLE
stable/prometheus-cloudwatch-exporter Add shasum of secrets yaml render to annotations

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -9,7 +9,7 @@ NOTE: The change log until version 0.4.10 is auto generated based on git commits
 
 ## 0.8.1
 
-Add secrets checksum annotation to deployment (#22448)
+Add secrets checksum annotation to deployment (#22449)
 
 ## 0.8.0
 

--- a/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -7,6 +7,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 0.4.10 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 0.8.1
+
+Add secrets checksum annotation to deployment (#22448)
+
+## 0.8.0
+
+Create ServiceAccount for deployment
+
 ## 0.7.0
 
 PrometheusRule support added to chart.

--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.8.0
+version: 0.8.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         {{ if .Values.aws.role}}iam.amazonaws.com/role: {{ .Values.aws.role }}{{ end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
Also added missing changelog entry for previous release of this chart.

#### Is this a new chart

NO

#### What this PR does / why we need it:

Adds a "checksum/secrets" annotation to the deployment.

We do daily scheduled deployments to refresh short lived AWS keys.  The helm chart stores AWS keys as kube secrets.  When nothing else changes but the AWS keys (which is most of the time), the deployment is not perceived as changed, no new replicaset gets created, and no pod restart occurs.  With this PR, each day's new AWS keys will result in a different checksum for the secrets.yaml, resulting in a changed annotation, resulting in pods restarting due to a new replicaset.

#### Which issue this PR fixes
  - fixes #22449 

#### Special notes for your reviewer:
None.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] - N/A - Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
