### PR TITLE
[stable/prometheus-mysql-exporter]:  Add service labels and annotations

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.5.3
+version: 0.6.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -43,6 +43,8 @@ The following table lists the configurable parameters of the mysql exporter char
 | `image.tag`                            | Image tag                                           | `v0.11.0`                          |
 | `image.pullPolicy`                     | Image pull policy                                   | `IfNotPresent`                     |
 | `service.name`                         | Service name                                        | `mysql-exporter`                   |
+| `service.labels`                       | Additional labels for the service                   | `{}`                               |
+| `service.annotations`                  | Annotations to be added to the service              | `{}`                               |
 | `service.type`                         | Service type                                        | `ClusterIP`                        |
 | `service.externalport`                 | The service port                                    | `9104`                             |
 | `service.internalPort`                 | The target port of the container                    | `9104`                             |

--- a/stable/prometheus-mysql-exporter/templates/service.yaml
+++ b/stable/prometheus-mysql-exporter/templates/service.yaml
@@ -7,6 +7,13 @@ metadata:
     chart: {{ template "prometheus-mysql-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/prometheus-mysql-exporter/values.yaml
+++ b/stable/prometheus-mysql-exporter/values.yaml
@@ -10,6 +10,8 @@ image:
   pullPolicy: "IfNotPresent"
 
 service:
+  labels: {}
+  annotations: {}
   name: mysql-exporter
   type: ClusterIP
   externalPort: 9104


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

The `prometheus-mysql-exporter` chart has a `serviceMonitor.targetLabels` value. This value uses the labels on the `service` resource. The `service`'s labels however aren't configurable.

Additionally, I added annotations if anyone needed it.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
