### PR TITLE
[stable/metallb] Move common labels into helper template

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.12.0
+version: 0.12.1
 name: metallb
 appVersion: 0.8.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters

--- a/stable/metallb/templates/_helpers.tpl
+++ b/stable/metallb/templates/_helpers.tpl
@@ -63,3 +63,20 @@ Create the name of the settings ConfigMap to use.
     {{ .Values.existingConfigMap }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common labels for the metallb chart
+*/}}
+{{- define "metallb.labels" -}}
+heritage: {{ .Release.Service | quote }}
+chart: {{ template "metallb.chart" . }}
+{{ template "metallb.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+Common selector labels for the metallb chart
+*/}}
+{{- define "metallb.selectorLabels" -}}
+release: {{ .Release.Name | quote }}
+app: {{ template "metallb.name" . }}
+{{- end -}}

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "metallb.fullname" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 data:
   config: |
 {{ toYaml .Values.configInline | indent 4 }}

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -3,25 +3,18 @@ kind: Deployment
 metadata:
   name: {{ template "metallb.fullname" . }}-controller
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
     component: controller
 spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: {{ template "metallb.name" . }}
+      {{- include "metallb.selectorLabels" . | nindent 6 }}
       component: controller
-      release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        heritage: {{ .Release.Service | quote }}
-        release: {{ .Release.Name | quote }}
-        chart: {{ template "metallb.chart" . }}
-        app: {{ template "metallb.name" . }}
+        {{- include "metallb.labels" . | nindent 8 }}
         component: controller
 {{- if .Values.prometheus.scrapeAnnotations }}
       annotations:

--- a/stable/metallb/templates/prometheusrules.yaml
+++ b/stable/metallb/templates/prometheusrules.yaml
@@ -4,10 +4,7 @@ kind: PrometheusRule
 metadata:
   name: {{ template "metallb.fullname" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ template "metallb.fullname" . }}.rules

--- a/stable/metallb/templates/psp.yaml
+++ b/stable/metallb/templates/psp.yaml
@@ -5,10 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 spec:
   hostNetwork: true
   hostPorts:

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -6,10 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "metallb.fullname" . }}:controller
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["services"]
@@ -26,10 +23,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "metallb.fullname" . }}:speaker
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
@@ -49,10 +43,7 @@ kind: Role
 metadata:
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -65,10 +56,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}:controller
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "metallb.controllerServiceAccountName" . }}
@@ -83,10 +71,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}:speaker
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "metallb.speakerServiceAccountName" . }}
@@ -101,10 +86,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "metallb.controllerServiceAccountName" . }}

--- a/stable/metallb/templates/service-accounts.yaml
+++ b/stable/metallb/templates/service-accounts.yaml
@@ -4,10 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "metallb.controllerServiceAccountName" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 {{- end }}
 ---
 {{- if .Values.serviceAccounts.speaker.create }}
@@ -16,8 +13,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "metallb.speakerServiceAccountName" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
 {{- end }}

--- a/stable/metallb/templates/service.yaml
+++ b/stable/metallb/templates/service.yaml
@@ -4,17 +4,13 @@ kind: Service
 metadata:
   name: {{ template "metallb.fullname" . }}-controller-metrics
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
     jobLabel: {{ .Values.prometheus.serviceMonitor.jobLabel }}
     component: controller
 spec:
   type: ClusterIP
   selector:
-    app: {{ template "metallb.name" . }}
-    release: {{ .Release.Name | quote }}
+    {{- include "metallb.selectorLabels" . | nindent 4 }}
     component: controller
   ports:
   - name: metrics
@@ -27,17 +23,13 @@ kind: Service
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker-metrics
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
     jobLabel: {{ .Values.prometheus.serviceMonitor.jobLabel }}
     component: speaker
 spec:
   type: ClusterIP
   selector:
-    app: {{ template "metallb.name" . }}
-    release: {{ .Release.Name | quote }}
+    {{- include "metallb.selectorLabels" . | nindent 4 }}
     component: speaker
   ports:
   - name: metrics

--- a/stable/metallb/templates/servicemonitor.yaml
+++ b/stable/metallb/templates/servicemonitor.yaml
@@ -4,17 +4,13 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "metallb.fullname" . }}-controller
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
     component: controller
 spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
-      app: {{ template "metallb.name" . }}
-      release: {{ .Release.Name | quote }}
+      {{- include "metallb.selectorLabels" . | nindent 6 }}
       component: controller
   namespaceSelector:
     matchNames:
@@ -38,17 +34,13 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
     component: speaker
 spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
-      app: {{ template "metallb.name" . }}
-      release: {{ .Release.Name | quote }}
+      {{- include "metallb.selectorLabels" . | nindent 6 }}
       component: speaker
   namespaceSelector:
     matchNames:

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -3,24 +3,17 @@ kind: DaemonSet
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
+    {{- include "metallb.labels" . | nindent 4 }}
     component: speaker
 spec:
   selector:
     matchLabels:
-      app: {{ template "metallb.name" . }}
+      {{- include "metallb.selectorLabels" . | nindent 6 }}
       component: speaker
-      release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        heritage: {{ .Release.Service | quote }}
-        release: {{ .Release.Name | quote }}
-        chart: {{ template "metallb.chart" . }}
-        app: {{ template "metallb.name" . }}
+        {{- include "metallb.labels" . | nindent 8 }}
         component: speaker
 {{- if .Values.prometheus.scrapeAnnotations }}
       annotations:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR moves the common labels out of the resources into a helper template. This allows users to override these labels in parent charts. By default, this PR does not change anything for the Helm chart, the output will be the same as before (except for label ordering).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
