### PR TITLE
[stable/seq] Update Seq chart to 2020 container version

### DIFF
--- a/stable/seq/Chart.yaml
+++ b/stable/seq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: seq
-version: 2.1.0
-appVersion: 5
+version: 2.2.0
+appVersion: 2020
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:
 - seq

--- a/stable/seq/README.md
+++ b/stable/seq/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the Seq chart and their
 | Parameter                            | Description                                                                                           | Default                               |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------|
 | `image.repository`                   | Image repository                                                                                      | `datalust/seq`                        |
-| `image.tag`                          | Seq image tag. Possible values listed [here](https://hub.docker.com/r/datalust/seq/tags/).            | `5`                                   |
+| `image.tag`                          | Seq image tag. Possible values listed [here](https://hub.docker.com/r/datalust/seq/tags/).            | `2020`                                   |
 | `image.pullPolicy`                   | Image pull policy                                                                                     | `IfNotPresent`                        |
 | `acceptEULA`                         | Accept EULA                                                                                           | `Y`                                   |
 | `baseURI`                            | Base URL for ingress/AAD (see values.yaml)                                                            |                                       |

--- a/stable/seq/values.yaml
+++ b/stable/seq/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: datalust/seq
-  tag: 5
+  tag: 2020
   pullPolicy: IfNotPresent
 
 # By passing the value Y in the ACCEPT_EULA environment variable,


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR updates the chart to track Seq 2020, which is the next major release following Seq 5.1.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
