### PR TITLE
[stable/graylog] Adding the ability to specify externalTrafficPolicy for LoadBalancer services

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.6.8
+version: 1.6.9
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/README.md
+++ b/stable/graylog/README.md
@@ -200,11 +200,14 @@ This chart will automatically calculate Java heap size from given `resources.req
 
 You can enable input ports by edit the `input` values. For example, you want to create a GELF input on port `12222`, and `12223` with Cloud LoadBalancer and syslog on UDP port `5410` without load balancer.
 
+In services of `type: LoadBalancer`, the default externalTrafficPolicy is `Cluster`, but may be overridden in order to [preserve the client IP][5] with `Local`.
+
 ```yaml
   input:
     tcp:
       service:
         type: LoadBalancer
+        externalTrafficPolicy: Local
         loadBalancerIP:
       ports:
         - name: gelf1
@@ -319,3 +322,4 @@ Note: All uncommitted logs will be permanently DELETED when this value is true
 [2]: https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions
 [3]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
 [4]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+[5]: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

--- a/stable/graylog/templates/tcp-service.yaml
+++ b/stable/graylog/templates/tcp-service.yaml
@@ -37,6 +37,7 @@ spec:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   type: "{{ .Values.graylog.input.tcp.service.type }}"
 {{- if eq "LoadBalancer" .Values.graylog.input.tcp.service.type }}
+  externalTrafficPolicy: {{ .Values.graylog.input.tcp.service.externalTrafficPolicy | default "Cluster" }}
   {{- if .Values.graylog.input.tcp.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.graylog.input.tcp.service.loadBalancerIP }}
   {{- end -}}

--- a/stable/graylog/templates/udp-service.yaml
+++ b/stable/graylog/templates/udp-service.yaml
@@ -37,6 +37,7 @@ spec:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
   type: "{{ .Values.graylog.input.udp.service.type }}"
 {{- if eq "LoadBalancer" .Values.graylog.input.udp.service.type }}
+  externalTrafficPolicy: {{ .Values.graylog.input.udp.service.externalTrafficPolicy | default "Cluster" }}
   {{- if .Values.graylog.input.udp.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.graylog.input.udp.service.loadBalancerIP }}
   {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Graylog uses Layer 4 loadbalancers for TCP/UDP traffic ingress, however there was no way to specify the externalTrafficPolicy in order to [preserve the Client IP address](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). My changes allow overrides to `Local`, but default to `Cluster`

#### Special notes for your reviewer:
@KongZ  - Obligatory mention :) Hi!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
