### PR TITLE
[stable/prometheus-operator] Conform kubelet resource monitor TLS with rest of monitors

### DIFF
--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -74,6 +74,11 @@ spec:
   - port: https-metrics
     scheme: https
     path: {{ .Values.kubelet.serviceMonitor.resourcePath }}
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
 {{- if .Values.kubelet.serviceMonitor.resourceMetricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceMetricRelabelings | indent 4) . }}


### PR DESCRIPTION
This change adds the missing `insecureSkipVerify: true` and TLS config for the kubelet resource service monitor.

Unfortunately the requests to the endpoint are being rejected due to these missing settings.

It uses the same settings as the other monitors in this file.

#### Checklist
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
