### PR TITLE
[stable/kube-ops-view] Fix Redis port

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.2.0
+version: 1.2.1
 appVersion: 20.4.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.redis.enabled }}
         args:
-        - --redis-url=redis://{{ .Release.Name }}-redis-master:{{ .Values.redis.master.port }}
+        - --redis-url=redis://{{ .Release.Name }}-redis-master:{{ .Values.redis.redisPort }}
         {{- end }}
         {{- with .Values.securityContext }}
         securityContext: {{ toYaml . | nindent 10 }}


### PR DESCRIPTION
Signed-off-by: Eugene Glotov <kivagant@gmail.com>

#### Is this a new chart
No

#### What this PR does / why we need it:

#### Which issue this PR fixes
```
Error: release kube-ops-view failed: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Args: []string: ReadString: expects " or n, but found {, error found in #10 byte of ...|{"args":[{"--redis-u|..., bigger context ...|-1.2.0-0dccd3c"}},"spec":{"containers":[{"args":[{"--redis-url=redis://kube-ops-view-redis-master":n|...
```

#### Special notes for your reviewer:

/cc @hjacobs

The Redis port key name probably was changed in the values of the `redis` chart, so it must be accordingly updated in this chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
