### PR TITLE
[stable/cluster-overprovisioner] add pod security context

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.3.0
+version: 0.4.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -36,6 +36,7 @@ The following table lists the configurable parameters for this chart and their d
 
 | Parameter                          | Description                                                                                                                     | Default           |
 | -----------------------------------|-------------------------------------------------------------------------------------------------------------------------------- |-------------------|
+| `podSecurityContext`               | Pod security context object                                                                                                     | `{}`              |
 | `priorityClassOverprovision.name`  | Name of the overprovision priorityClass                                                                                         | `overprovision`   |
 | `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass                                                                               | `-1`              |
 | `priorityClassDefault.enabled`     | If true, enable default priorityClass                                                                                           | `true`            |
@@ -43,19 +44,19 @@ The following table lists the configurable parameters for this chart and their d
 | `priorityClassDefault.value`       | Priority value of the default priorityClass                                                                                     | `0`               |
 | `image.repository`                 | Image repository                                                                                                                | `k8s.gcr.io/pause`|
 | `image.tag`                        | Image tag                                                                                                                       | `3.1`             |
-| `image.pullSecrets`                | Image pull secrets                                                                                                                   | `[]`              |
+| `image.pullSecrets`                | Image pull secrets                                                                                                              | `[]`              |
 | `image.pullPolicy`                 | Container pull policy                                                                                                           | `IfNotPresent`    |
 | `fullnameOverride`                 | Override the fullname of the chart                                                                                              | `nil`             |
 | `nameOverride`                     | Override the name of the chart                                                                                                  | `nil`             |
 | `deployments`                      | Define optional additional deployments                                                                                          | `[]`              |
 | `deployments[].name`               | Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) | ``                |
 | `deployments[].replicaCount`       | Number of replicas                                                                                                              | `1`               |
-| `deployments[].annotations`       | Annotations to add to the deployment                                                                                                              | `{}`               |
+| `deployments[].annotations`        | Annotations to add to the deployment                                                                                            | `{}`              |
 | `deployments[].resources`          | Resources for the overprovision pods                                                                                            | `{}`              |
 | `deployments[].affinity`           | Map of node/pod affinities                                                                                                      | `{}`              |
 | `deployments[].nodeSelector`       | Node labels for pod assignment                                                                                                  | `{}`              |
 | `deployments[].tolerations`        | Optional deployment tolerations                                                                                                 | `[]`              |
-| `deployments[].labels`        | Optional labels tolerations                                                                                                 | `{}`              |
+| `deployments[].labels`             | Optional labels tolerations                                                                                                     | `{}`              |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -4,6 +4,7 @@
 {{- $name :=  include "cluster-overprovisioner.name" . -}}
 {{- $chart :=  include "cluster-overprovisioner.chart" . -}}
 {{- $chartName := .Chart.Name }}
+{{- $podSecurityContext := .Values.podSecurityContext }}
 {{- $priorityClassName := .Values.priorityClassOverprovision.name }}
 {{- $repository := .Values.image.repository }}
 {{- $imageTag := .Values.image.tag }}
@@ -45,6 +46,8 @@ spec:
     {{- end }}
     spec:
       priorityClassName: {{ $priorityClassName }}
+      securityContext:
+        {{- toYaml $podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $chartName }}
           image: "{{ $repository }}:{{ $imageTag }}"

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -1,3 +1,6 @@
+podSecurityContext: {}
+  # fsGroup: 2000
+
 priorityClassOverprovision:
   name: overprovisioning
   value: -1


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds ability to configure the podSecurityContext.  Will allow running this chart under a more restrictive PSP.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
