### PR TITLE
[incubator/zookeeper] Update the location of the github repo

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -9,7 +9,7 @@ description: Centralized service for maintaining configuration information, nami
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif
 sources:
 - https://github.com/apache/zookeeper
-- https://github.com/kubernetes/contrib/tree/master/statefulsets/zookeeper
+- https://github.com/helm/charts/tree/master/incubator/zookeeper
 maintainers:
 - name: lachie83
   email: lachlan.evenson@microsoft.com


### PR DESCRIPTION
#### What this PR does / why we need it:

The kubernetes location is archived and no longer the correct
repo. Point the chart metadata at this repo.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)