### PR TITLE
[stable/datadog] Handle arguments in the cluster-agent command

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.18
+
+* Support arguments in the cluster-agent container `command` value
+
 ## 2.3.17
 
 * grammar edits to datadog helm docs!

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.17
+version: 2.3.18
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -80,8 +80,10 @@ spec:
       containers:
       - name: cluster-agent
         image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"
-        {{- if .Values.clusterAgent.command }}
-        command: {{ .Values.clusterAgent.command }}
+        {{- with .Values.clusterAgent.command }}
+        command: {{ range . }}
+          - {{ . | quote }}
+        {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:


### PR DESCRIPTION
#### Which issue this PR fixes

Without quotes around the command and its arguments, Kubernetes joins all string in a single binary name, so it's not possible to run `datadog-cluster-agent start` in the container. 

This PR fixes the described behaviour following the same pattern, that I found in another helm chart: https://github.com/helm/charts/blob/d1efe909ac55e6cc68fbc6f7b6263be2d20cdff5/incubator/zookeeper/templates/statefulset.yaml#L55-L59

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
