### PR TITLE
[stable/grafana] Create grafana secret for ldap even if admin password is passed via file

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.3.0
+version: 5.3.1
 appVersion: 7.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/secret.yaml
+++ b/stable/grafana/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) }}
+{{- if or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD)) (not .Values.ldap.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,11 +8,13 @@ metadata:
     {{- include "grafana.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) }}
   admin-user: {{ .Values.adminUser | b64enc | quote }}
   {{- if .Values.adminPassword }}
   admin-password: {{ .Values.adminPassword | b64enc | quote }}
   {{- else }}
   admin-password: {{ randAlphaNum 40 | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if not .Values.ldap.existingSecret }}
   ldap-toml: {{ .Values.ldap.config | b64enc | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When GF_SECURITY_ADMIN_PASSWORD__FILE is passed, the 'grafana' secret is not created. However this secret also contains the ldap.toml config which otherwise has to be passed via another secret. This PR allows for the grafana secret to still be created but with only the ldap config.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
