### PR TITLE
[stable/prometheus-mongodb-exporter] Add serviceMonitor targetLabels and service labels

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.5.0
+version: 2.6.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -63,4 +63,5 @@ podAnnotations:
 | `serviceMonitor.scrapeTimeout` | Interval at which metric scrapes should time out | `10s` |
 | `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | `` |
 | `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}` |
+| `serviceMonitor.targetLabels` | Set of labels to transfer on the Kubernetes Service onto the target. | `[]`
 | `tolerations` | List of node taints to tolerate  | `[]` |

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -53,6 +53,7 @@ podAnnotations:
 | `resources` | Pod resource requests and limits | `{}` |
 | `env` | Extra environment variables passed to pod | `{}` |
 | `securityContext` | Security context for the pod | See values.yaml |
+| `service.labels` | Additional labels for the service definition | `{}` |
 | `service.annotations` | Annotations to be added to the service | `{}` |
 | `service.port` | The port to expose | `9216` |
 | `service.type` | The type of service to expose | `ClusterIP` |

--- a/stable/prometheus-mongodb-exporter/templates/service.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:

--- a/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
@@ -26,5 +26,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}
 

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -74,6 +74,7 @@ securityContext:
   runAsUser: 10000
 
 service:
+  labels: {}
   annotations: {}
   port: 9216
   type: ClusterIP

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -90,5 +90,6 @@ serviceMonitor:
   scrapeTimeout: 10s
   namespace:
   additionalLabels: {}
+  targetLabels: []
 
 tolerations: []


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

This PR adds the serviceMonitor `targetLabels` key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec)

This takes implementation is the same as [stable/prometheus-redis-exporter ](https://github.com/helm/charts/tree/master/stable/prometheus-redis-exporter) and [bitnami/nats](https://github.com/bitnami/charts/pull/2691) which I have both worked on.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
