### PR TITLE
[stable/cockroachdb] deprecating this cockroachdb chart repository

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,18 +1,14 @@
 apiVersion: v1
 name: cockroachdb
+# The stable/cockroachdb chart is deprecated and no longer maintained. For
+# details on the deprecation policy, including how to un-deprecate a chart,
+# see the PROCESSES.md file.
+deprecated: true
+description: DEPRECATED -- CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 home: https://www.cockroachlabs.com
 version: 3.0.8
 appVersion: 19.2.5
-description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:
 - https://github.com/cockroachdb/cockroach
-maintainers:
-- name: a-robinson
-  email: alexdwanerobinson@gmail.com
-- name: DuskEagle
-  email: Joel.A.Kenny@gmail.com
-- name: joshimhoff
-  email: joshimhoff13@gmail.com
-- name: keith-mcclellan
-  email: keith.mcclellan@gmail.com
+maintainers: []

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 3.0.7
+version: 3.0.8
 appVersion: 19.2.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -1,6 +1,18 @@
 # CockroachDB Helm Chart
 
 
+## This Helm chart is deprecated
+
+Given the [deprecation of `stable`](https://github.com/helm/charts#deprecation-timeline), future CockroachDB Helm charts are now located at [cockroachdb/charts](https://github.com/cockroachdb/helm-charts/).
+
+The CockroachDB charts repository is already included in the Hubs. Updated installation instructions are included in the new [source code repository README](https://github.com/cockroachdb/helm-charts/blob/master/README.md).
+
+To update an exisiting _stable_ deployment with a chart hosted in the CockroachDB repository, you can run:
+
+```bash
+$ helm repo add cockroachdb https://charts.cockroachdb.com/
+$ helm upgrade my-release cockroachdb/cockroachdb
+```
 
 
 ## Documentation

--- a/stable/cockroachdb/templates/NOTES.txt
+++ b/stable/cockroachdb/templates/NOTES.txt
@@ -1,3 +1,20 @@
+This Helm chart is deprecated
+
+Given the deprecation of `stable` (https://github.com/helm/charts#deprecation-timeline), future CockroachDB Helm charts are now located at cockroachdb/charts (https://github.com/cockroachdb/helm-charts/).
+
+The CockroachDB charts repository is already included in the Hubs. Updated installation instructions are included in the new source code repository README (https://github.com/cockroachdb/helm-charts/blob/master/README.md).
+
+To update an exisiting _stable_ deployment with a chart hosted in the CockroachDB repository, you can run:
+
+```bash
+$ helm repo add cockroachdb https://charts.cockroachdb.com/
+$ helm upgrade my-release cockroachdb/cockroachdb
+```
+
+
+---
+
+
 CockroachDB can be accessed via port {{ .Values.service.ports.grpc.external.port }} at the
 following DNS name from within your cluster:
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Given the deprecation of `stable`, future CockroachDB Helm charts are
now located at:

  code repository: https://github.com/cockroachdb/helm-charts
  charts repository: https://charts.cockroachdb.com

Update this repository to point users to the new locations.

Signed-off-by: James H. Linder <jamesl@cockroachlabs.com>

#### Checklist
 
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
