### PR TITLE
[stable/rocketchat] Add persistence.existingClaim configuration, closes #22262

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rocketchat
-version: 2.0.3
+version: 2.0.4
 appVersion: 3.2.2
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/stable/rocketchat/README.md
+++ b/stable/rocketchat/README.md
@@ -65,6 +65,7 @@ Parameter | Description | Default
 `persistence.storageClass` | Storage class of the PVC to use | `""`
 `persistence.accessMode` | Access mode of the PVC | `ReadWriteOnce`
 `persistence.size` | Size of the PVC | `8Gi`
+`persistence.existingClaim` | An Existing PVC name for rocketchat volume | `""`
 `resources` | Pod resource requests and limits | `{}`
 `securityContext.enabled` | Enable security context for the pod | `true`
 `securityContext.runAsUser` | User to run the pod as | `999`

--- a/stable/rocketchat/templates/deployment.yaml
+++ b/stable/rocketchat/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
       - name: rocket-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "rocketchat.fullname" . }}
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "rocketchat.fullname" . }}{{- end }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/rocketchat/values.yaml
+++ b/stable/rocketchat/values.yaml
@@ -101,6 +101,7 @@ mongodb:
 ##
 persistence:
   enabled: false
+  # existingClaim: existingClaimName
   ## rocketchat data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Signed-off-by: Maarten de Waard <maarten@greenhost.nl>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR solves #22262 by adding the `persistence.existingClaim` configuration parameter to the deployment.yaml and values.yaml files

#### Which issue this PR fixes

  - fixes #22262

#### Special notes for your reviewer:

n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
