### PR TITLE
incubator/kube-downscaler: Manage Resources

### DIFF
--- a/incubator/kube-downscaler/Chart.yaml
+++ b/incubator/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: 0.4.0
+version: 0.4.1
 appVersion: 19.10.1
 description: A Helm chart for kube-downscaler
 home: https://github.com/hjacobs/kube-downscaler

--- a/incubator/kube-downscaler/README.md
+++ b/incubator/kube-downscaler/README.md
@@ -42,26 +42,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the kube-downscaler chart and their default values.
 
-| Parameter                 | Description                                                                                          | Default                   |
-| ------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------- |
-| `replicaCount`            | Number of replicas to run                                                                            | `1`                       |
-| `name`                    | How to name resources created by this chart                                                          | `kube-downscaler`         |
-| `debug.enable`            | Do you want to start the downscaler in debug mode                                                    | `false`                   |
-| `namespace.active_in`     | Which namespace does the downscaler scans for deployment/statefulsets to downscale (`''` equals all) | `''`                      |
-| `interval`                | Interval between scans, in seconds                                                                   | `60`                      |
-| `image.repository`        | Downscaler container image repository                                                                | `hjacobs/kube-downscaler` |
-| `image.tag`               | Downscaler container image tag                                                                       | `19.10.1`                 |
-| `image.pullPolicy`        | Downscaler container image pull policy                                                               | `IfNotPresent`            |
-| `nodeSelector`            | Node labels for downscaler pod assignment                                                            | `{}`                      |
-| `tolerations`             | Downscaler pod toleration for taints                                                                 | `[]`                      |
-| `affinity`                | Downscaler pod affinity                                                                              | `{}`                      |
-| `podAnnotations`          | Annotations to be added to downscaler pod                                                            | `{}`                      |
-| `podLabels`               | Labels to be added to downscaler pod                                                                 | `{}`                      |
-| `resources`               | Downscaler pod resource requests & limits                                                            | `{}`                      |
-| `securityContext`         | SecurityContext to apply to the downscaler pod                                                       | `{}`                      |
-| `rbac.create`             | If true, create & use RBAC resources                                                                 | `true`                    |
-| `rbac.serviceAccountName` | ServiceAccount downscaler will use (ignored if rbac.create=true)                                     | `default`                 |
-| `extraArgs`               | Add extra args to docker command                                                                     | `[]`                      |
+| Parameter               | Description                                                                                          | Default                                 |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `replicaCount`            | Number of replicas to run                                                                            | `1`                                       |
+| `name`                    | How to name resources created by this chart                                                          | `kube-downscaler`                         |
+| `debug.enable`            | Do you want to start the downscaler in debug mode                                                    | `false`                                   |
+| `namespace.active_in`     | Which namespace does the downscaler scans for deployment/statefulsets to downscale (`''` equals all)   | `''`                                      |
+| `interval`                | Interval between scans, in seconds                                                                   | `60`                                      |
+| `image.repository`        | Downscaler container image repository                                                                | `hjacobs/kube-downscaler`                 |
+| `image.tag`               | Downscaler container image tag                                                                       | `19.10.1`                                 |
+| `image.pullPolicy`        | Downscaler container image pull policy                                                               | `IfNotPresent`                            |
+| `nodeSelector`            | Node labels for downscaler pod assignment                                                            | `{}`                                      |
+| `tolerations`             | Downscaler pod toleration for taints                                                                 | `[]`                                      |
+| `affinity`                | Downscaler pod affinity                                                                              | `{}`                                      |
+| `podAnnotations`          | Annotations to be added to downscaler pod                                                            | `{}`                                      |
+| `podLabels`               | Labels to be added to downscaler pod                                                                 | `{}`                                      |
+| `resources`               | Downscaler pod resource requests & limits                                                            | `{}`                                      |
+| `securityContext`         | SecurityContext to apply to the downscaler pod                                                       | `{}`                                      |
+| `rbac.create`             | If true, create & use RBAC resources                                                                 | `true`                                    |
+| `rbac.serviceAccountName` | ServiceAccount downscaler will use (ignored if rbac.create=true)                                     | `default`                                 |
+| `downscaleResources`      | Resources the downscaler is allowed to manage                                                        | `[deployments, statefulsets, namespaces]` |
+| `excludedDeployments`     | Deployments to exclude from the downscaler                                                           | `[]`                                      |
+| `excludedNamespaces`      | Namespaces to exclude from the downscaler                                                            | `[]`                                      |
+| `extraArgs`               | Add extra args to docker command                                                                     | `[]`                                      |
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 

--- a/incubator/kube-downscaler/templates/clusterrole.yaml
+++ b/incubator/kube-downscaler/templates/clusterrole.yaml
@@ -20,9 +20,9 @@ rules:
   - apiGroups:
       - "*"
     resources:
-      - deployments
-      - statefulsets
-      - namespaces
+      {{- range .Values.downscaleResources }}
+      - {{ . }}
+      {{- end }}
     verbs:
       - get
       - watch

--- a/incubator/kube-downscaler/templates/deployment.yaml
+++ b/incubator/kube-downscaler/templates/deployment.yaml
@@ -37,9 +37,16 @@ spec:
           - --namespace="{{ .Values.namespace.active_in }}"
           {{- end }}
           {{- end }}
-          {{ if .Values.debug.enable }}
+          {{- if .Values.debug.enable }}
           - --debug
-          {{end }}
+          {{- end }}
+          - --include-resources="{{- join "," .Values.downscaleResources }}"
+          {{- if .Values.excludedNamespaces }}
+          - --exclude-namespaces="{{- join "," .Values.excludedNamespaces }}"
+          {{- end }}
+          {{- if .Values.excludedDeployments }}
+          - --exclude-deployments="{{- join "," .Values.excludedDeployments }}"
+          {{- end }}
 {{- with .Values.extraArgs }}
 {{ toYaml . | indent 10 }}
 {{- end }}

--- a/incubator/kube-downscaler/values.yaml
+++ b/incubator/kube-downscaler/values.yaml
@@ -12,6 +12,18 @@ namespace:
   # Deployment will query all namespaces if left empty:
   active_in: ''
 
+# The resources kinds kube-downscaler is allowed to manage
+downscaleResources:
+  - deployments
+  - statefulsets
+  - namespaces
+
+# List of namespaces to be excluded from the downscaler
+excludedNamespaces: []
+
+# List of deployments to be excluded from the downscaler
+excludedDeployments: []
+
 # Default is 1 minute.
 interval: 60
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This commit makes a few minor modifications to the way the Helm chart
allows users to manage downscaler resources. The core functionality has
not changed since `extraArgs` already existed. These changes improve
upon how a user interacts with specific commandline arguments to better
manage the resources.

#### Special notes for your reviewer:

First `clusterrole.yaml` was updated to take a list of resources from the
values file. This will allow the resource configuration in the for the
role to match the commandline argument for `include-resources`.

Second `include-resources` was added as a commandline argument so that
users can have full control over which resources the downscaler does and
does not have access to. This could be achieved previously by the use of
`extraArgs` but it is now a cleaner interaction for the user since they
don't need to worry about list formatting.

_Both the `clusterrole.yaml` and `deployment.yaml` get the resources to
manage from `downscaleResources` in `values.yaml`._

Third `exclude-namespaces` and `exclude-deployments` were added as
commandline arguments to help improve users ability to exclude specific
namespaces and deployments from the downscaler. This was able to be done
previously with the use of `extraArgs` but much like the other changes
this makes the user interaction more clean and manageable. Both of these
arguments derive their values from `excludedNamespaces` and
`excludedDeployments` in `values.yaml` respectively.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
