### PR TITLE
[stable/nginx-ingress] adding backwards compatible component label key override

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.40.1
+version: 1.40.2
 appVersion: 0.32.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. | `101`
 `controller.useComponentLabel` | Wether to add component label so the HPA can work separately for controller and defaultBackend. *Note: don't change this if you have an already running deployment as it will need the recreation of the controller deployment* | `false`
+`controller.componentLabelKeyOverride` | Allows override of the component label key | `""`
 `controller.containerPort.http` | The port that the controller container listens on for http connections. | `80`
 `controller.containerPort.https` | The port that the controller container listens on for https connections. | `443`
 `controller.config` | nginx [ConfigMap](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md) entries | none
@@ -191,6 +192,7 @@ Parameter | Description | Default
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
 `defaultBackend.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses nobody user. | `65534`
 `defaultBackend.useComponentLabel` | Whether to add component label so the HPA can work separately for controller and defaultBackend. *Note: don't change this if you have an already running deployment as it will need the recreation of the defaultBackend deployment* | `false`
+`defaultBackend.componentLabelKeyOverride` | Allows override of the component label key | `""`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
 `defaultBackend.extraEnvs` | any additional environment variables to set in the defaultBackend pods | `[]`
 `defaultBackend.port` | Http port number | `8080`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
   name: {{ template "nginx-ingress.controller.fullname" . }}
-  annotations:    
+  annotations:
 {{ toYaml .Values.controller.deploymentAnnotations | indent 4}}
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.controller.useComponentLabel }}
-      app.kubernetes.io/component: controller
+      {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
     {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   updateStrategy:
@@ -37,7 +37,7 @@ spec:
         app: {{ template "nginx-ingress.name" . }}
         release: {{ template "nginx-ingress.releaseLabel" . }}
         component: "{{ .Values.controller.name }}"
-        app.kubernetes.io/component: controller
+        {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -7,7 +7,8 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
+
     {{- if .Values.controller.deploymentLabels }}
 {{ toYaml .Values.controller.deploymentLabels | indent 4 }}
     {{- end }}
@@ -20,7 +21,7 @@ spec:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.controller.useComponentLabel }}
-      app.kubernetes.io/component: controller
+      {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
     {{- end }}
 {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicaCount }}
@@ -41,7 +42,7 @@ spec:
         app: {{ template "nginx-ingress.name" . }}
         release: {{ template "nginx-ingress.releaseLabel" . }}
         component: "{{ .Values.controller.name }}"
-        app.kubernetes.io/component: controller
+        {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -42,6 +42,6 @@ spec:
   selector:
     app: {{ template "nginx-ingress.name" . }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
   type: "{{ .Values.controller.metrics.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
@@ -14,6 +14,6 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ template "nginx-ingress.releaseLabel" . }}
-      app.kubernetes.io/component: controller
+      {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
   minAvailable: {{ .Values.controller.minAvailable }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-service-internal.yaml
+++ b/stable/nginx-ingress/templates/controller-service-internal.yaml
@@ -40,6 +40,6 @@ spec:
   selector:
     app: {{ template "nginx-ingress.name" . }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
   type: "{{ .Values.controller.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -89,6 +89,6 @@ spec:
   selector:
     app: {{ template "nginx-ingress.name" . }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
   type: "{{ .Values.controller.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -39,6 +39,6 @@ spec:
   selector:
     app: {{ template "nginx-ingress.name" . }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: controller
+    {{ .Values.controller.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: controller
   type: "{{ .Values.controller.admissionWebhooks.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: default-backend
+    {{ .Values.defaultBackend.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: default-backend
     {{- if .Values.defaultBackend.deploymentLabels }}
 {{ toYaml .Values.defaultBackend.deploymentLabels | indent 4 }}
     {{- end }}
@@ -18,7 +18,7 @@ spec:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ template "nginx-ingress.releaseLabel" . }}
     {{- if .Values.defaultBackend.useComponentLabel }}
-      app.kubernetes.io/component: default-backend
+      {{ .Values.defaultBackend.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: default-backend
     {{- end }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -33,7 +33,7 @@ spec:
       labels:
         app: {{ template "nginx-ingress.name" . }}
         release: {{ template "nginx-ingress.releaseLabel" . }}
-        app.kubernetes.io/component: default-backend
+        {{ .Values.defaultBackend.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: default-backend
         {{- if .Values.defaultBackend.podLabels }}
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
         {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    app.kubernetes.io/component: default-backend
+    {{ .Values.defaultBackend.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: default-backend
     heritage: {{ .Release.Service }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
@@ -14,6 +14,6 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ template "nginx-ingress.releaseLabel" . }}
-      app.kubernetes.io/component: default-backend
+      {{ .Values.defaultBackend.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: default-backend
   minAvailable: {{ .Values.defaultBackend.minAvailable }}
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -40,6 +40,6 @@ spec:
   selector:
     app: {{ template "nginx-ingress.name" . }}
     release: {{ template "nginx-ingress.releaseLabel" . }}
-    app.kubernetes.io/component: default-backend
+    {{ .Values.defaultBackend.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: default-backend
   type: "{{ .Values.defaultBackend.service.type }}"
 {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -16,6 +16,9 @@ controller:
   # We recommend setting this to true for new deployments.
   useComponentLabel: false
 
+  # Override component label key
+  # componentLabelKeyOverride:
+
   # Configures the ports the nginx-controller listens on
   containerPort:
     http: 80
@@ -457,6 +460,9 @@ defaultBackend:
   # Note that if you enable it for existing deployments, it won't work as the labels are immutable.
   # We recommend setting this to true for new deployments.
   useComponentLabel: false
+
+  # Override component label key
+  # componentLabelKeyOverride:
 
   extraArgs: {}
 


### PR DESCRIPTION
Signed-off-by: Rodrigo Lomonaco <rodrigo.lomonaco@xero.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This adds a backwards compatible component label override.
It allows existing deployments with incorrectly set labels to be upgraded without needing to recreate/redeploy.
We're upgrading from 1.24.7 and we have a label "component=controller" which is not compatible with 1.40.X, this change will allow a user-specified label to be used in place of "app.kubernetes.io/component" and is fully backwards-compatible

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
