### PR TITLE
[incubator/sentry-kubernetes] Make EVENT_LEVELS env configurable

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.2.3
+version: 0.2.4
 appVersion: latest
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 home: https://github.com/getsentry/sentry-kubernetes

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -19,6 +19,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
 | `sentry.release`        | Sentry release                                                                                                              | Empty                         |
 | `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |
+| `sentry.eventLevels`    | Sentry event levels                                                                                                         | Empty                         |
 | `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
 | `image.tag`             | Container image tag                                                                                                         | `latest`                      |
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           - name: LOG_LEVEL
             value: {{ .Values.sentry.logLevel }}
           {{ end }}
+          {{ if .Values.sentry.eventLevels }}
+          - name: EVENT_LEVELS
+            value: {{ .Values.sentry.eventLevels }}
+          {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}

--- a/incubator/sentry-kubernetes/values.yaml
+++ b/incubator/sentry-kubernetes/values.yaml
@@ -3,6 +3,7 @@
 sentry:
   dsn: <change-me>
   logLevel: ~
+  eventLevels: ~
 # Sentry DSN config using an existing secret:
 # existingSecret:
 image:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:

Make the `EVENT_LEVELS` environment configurable through the `sentry.eventLevels` value.

#### Special notes for your reviewer:

The [underlying code](https://github.com/getsentry/sentry-kubernetes/blob/master/sentry-kubernetes.py#L42) already uses `EVENT_LEVELS`.
This env var can be easily set if sentry-kubernetes is deployed using kube configs, but not if deployed using this helm chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
