### PR TITLE
prometheus-blackbox-exporter: config: false it will not mount the configmap/secret

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.1.1
+version: 4.1.2
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -86,8 +86,10 @@ spec:
           readinessProbe:
             {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           volumeMounts:
+          {{- if .Values.config }}
             - mountPath: /config
               name: config
+          {{- end}}
           {{- range .Values.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -101,13 +103,15 @@ spec:
               readOnly: {{ .readOnly }}
           {{- end }}
       volumes:
+{{- if .Values.config }}
         - name: config
-{{- if .Values.secretConfig }}
+          {{- if .Values.secretConfig }}
           secret:
             secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
-{{- else }}
+          {{- else }}
           configMap:
             name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+          {{- end }}
 {{- end }}
       {{- range .Values.extraConfigmapMounts }}
         - name: {{ .name }}


### PR DESCRIPTION
#### What this PR does / why we need it:
If the value `config` is set to `false` it will not create a configmap for the blackbox exporter configuration.
However, the deployment will still try to mount it because it only checks if the config is a secret or a configmap, it doesn't check if exists. Therefore, will result in an error saying that the configmap (or secret), that is trying to mount, does not exists and it needs to be created before applying the chart.

This PR will add an additional check `if config -> mount it; else -> ignore`

#### Special notes for your reviewer:
My use case is the following:
I want to use an already created secret as configuration for my blackbox-exporter.
To do it:

1- I set `config to false` to ignore the mounted configuration (/config) and use the default one.
2- I use `extraSecretMounts` to mount the secret and override the default configuration.
```
extraSecretMounts:
- name: blackbox-exporter
  mountPath: /etc/blackbox_exporter/
  secretName: blackbox-exporter
  readOnly: true
  subPath: ""
```


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
