### PR TITLE
[stable/prometheus-operator] remove namespace field from non-namespaced resources

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.15.12
+version: 8.15.13
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/psp.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
-  namespace: {{ template "prometheus-operator.namespace" . }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{- if .Values.global.rbac.pspAnnotations }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
-  namespace: {{ template "prometheus-operator.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-admission
-  namespace: {{ template "prometheus-operator.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/psp.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
-  namespace: {{ template "prometheus-operator.namespace" . }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{- if .Values.global.rbac.pspAnnotations }}

--- a/stable/prometheus-operator/templates/prometheus/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus/psp.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
-  namespace: {{ template "prometheus-operator.namespace" . }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{- if .Values.global.rbac.pspAnnotations }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR provides a fix for Issue #22946. It removes the `namespace:` fields for those templates related to non-namespaced resources such as `PodSecurityPolicy` and `ClusterRoleBinding`.

#### Which issue this PR fixes

  - fixes #22946

#### Special notes for your reviewer:
none

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
