### PR TITLE
[stable/nextcloud] Inject certificates into image

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.11.0
+version: 1.12.0
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -150,6 +150,19 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `hpa.maxPods`                                                | Max. pods for the Nextcloud HorizontalPodAutoscaler     | `10`                                        |
 | `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level           | not set                                     |
 | `podAnnotations`                                             | Annotations to be added at 'pod' level                  | not set                                     |
+| `certificates.customCertificate.certificateSecret`           | Secret containing the certificate and key to add        | `""`                                        |
+| `certificates.customCertificate.chainSecret.name`            | Name of the secret containing the certificate chain     | `""`                                        |
+| `certificates.customCertificate.chainSecret.key`             | Key of the certificate chain file inside the secret     | `""`                                        |
+| `certificates.customCertificate.certificateLocation`         | Location in the container to store the certificate      | `/etc/ssl/certs/ssl-cert-snakeoil.pem`      |
+| `certificates.customCertificate.keyLocation`                 | Location in the container to store the private key      | `/etc/ssl/private/ssl-cert-snakeoil.key`    |
+| `certificates.customCertificate.chainLocation`               | Location in the container to store the cert chain         `/etc/ssl/certs/chain.pem`                  |
+| `certificates.customCA`                                      | List of secrets to import into the trust store          | `[]`                                        |
+| `certificates.image.registry`                                | Container sidecar registry                              | `docker.io`                                 |
+| `certificates.image.repository`                              | Container sidecar image                                 | `alpine`                                    |
+| `certificates.image.tag`                                     | Container sidecar image tag                             | `latest`                                    |
+| `certificates.image.pullPolicy`                              | Container sidecar image pull policy                     | `Always`                                    |
+| `certificates.image.pullSecrets`                             | Container sidecar image pull secrets                    | `image.pullSecrets`                         |
+| `certificates.extraEnvVars`                                  | Container sidecar extra environment variables (proxy)   | `[]`                                        |
 
 > **Note**:
 >
@@ -225,4 +238,53 @@ nextcloud:
           )
         )
       );
+```
+
+## Certificates
+
+### CA Certificates
+Custom CA certificates not included in the base docker image can be added with
+the following configuration. The secret must exist in the same namespace as the
+deployment. Will load all certificates files it finds in the secret.
+
+```yaml
+certificates:
+  customCAs:
+  - secret: my-ca-1
+  - secret: my-ca-2
+```
+
+#### Secret
+Secret can be created with:
+
+```bash
+kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
+```
+
+### TLS Certificate
+A web server TLS Certificate can be injected into the container with the
+following configuration. The certificate will be stored at the location
+specified in the certificateLocation value.
+
+```yaml
+certificates:
+  customCertificate:
+    certificateSecret: my-secret
+    certificateLocation: /ssl/server.pem
+    keyLocation: /ssl/key.pem
+    chainSecret:
+      name: my-cert-chain-secret
+      key: chain.pem
+```
+
+#### Secret
+The certificate tls secret can be created with:
+
+```bash
+kubectl create secret tls my-secret --cert tls.crt --key tls.key
+```
+
+The certificate chain is created with:
+```bash
+kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
 ```

--- a/stable/nextcloud/templates/_certificates.tpl
+++ b/stable/nextcloud/templates/_certificates.tpl
@@ -1,0 +1,126 @@
+{{/* Templates for certificates injection */}}
+
+{{/*
+Return the proper Redmine image name
+*/}}
+{{- define "certificates.image" -}}
+{{- $registryName := default .Values.certificates.image.registry .Values.image.registry -}}
+{{- $repositoryName := .Values.certificates.image.repository -}}
+{{- $tag := .Values.certificates.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.initContainer" -}}
+{{- if .Values.certificates.customCAs }}
+- name: certificates
+  image: {{ template "certificates.image" . }}
+  imagePullPolicy: {{ default .Values.image.pullPolicy .Values.certificates.image.pullPolicy }}
+  imagePullSecrets:
+  {{- range (default .Values.image.pullSecrets .Values.certificates.image.pullSecrets) }}
+    - name: {{ . }}
+  {{- end }}
+  command:
+  {{- if .Values.certificates.customCertificate.certificateSecret }}
+  - sh
+  - -c
+  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+    else apt-get update && apt-get install -y ca-certificates openssl; fi
+  {{- else }}
+  - sh
+  - -c
+  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+    else apt-get update && apt-get install -y ca-certificates openssl; fi
+    && openssl req -new -x509 -days 3650 -nodes -sha256
+       -subj "/CN=$(hostname)" -addext "subjectAltName = DNS:$(hostname)"
+       -out  /etc/ssl/certs/ssl-cert-snakeoil.pem
+       -keyout /etc/ssl/private/ssl-cert-snakeoil.key -extensions v3_req
+  {{- end }}
+  {{- if .Values.certificates.extraEnvVars }}
+  env:
+  {{- tpl (toYaml .Values.certificates.extraEnvVars) $ | nindent 2 }}
+  {{- end }}
+  volumeMounts:
+    - name: etc-ssl-certs
+      mountPath: /etc/ssl/certs
+      readOnly: false
+    - name: etc-ssl-private
+      mountPath: /etc/ssl/private
+      readOnly: false
+    - name: custom-ca-certificates
+      mountPath: /usr/local/share/ca-certificates
+      readOnly: true
+{{- end }}
+{{- end }}
+
+{{- define "certificates.volumes" -}}
+{{- if .Values.certificates.customCAs }}
+- name: etc-ssl-certs
+  emptyDir:
+    medium: "Memory"
+- name: etc-ssl-private
+  emptyDir:
+    medium: "Memory"
+- name: custom-ca-certificates
+  projected:
+    defaultMode: 0400
+    sources:
+    {{- range $index, $customCA := .Values.certificates.customCAs }}
+    - secret:
+        name: {{ $customCA.secret }}
+        # items not specified, will mount all keys
+    {{- end }}
+{{- end -}}
+{{- if .Values.certificates.customCertificate.certificateSecret }}
+- name: custom-certificate
+  secret:
+    secretName: {{ .Values.certificates.customCertificate.certificateSecret }}
+{{- if .Values.certificates.customCertificate.chainSecret }}
+- name: custom-certificate-chain
+  secret:
+    secretName: {{ .Values.certificates.customCertificate.chainSecret.name }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.volumeMount" -}}
+{{- if .Values.certificates.customCAs }}
+- name: etc-ssl-certs
+  mountPath: /etc/ssl/certs/
+  readOnly: false
+- name: etc-ssl-private
+  mountPath: /etc/ssl/private/
+  readOnly: false
+- name: custom-ca-certificates
+  mountPath: /usr/local/share/ca-certificates
+  readOnly: true
+{{- end -}}
+{{- if .Values.certificates.customCertificate.certificateSecret }}
+- name: custom-certificate
+  mountPath: {{ .Values.certificates.customCertificate.certificateLocation }}
+  subPath: tls.crt
+  readOnly: true
+- name: custom-certificate
+  mountPath: {{ .Values.certificates.customCertificate.keyLocation }}
+  subPath: tls.key
+  readOnly: true
+{{- if .Values.certificates.customCertificate.chainSecret }}
+- name: custom-certificate-chain
+  mountPath: {{ .Values.certificates.customCertificate.chainLocation }}
+  subPath: {{ .Values.certificates.customCertificate.chainSecret.key }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         - name: {{ . }}
       {{- end}}
       {{- end }}
+      initContainers:
+      {{- include "certificates.initContainer" . | indent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -201,6 +203,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        {{- include "certificates.volumeMount" . | indent 8 }}
         - name: nextcloud-data
           mountPath: /var/www/
           subPath: {{ ternary "root" (printf "%s/%s" .Values.nextcloud.persistence.subPath "root") (empty .Values.nextcloud.persistence.subPath) }}
@@ -321,6 +324,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
+      {{- include "certificates.volumes" . | indent 6 }}
       - name: nextcloud-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -345,3 +345,32 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Add custom certificates and certificate authorities to redmine container
+certificates:
+  customCertificate:
+    certificateSecret: ""
+    chainSecret: {}
+    # name: secret-name
+    # key: secret-key
+    certificateLocation: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    keyLocation: /etc/ssl/private/ssl-cert-snakeoil.key
+    chainLocation: /etc/ssl/certs/mychain.pem
+  customCA: []
+  # - secret: custom-CA
+  # - secret: more-custom-CAs
+  image:
+    registry: docker.io
+    repository: alpine
+    tag: latest
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    # pullPolicy:
+    # pullSecrets
+    #   - myRegistryKeySecretName
+  extraEnvVars: []
+  # - name: myvar
+  #   value: myval


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds CA certificate support to nextcloud. Allowing it to authenticate against ldap with an internal CA.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
