### PR TITLE
[stable/cerebro] Bump version to 0.9.2

### DIFF
--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -1,6 +1,6 @@
 name: cerebro
 version: 1.9.0
-appVersion: 0.9.0
+appVersion: 0.9.2
 apiVersion: v1
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.
 home: https://github.com/lmenezes/cerebro

--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.9.0
+version: 1.9.1
 appVersion: 0.9.2
 apiVersion: v1
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -42,7 +42,7 @@ The following table lists the configurable parameters of the cerebro chart and t
 |-------------------------------------|-------------------------------------|-------------------------------------------|
 | `replicaCount`                      | Number of replicas                  | `1`                                       |
 | `image.repository`                  | The image to run                    | `lmenezes/cerebro`                        |
-| `image.tag`                         | The image tag to pull               | `0.9.0`                                   |
+| `image.tag`                         | The image tag to pull               | `0.9.2`                                   |
 | `image.pullPolicy`                  | Image pull policy                   | `IfNotPresent`                            |
 | `image.pullSecrets`                 | Specify image pull secrets          | `nil` (does not add image pull secrets to deployed pods) |
 | `init.image.repository`             | The image to run                    | `docker.io/busybox`                       |

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: lmenezes/cerebro
   # Note: when updating the version, ensure `config` and the ConfigMap are kept
   # in sync with the default configuration of the upstream image
-  tag: 0.9.0
+  tag: 0.9.2
   pullPolicy: IfNotPresent
 
 deployment:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Bumps cerebro to 0.9.2 (latest), which patches problems when connecting to AWS Elasticsearch

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
