### PR TITLE
[stable/prometheus-blackbox-exporter] Fix use of variable in Promethe…

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.3.0
+version: 4.4.0
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusRule.enabled }}
+{{- if and .Values.prometheusRule.enabled .Values.prometheusRule.rules }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -18,6 +18,6 @@ spec:
   {{- with .Values.prometheusRule.rules }}
   groups:
     - name: {{ template "prometheus-blackbox-exporter.name" $ }}
-      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+      rules: {{ toYaml . | nindent 8 }}
   {{- end }}
 {{- end }}

--- a/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -15,9 +15,14 @@ metadata:
 {{- toYaml . | nindent 4 -}}
     {{- end }}
 spec:
+  {{- $evaluateRules := .Values.prometheusRule.evaluateRules }}
   {{- with .Values.prometheusRule.rules }}
   groups:
     - name: {{ template "prometheus-blackbox-exporter.name" $ }}
+      {{- if $evaluateRules }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- else }}
       rules: {{ toYaml . | nindent 8 }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -148,6 +148,8 @@ prometheusRule:
   enabled: false
   additionalLabels: {}
   namespace: ""
+  # If enabled the rules are passed through the "tpl" function so variables like .Release.Name can be evaluated
+  evaluateRules: true
   rules: []
 
 ## Network policy for chart


### PR DESCRIPTION
#### What this PR does / why we need it:
If I try and configure a rule with "$labels" in it I can't get it to work using the previous syntax.

e.g. `message: The status code of {{ $labels.target }} is 4xx or 5xx` gets me an error like `undefined variable "$labels"`

#### Which issue this PR fixes
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
