### PR TITLE
fix(stable/prometheus-operator): invalid cert for kubelet metrics scrape

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.15.7
+version: 8.15.8
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -74,6 +74,10 @@ spec:
   - port: https-metrics
     scheme: https
     path: {{ .Values.kubelet.serviceMonitor.resourcePath }}
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 {{- if .Values.kubelet.serviceMonitor.resourceMetricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceMetricRelabelings | indent 4) . }}


### PR DESCRIPTION
This new endpoint was added on the https-metrics port without the same tlsConfig
and bearerTokenFile used for other Kubelet endpoints.

Introduced in PR #22586 (commit 2f556a6c4f)
Fixes issue #22890

Signed-off-by: Thomas Lovett <tklovett@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
This fixes a recently introduced bug. A new ServiceMonitor endpoint spec for kublet's `/metrics/resource/v1alpha1` endpoint was added. The port was configured as `https-metrics` and the config is gated by `.Values.kubelet.serviceMonitor.https`, but no `tlsConfig` or `bearerTokenFile` file was configured. This results in Prometheus registering the endpoint as a target, but failing to scrape it:
```
Get "https://10.0.149.72:10250/metrics/resource/v1alpha1": x509: certificate signed by unknown authority
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #22890 
identified by @den-is in https://github.com/helm/charts/pull/22586#issuecomment-647161493

#### Special notes for your reviewer:

The path will change in 1.18,
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
