### PR TITLE
[incubator/rundeck] envSecret, awsConfigSecret, kubeConfigSecret, extraConfigSecret, nginx req size

### DIFF
--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -1,9 +1,10 @@
-apiVersion: v1
+apiVersion: v2
 description: A Rundeck chart for Kubernetes
 name: rundeck
+type: application
 home: https://github.com/rundeck/rundeck
-version: 0.2.1
-appVersion: 3.2.7
+version: 0.3.0
+appVersion: 3.2.8
 keywords:
 - rundeck
 - jobs

--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -1,7 +1,6 @@
-apiVersion: v2
+apiVersion: v1
 description: A Rundeck chart for Kubernetes
 name: rundeck
-type: application
 home: https://github.com/rundeck/rundeck
 version: 0.3.0
 appVersion: 3.2.8

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -26,8 +26,11 @@ ingress | Any ingress rules to apply. | None
 resources | Any resource constraints to apply. | None
 rundeck.adminUser | The config to set up the admin user that should be placed at the realm.properties file. | "admin:admin,user,admin,architect,deploy,build"
 rundeck.env | The rundeck environment variables that you would want to set | Default variables provided in docker file
+rundeck.envSecret | Name of secret containing environment variables to add to the Rundeck deployment | ""
 rundeck.sshSecrets | A reference to the Kubernetes Secret that contains the ssh keys. | ""
-rundeck.awsCredentialsSecret | A reference to the Kubernetes Secret that contains the aws credentials. | ""
+rundeck.awsConfigSecret | Name of secret to mount under the `~/.aws/` directory. Useful when AWS IRSA is not an option. | ""
+rundeck.kubeConfigSecret | Name of secret to mount under the `~/.kube/` directory. Useful when Rundeck needs configuration for multiple K8s clusters. | ""
+rundeck.extraConfigSecret | Name of secret containing additional files to mount at `~/extra/`. Can be useful for working with RUNDECK_TOKENS_FILE configuration | ""
 nginxConfOverride | An optional multi-line value that can replace the default nginx.conf. | ""
 persistence.enabled | Whether or not to attach persistent storage to the Rundeck pod | false
 persistence.claim.create | Whether the helm chart should create a persistent volume claim. See the values.yaml for more claim options | false
@@ -36,3 +39,82 @@ persistence.existingClaim | Name of an existing volume claim | None
 serviceAccount.create | Set to true to create a service account for the Rundeck pod | false
 serviceAccount.annotations | A map of annotations to attach to the service account (eg: AWS IRSA) | {}
 serviceAccount.name | Name of the service account the Rundeck pod should use | ""
+
+## AWS & K8s Permissions
+
+If Rundeck jobs need access to the AWS or Kubernetes APIs this chart provides a couple options.
+
+### AWS IRSA
+If running Rundeck in AWS on EKS, [AWS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html) can be used to grant Rundeck IAM permissions by adding the appropriate annotation at `serviceAccount.annotations` (see `./values.yaml` for example). This can also be used to grant access to other EKS K8s APIs by adding the proper role bindings in those clusters that reference the IAM user.
+
+### AWS & K8s
+The `rundeck.awsConfigSecret` and `rundeck.kubeConfigSecret` keys allow for mounting additional configuration for AWS and Kubernetes tools and SDKs. The secrets are mounted into their respective configuration directories under the Rundeck users's home directory. 
+
+For example, you can create a secret containing kubeconfig file content that can be used to configure authentication to another remote cluster via the AWS IAM authenticator. Combine this with an AWS IRSA annotation on the Rundeck service account and you can configure Rundeck to auth to multiple EKS clusters' APIs accross multiple AWS accounts without ever needing to manage AWS IAM API keys or K8s credentials.
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: rundeck-kube-config
+  namespace: rundeck
+stringData:
+  config: |-
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        certificate-authority-data: LS0tLS1CRUdJ[YOUR_CLUSTER_CA_INFO]tLQo=
+        server: https://[your_eks_server_id].sk1.us-west-2.eks.amazonaws.com
+    name: staging
+    contexts:
+    - context:
+        cluster: staging
+        user: admin
+        namespace: default
+    name: stating
+    current-context: staging
+    preferences: {}
+    users:
+    - name: admin
+    user:
+        exec:
+        apiVersion: client.authentication.k8s.io/v1alpha1
+        args:
+        - token
+        - -i
+        - staging
+        command: aws-iam-authenticator
+```
+
+Note that the Rundeck Docker image does not currently include the [Kubernetes plugin](https://github.com/rundeck-plugins/kubernetes) nor the `aws-iam-authenticator`, `kubectl`, and `aws` command line tools. All of these may be added to the Rundeck image by extending the Dockerfile with additional install steps.
+
+An example Dockerfile that adds the Rundeck k8s module and needed CLI tools:
+```Dockerfile
+ARG RUNDECK_IMAGE
+FROM ${RUNDECK_IMAGE:-rundeck/rundeck:3.2.6-20200427}
+
+# Kubernetes support
+USER root
+RUN apt-get update && sudo apt-get install -y apt-transport-https gnupg2
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update && apt-get install -y \
+  kubectl \
+  apt-transport-https \
+  gnupg2 \
+  python3-pip \
+  awscli \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip3 install kubernetes requests==2.22.0
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Install aws-iam-authenticator
+RUN curl -o aws-iam-authenticator \
+  https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator && \
+  chmod +x ./aws-iam-authenticator && \
+  mv aws-iam-authenticator /usr/local/bin
+
+USER rundeck
+ADD --chown=rundeck:root https://github.com/rundeck-plugins/kubernetes/releases/download/1.0.15/kubernetes-plugin-1.0.15.zip ./libext/
+```

--- a/incubator/rundeck/files/nginx/nginx.conf
+++ b/incubator/rundeck/files/nginx/nginx.conf
@@ -10,6 +10,7 @@ http {
         }
         location / {
             recursive_error_pages on;
+            client_max_body_size 50M; # upload archives (backup/restore)
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header User-Agent $http_user_agent;

--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -21,8 +21,7 @@ spec:
         # This will restart the rundeck pod if its environment configuration is updated by helm
         checksum/config: {{ include (print $.Template.BasePath "/rundeck-environment-configmap.yaml") . | sha256sum }}
         {{- with .Values.deployment.annotations }}
-        annotations:
-          {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "rundeck.name" . }}
@@ -63,6 +62,10 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-environment-configmap
+          {{- if .Values.rundeck.envSecret }}
+          - secretRef:
+              name: {{ .Values.rundeck.envSecret }}
+          {{- end }}
           env:
             - name: RUNDECK_GRAILS_URL
               value: {{ .Values.rundeck.env.RUNDECK_GRAILS_URL }}
@@ -78,9 +81,17 @@ spec:
             mountPath: /home/rundeck/.ssh
             readOnly: true
         {{- end }}
-        {{- if .Values.rundeck.awsCredentialsSecret }}
-          - name: aws-credentials
-            mountPath: /home/rundeck/.aws/credentials
+        {{- if .Values.rundeck.awsConfigSecret }}
+          - name: aws-config
+            mountPath: /home/rundeck/.aws/
+        {{- end }}
+        {{- if .Values.rundeck.kubeConfigSecret }}
+          - name: kube-config
+            mountPath: /home/rundeck/.kube/
+        {{- end }}
+        {{- if .Values.rundeck.extraConfigSecret }}
+          - name: extra-config
+            mountPath: /home/rundeck/extra/
         {{- end }}
           ports:
             - name: rundeck
@@ -134,6 +145,16 @@ spec:
         - name: aws-credentials
           secret:
             secretName: {{ .Values.rundeck.awsCredentialsSecret}}
+        {{- end }}
+        {{- if .Values.rundeck.kubeConfigSecret }}
+        - name: kube-config
+          secret:
+            secretName: {{ .Values.rundeck.kubeConfigSecret}}
+        {{- end }}
+        {{- if .Values.rundeck.extraConfigSecret }}
+        - name: extra-config
+          secret:
+            secretName: {{ .Values.rundeck.extraConfigSecret}}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/incubator/rundeck/values.yaml
+++ b/incubator/rundeck/values.yaml
@@ -30,8 +30,24 @@ rundeck:
     # RUNDECK_PLUGIN_EXECUTIONFILESTORAGE_S3_REGION: ${RUNDECK_PLUGIN_EXECUTIONFILESTORAGE_S3_REGION}
     # RUNDECK_STORAGE_CONVERTER_1_CONFIG_PASSWORD: ${RUNDECK_STORAGE_PASSWORD}
     # RUNDECK_CONFIG_STORAGE_CONVERTER_1_CONFIG_PASSWORD: ${RUNDECK_STORAGE_PASSWORD}
+    # RUNDECK_TOKENS_FILE: /home/rundeck/extra/tokens.properties
+
+  # Name of the secret containing SSH files to mount under ~/.ssh
   # sshSecrets: "ssh-secret"
-  awsCredentialsSecret: ""
+
+  # Name of secret containing to mount under ~/.aws/
+  # awsConfigSecret: "aws-secret"
+
+  # Name of secret to mount under ~/.kube/
+  # kubeConfigSecret: "kube-secret"
+
+  # Name of secret containing additional sensitive Runtime environment variables (eg: RUNDECK_DATABASE_PASSWORD)
+  # See https://hub.docker.com/r/rundeck/rundeck/
+  # envSecret: "env-secret"
+
+  # Name of secret containing additional files to mount into Rundeck's ~/extra directory.
+  # This can be useful for populating a file you reference with RUNDECK_TOKENS_FILE above.
+  # extraConfigSecret: "extra-secret"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
### What this PR does / why we need it:

Changed:
* `rundeck.awsCredentialsSecret` renamed to `rundeck.awsConfigSecret` as it no longer needs to contain only credentials and can be used for all configuration in that directory. Helper text added to README to indicate that this secret is mounted under `~/.aws/`.

New:
* ~~Bump up chart API to v2~~([I read](https://github.com/helm/charts#status-of-the-project)), chart minor version bump to 0.3.0, app version bumped to 3.2.8 (3.3.0 is still in preview) .
* Adds support for specifying the name of an existing secret to add to the Rundeck deployment's `envFrom` for sensitive environment variables (like RUNDECK_DATABASE_PASSWORD).
* Adds support for specifying the name of an existing secret to mount K8s configuration as files under `~/.kube/`. Useful when configuring Rundeck's access to other k8s clusters using config contexts. 
* Adds support for specifying the name of an existing secret to mount as additional configuration files under `~/extra/`. This can be useful for using secrets to configure static API keys file via the RUNDECK_TOKENS_FILE environment variable.
* Helper text in README to show example Dockerfile to extend the Rundeck image according to documentation for adding the kubernetes plugin among other tools. 
* Helper text in README to explain how one might configure AWS IRSA for multi-EKS / multi-AWS access to Rundeck jobs. Great when using the S3 execution log module on EKS!

Fixes:
* Pod spec template annotations were [being double nested](https://github.com/helm/charts/compare/master...mothership:rundeck?expand=1#diff-2e1b506cdb7fa4a7b1c259f684deeeedL24-L25)
* Increases the included Nginx configuration to allow for `client_max_body_size 50M;` which helps when restoring from medium sized project backups.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
