### PR TITLE
stable/prometheus-cloudwatch-exporter: Add containerPort, livenessProbe.path and readinessProbe.path variables

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.8.2
+version: 0.8.3
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `image.tag`                       | Image tag                                                               | `cloudwatch_exporter-0.8.0` |
 | `image.pullPolicy`                | Image pull policy                                                       | `IfNotPresent`              |
 | `command`                         | Container entrypoint command                                            | `[]`                        |
+| `containerPort`                   | Application listening port                                              | `9106`                      |
 | `service.type`                    | Service type                                                            | `ClusterIP`                 |
 | `service.port`                    | The service port                                                        | `80`                        |
 | `service.portName`                | The name of the service port                                            | `http`                      |

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -66,22 +66,22 @@ spec:
           {{- end }}
           ports:
             - name: container-port
-              containerPort: 9106
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /-/healthy
+              path: {{ .Values.livenessProbe.path }}
               port: container-port
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /-/ready
+              path: {{ .Values.readinessProbe.path }}
               port: container-port
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -23,6 +23,8 @@ image:
 
 command: []
 
+containerPort: 9106
+
 service:
   type: ClusterIP
   port: 9106
@@ -113,6 +115,7 @@ affinity: {}
 
 # Configurable health checks against the /healthy and /ready endpoints
 livenessProbe:
+  path: /-/healthy
   initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 5
@@ -120,6 +123,7 @@ livenessProbe:
   failureThreshold: 3
 
 readinessProbe:
+  path: /-/ready
   initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 5


### PR DESCRIPTION
#### What this PR does / why we need it:
The goal is to make the chart more generic to deploy others cloudwatch exporter like [yace](https://github.com/ivx/yet-another-cloudwatch-exporter).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
