### PR TITLE
[incubator/rundeck] fixes broken deployment strategy and annotations

### DIFF
--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.2.7
 keywords:
 - rundeck

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -16,7 +16,7 @@ Parameter | Description | Default
 --------- | ----------- | -------
 deployment.replicaCount | How many replicas to run. Rundeck can really only work with one. | 1
 deployment.annotations | You can pass annotations inside deployment.spec.template.metadata.annotations. Useful for KIAM/Kube2IAM and others for example. | {}
-deployment.rolloutStrategy | Sets the K8s rollout strategy for the Rundeck deployment | { type: RollingUpdate }
+deployment.strategy | Sets the K8s rollout strategy for the Rundeck deployment | { type: RollingUpdate }
 image.repository | Name of the image to run, without the tag. | [rundeck/rundeck](https://github.com/rundeck/rundeck)
 image.tag | The image tag to use. | 3.2.7
 image.pullPolicy | The kubernetes image pull policy. | IfNotPresent

--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -3,13 +3,14 @@ kind: Deployment
 metadata:
   name: {{ include "rundeck.fullname" . }}
   labels: {{ include "rundeck.labels" . | indent 4 }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
   strategy:
-    {{- with .Values.deployment.annotations }}
-    annotations:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+    {{- toYaml .Values.deployment.strategy | nindent 4 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "rundeck.name" . }}

--- a/incubator/rundeck/values.yaml
+++ b/incubator/rundeck/values.yaml
@@ -10,7 +10,7 @@ image:
 deployment:
   replicaCount: 1
   annotations: {}
-  rolloutStrategy:
+  strategy:
     type: RollingUpdate
     # Recreate can help when using persistent volumes
     # type: Recreate


### PR DESCRIPTION
Signed-off-by: Jonathan Cole <jonathan@mothership.com>

- Fixes broken deployment strategy
- Renames `deployment.rolloutStrategy` in values to `deployment.strategy`
- Uses provided annotations for both deployment and pod template

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
