### PR TITLE
[stable/mongodb-replicaset] Warning fixed, made client service optional (#22209, #22759).

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.16.1
+version: 3.16.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -112,6 +112,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `extraVars`                         | Set environment variables for the main container                          | `{}`                                                |
 | `extraLabels`                       | Additional labels to add to resources                                     | `{}`                                                |
 | `extraVolumes`                      | Additional volumes to add to the resources                                | `[]`                                                |
+| `clientService.enabled`             | Enables the headless client service                                       | `true`                                              |
 | `global.namespaceOverride`          | Override the deployment namespace                                         | Not set (`Release.Namespace`)                       |
 
 *MongoDB config file*

--- a/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
@@ -1,4 +1,5 @@
-# A headless service for client applications to use
+{{- if .Values.clientService.enabled -}}
+# An optional headless service for client applications to use
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,4 +31,4 @@ spec:
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}
-
+{{- end -}}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -3,8 +3,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Override the deployment namespace
-global:
-#  namespaceOverride: ""
+global: {}
+# global:
+#   namespaceOverride: ""
 
 replicas: 3
 port: 27017
@@ -198,3 +199,7 @@ livenessProbe:
   failureThreshold: 3
   periodSeconds: 10
   successThreshold: 1
+
+# Enables/disables the headless client service
+clientService:
+  enabled: true


### PR DESCRIPTION


#### Is this a new chart
Nope.

#### What this PR does / why we need it:
Removes warnings that are confusing to the end user and fixes an issue with Istio deployments by making a service component optional.

#### Which issue this PR fixes
This PR fixes #22209 where the headless `client` service causes port conflicts when used with Istio.
This PR also fixes #22759 where `global` option causes warnings when this Chart is used as a subchart:
```
coalesce.go:160: warning: skipped value for global: Not a table.
```

#### Special notes for your reviewer:
N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
