### PR TITLE
[stable/nginx-ingress] add controller.podAnnotationConfigChecksum

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.40.2
+version: 1.40.3
 appVersion: 0.32.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -89,6 +89,7 @@ Parameter | Description | Default
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
 `controller.nodeSelector` | node labels for pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to pods | `{}`
+`controller.podAnnotationConfigChecksum` | add annotation with checksum/config | `false`
 `controller.deploymentLabels` | labels to add to the deployment metadata | `{}`
 `controller.podLabels` | labels to add to the pod container metadata | `{}`
 `controller.podSecurityContext` | Security context policies to add to the controller pod | `{}`

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -32,10 +32,13 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:
     metadata:
-      {{- if .Values.controller.podAnnotations }}
+      {{- if or .Values.controller.podAnnotations .Values.controller.podAnnotationConfigChecksum }}
       annotations:
       {{- range $key, $value := .Values.controller.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- if .Values.controller.podAnnotationConfigChecksum }}
+        checksum/config: {{ tpl (toYaml .Values.controller) . | sha256sum }}
       {{- end }}
       {{- end }}
       labels:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -220,6 +220,10 @@ controller:
   ##
   podAnnotations: {}
 
+  # Add Config Checksum to pod Annotations
+  # This will trigger Rolling Updates on configuration changes
+  podAnnotationConfigChecksum: false
+
   replicaCount: 1
 
   minAvailable: 1


### PR DESCRIPTION
Signed-off-by: raittes <raittes@gmail.com>

#### What this PR does / why we need it:
This flag adds an annotation with `checksum/config` in pod template metadata
that will trigger an Rolling Update when configuration changes
Ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
