### PR TITLE
Update service port name to follow istio convention

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark-history-server
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/templates/service.yaml
+++ b/stable/spark-history-server/templates/service.yaml
@@ -14,10 +14,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.service.port }}
+  - port: {{ .Values.service.port.number }}
     targetPort: historyport
     protocol: TCP
-    name: historyport
+    name: {{ .Values.service.port.name }}
   selector:
     app.kubernetes.io/name: {{ include "spark-history-server.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -16,7 +16,9 @@ image:
 
 service:
   type: LoadBalancer
-  port: 18080
+  port:
+    number: 18080
+    name: http-historyport
   annotations: {}
 
 environment:


### PR DESCRIPTION
Service port name is currently historyport, which doesn't follow istio port naming convention: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/