### PR TITLE
[stable/prometheus] Fix rbac for get ingress info

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.6.0
+version: 11.6.1
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -32,7 +32,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
       - ingresses

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -32,6 +32,7 @@ rules:
       - list
       - watch
   - apiGroups:
+      - "extensions"
       - "networking.k8s.io"
     resources:
       - ingresses/status


### PR DESCRIPTION
Signed-off-by: Eugene Medvedev <jidckii@gmail.com>
#### What this PR does / why we need it:
I use kube SD for find ingress endpoint.
Example:
```
  - job_name: kubernetes-ingresses
    params:
      module:
      - http_2xx
    scrape_interval: 1m
    scrape_timeout: 30s
    metrics_path: /probe
    kubernetes_sd_configs:
      - role: ingress
    relabel_configs:
      - source_labels: [__meta_kubernetes_ingress_annotation_prometheus_io_probe]
        action: keep
        regex: true
      - source_labels: [__meta_kubernetes_ingress_scheme,__address__,__meta_kubernetes_ingress_path]
        regex: (.+);(.+);(.+)
        replacement: ${1}://${2}${3}
        target_label: __param_target
      - target_label: __address__
        replacement: blackbox-prometheus-blackbox-exporter:9115
      - source_labels: [__param_target]
        target_label: instance
      - action: labelmap
        regex: __meta_kubernetes_ingress_label_(.+)
      - source_labels: [__meta_kubernetes_namespace]
        target_label: kubernetes_namespace
      - source_labels: [__meta_kubernetes_ingress_name]
        target_label: kubernetes_name
```
But now RBAC have bad rules
logs prometheus:
```
level=info ts=2020-06-30T13:52:35.556Z caller=main.go:827 msg="Completed loading of configuration file" filename=/etc/config/prometheus.yml
level=error ts=2020-06-30T13:52:35.576Z caller=klog.go:94 component=k8s_client_runtime func=ErrorDepth msg="/app/discovery/kubernetes/kubernetes.go:429: Failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:prometheus:prometheus-server\" cannot list resource \"ingresses\" in API group \"networking.k8s.io\" at the cluster scope"
level=error ts=2020-06-30T13:52:37.046Z caller=klog.go:94 component=k8s_client_runtime func=ErrorDepth msg="/app/discovery/kubernetes/kubernetes.go:429: Failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:prometheus:prometheus-server\" cannot list resource \"ingresses\" in API group \"networking.k8s.io\" at the cluster scope"
level=error ts=2020-06-30T13:52:38.808Z caller=klog.go:94 component=k8s_client_runtime func=ErrorDepth msg="/app/discovery/kubernetes/kubernetes.go:429: Failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:prometheus:prometheus-server\" cannot list resource \"ingresses\" in API group \"networking.k8s.io\" at the cluster scope"
```
I use kubernetes version:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.2", GitCommit:"59603c6e503c87169aea6106f57b9f242f64df89", GitTreeState:"clean", BuildDate:"2020-01-18T23:30:10Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.5", GitCommit:"e0fccafd69541e3750d460ba0f9743b90336f24f", GitTreeState:"clean", BuildDate:"2020-04-16T11:35:47Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}

```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
