### PR TITLE
[stable/mysql] Add support for extra environment variables (#22945)

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 1.6.4
+version: 1.6.5
 appVersion: 5.7.30
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |
 | `extraVolumeMounts`                          | Additional volumeMounts as a string to be passed to the `tpl` function                       |                                                      |
 | `extraInitContainers`                        | Additional init containers as a string to be passed to the `tpl` function                    |                                                      |
+| `extraEnvVars`                               | Additional environment variables as a string to be passed to the `tpl` function              |                                                      |
 | `mysqlRootPassword`                          | Password for the `root` user. Ignored if existing secret is provided                         | Random 10 characters                                 |
 | `mysqlUser`                                  | Username of new user to create.                                                              | `nil`                                                |
 | `mysqlPassword`                              | Password for the new user. Ignored if existing secret is provided                            | Random 10 characters                                 |

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -123,6 +123,9 @@ spec:
         - name: TZ
           value: {{ .Values.timezone }}
         {{- end }}
+        {{- if .Values.extraEnvVars }}
+{{ tpl .Values.extraEnvVars . | indent 8 }}
+        {{- end }}
         ports:
         - name: mysql
           containerPort: 3306

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -60,6 +60,11 @@ extraInitContainers: |
   #   image: busybox
   #   command: ['do', 'something']
 
+## A string to add extra environment variables
+# extraEnvVars: |
+#   - name: EXTRA_VAR
+#     value: "extra"
+
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.
 # ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
Signed-off-by: Casey Buto <cbuto22@gmail.com>

#### What this PR does / why we need it:
This PR adds the ability to supply extra environment variables (`extraEnvVars`) to support a variety of use cases and allow for more flexibility when using this chart. 

#### Which issue this PR fixes
* fixes #22945

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)