### PR TITLE
[incubator/etcd] support k8s 1.18.x

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.7.4
+version: 0.7.5
 appVersion: 3.2.26
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
 {{- $etcdAuthOptions := include "etcd.authOptions" . }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "etcd.fullname" . }}
@@ -94,14 +94,14 @@ spec:
                 - |
                   EPS=""
                   for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                      EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
+                      EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.$(hostname -d):2379"
                   done
 
                   HOSTNAME=$(hostname)
                   AUTH_OPTIONS="{{ $etcdAuthOptions }}"                  
 
                   member_hash() {
-                      etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
+                      etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | cut -d ',' -f1
                   }
 
                   SET_ID=${HOSTNAME##*[^0-9]}
@@ -123,28 +123,28 @@ spec:
             # store member id into PVC for later member replacement
             collect_member() {                
                 while ! etcdctl $AUTH_OPTIONS member list > /dev/null 2>&1; do sleep 1; done
-                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1 > /var/run/etcd/member_id
+                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | cut -d ',' -f1 > /var/run/etcd/member_id
                 exit 0
             }
 
             eps() {
                 EPS=""
                 for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                    EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
+                    EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.$(hostname -d):2379"
                 done
                 echo ${EPS}
             }
 
             member_hash() {
-                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
+                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | cut -d ',' -f1
             }
 
             # we should wait for other pods to be up before trying to join
             # otherwise we got "no such host" errors when trying to resolve other members
             for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
                 while true; do
-                    echo "Waiting for ${SET_NAME}-${i}.${SET_NAME} to come up"
-                    ping -W 1 -c 1 ${SET_NAME}-${i}.${SET_NAME} > /dev/null && break
+                    echo "Waiting for ${SET_NAME}-${i}.$(hostname -d) to come up"
+                    ping -W 1 -c 1 ${SET_NAME}-${i}.$(hostname -d) > /dev/null && break
                     sleep 1s
                 done                
             done
@@ -155,11 +155,11 @@ spec:
                 member_id=$(cat /var/run/etcd/member_id)
 
                 # re-join member
-                ETCDCTL_ENDPOINT=$(eps) etcdctl $AUTH_OPTIONS member update ${member_id} {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | true
+                ETCDCTL_ENDPOINT=$(eps) etcdctl $AUTH_OPTIONS member update ${member_id} {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | true
                 exec etcd --name ${HOSTNAME} \
                     --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
                     --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379\
-                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.$(hostname -d):2379 \
                     --data-dir /var/run/etcd/default.etcd
                     
             fi
@@ -181,7 +181,7 @@ spec:
                 fi
 
                 echo "Adding new member"
-                etcdctl $AUTH_OPTIONS member add ${HOSTNAME} {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | grep "^ETCD_" > /var/run/etcd/new_member_envs
+                etcdctl $AUTH_OPTIONS member add ${HOSTNAME} {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | grep "^ETCD_" > /var/run/etcd/new_member_envs
 
                 if [ $? -ne 0 ]; then
                     echo "Exiting"
@@ -197,9 +197,9 @@ spec:
                 exec etcd --name ${HOSTNAME} \
                     --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
                     --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
-                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.$(hostname -d):2379 \
                     --data-dir /var/run/etcd/default.etcd \
-                    --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
+                    --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 \
                     --initial-cluster ${ETCD_INITIAL_CLUSTER} \
                     --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE}
                     
@@ -207,17 +207,17 @@ spec:
 
             PEERS=""
             for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                PEERS="${PEERS}${PEERS:+,}${SET_NAME}-${i}={{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2380"
+                PEERS="${PEERS}${PEERS:+,}${SET_NAME}-${i}={{ $etcdPeerProtocol }}://${SET_NAME}-${i}.$(hostname -d):2380"
             done
 
             collect_member &
 
             # join member
             exec etcd --name ${HOSTNAME} \
-                --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
+                --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 \
                 --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
                 --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
-                --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
+                --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.$(hostname -d):2379 \
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state new \

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -94,14 +94,14 @@ spec:
                 - |
                   EPS=""
                   for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                      EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.$(hostname -d):2379"
+                      EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
                   done
 
                   HOSTNAME=$(hostname)
                   AUTH_OPTIONS="{{ $etcdAuthOptions }}"                  
 
                   member_hash() {
-                      etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | cut -d ',' -f1
+                      etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
                   }
 
                   SET_ID=${HOSTNAME##*[^0-9]}
@@ -123,28 +123,28 @@ spec:
             # store member id into PVC for later member replacement
             collect_member() {                
                 while ! etcdctl $AUTH_OPTIONS member list > /dev/null 2>&1; do sleep 1; done
-                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | cut -d ',' -f1 > /var/run/etcd/member_id
+                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1 > /var/run/etcd/member_id
                 exit 0
             }
 
             eps() {
                 EPS=""
                 for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                    EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.$(hostname -d):2379"
+                    EPS="${EPS}${EPS:+,}{{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2379"
                 done
                 echo ${EPS}
             }
 
             member_hash() {
-                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | cut -d ',' -f1
+                etcdctl $AUTH_OPTIONS member list | grep {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | cut -d ',' -f1
             }
 
             # we should wait for other pods to be up before trying to join
             # otherwise we got "no such host" errors when trying to resolve other members
             for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
                 while true; do
-                    echo "Waiting for ${SET_NAME}-${i}.$(hostname -d) to come up"
-                    ping -W 1 -c 1 ${SET_NAME}-${i}.$(hostname -d) > /dev/null && break
+                    echo "Waiting for ${SET_NAME}-${i}.${SET_NAME} to come up"
+                    ping -W 1 -c 1 ${SET_NAME}-${i}.${SET_NAME} > /dev/null && break
                     sleep 1s
                 done                
             done
@@ -155,11 +155,11 @@ spec:
                 member_id=$(cat /var/run/etcd/member_id)
 
                 # re-join member
-                ETCDCTL_ENDPOINT=$(eps) etcdctl $AUTH_OPTIONS member update ${member_id} {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | true
+                ETCDCTL_ENDPOINT=$(eps) etcdctl $AUTH_OPTIONS member update ${member_id} {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | true
                 exec etcd --name ${HOSTNAME} \
                     --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
                     --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379\
-                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.$(hostname -d):2379 \
+                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
                     --data-dir /var/run/etcd/default.etcd
                     
             fi
@@ -181,7 +181,7 @@ spec:
                 fi
 
                 echo "Adding new member"
-                etcdctl $AUTH_OPTIONS member add ${HOSTNAME} {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 | grep "^ETCD_" > /var/run/etcd/new_member_envs
+                etcdctl $AUTH_OPTIONS member add ${HOSTNAME} {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 | grep "^ETCD_" > /var/run/etcd/new_member_envs
 
                 if [ $? -ne 0 ]; then
                     echo "Exiting"
@@ -197,9 +197,9 @@ spec:
                 exec etcd --name ${HOSTNAME} \
                     --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
                     --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
-                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.$(hostname -d):2379 \
+                    --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
                     --data-dir /var/run/etcd/default.etcd \
-                    --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 \
+                    --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
                     --initial-cluster ${ETCD_INITIAL_CLUSTER} \
                     --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE}
                     
@@ -207,17 +207,17 @@ spec:
 
             PEERS=""
             for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                PEERS="${PEERS}${PEERS:+,}${SET_NAME}-${i}={{ $etcdPeerProtocol }}://${SET_NAME}-${i}.$(hostname -d):2380"
+                PEERS="${PEERS}${PEERS:+,}${SET_NAME}-${i}={{ $etcdPeerProtocol }}://${SET_NAME}-${i}.${SET_NAME}:2380"
             done
 
             collect_member &
 
             # join member
             exec etcd --name ${HOSTNAME} \
-                --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.$(hostname -d):2380 \
+                --initial-advertise-peer-urls {{ $etcdPeerProtocol }}://${HOSTNAME}.${SET_NAME}:2380 \
                 --listen-peer-urls {{ $etcdPeerProtocol }}://0.0.0.0:2380 \
                 --listen-client-urls {{ $etcdClientProtocol }}://0.0.0.0:2379 \
-                --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.$(hostname -d):2379 \
+                --advertise-client-urls {{ $etcdClientProtocol }}://${HOSTNAME}.${SET_NAME}:2379 \
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state new \


### PR DESCRIPTION
- changed to non-beta manifest API version
- added domain name while resolving set instances

Signed-off-by: David K. Bainbridge <dbainbri@ciena.com>

#### Is this a new chart
No. @lachie83 

#### What this PR does / why we need it:
Updates the chart so it will deploy on k8s 1.18.4

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
