### PR TITLE
[stable/openvpn] add .Values.openvpn.clientConfServer option

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.2.3
+version: 4.3.0
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -108,6 +108,7 @@ Parameter | Description | Default
 `openvpn.dhcpOptionDomain`           | Push a `dhcp-option DOMAIN` config                                   | `true`
 `openvpn.serverConf`                 | Lines appended to the end of the server configuration file (optional)| `nil`
 `openvpn.clientConf`                 | Lines appended into the client configuration file (optional)         | `nil`
+`openvpn.clientConfServer`           | Replace the IP of the node/service with this String (e.g. hostname)  | `nil`
 `openvpn.redirectGateway`            | Redirect all client traffic through VPN                              | `true`
 `openvpn.useCrl`                     | Use/generate a certificate revocation list (crl.pem)                 | `false`
 `openvpn.taKey`                      | Use/generate a ta.key file for hardening security                    | `false`

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -59,10 +59,18 @@ data:
       client
       nobind
       dev tun
+{{- if and .Values.openvpn.clientConfServer }}
+{{- if eq .Values.service.type "NodePort" }}
+      remote {{ .Values.openvpn.clientConfServer }} {{ .Values.service.nodePort }} {{ .Values.openvpn.OVPN_PROTO }}
+{{- else }}
+      remote {{ .Values.openvpn.clientConfServer }} {{ .Values.service.externalPort }} {{ .Values.openvpn.OVPN_PROTO }}
+{{- end }}
+{{- else }}
 {{- if eq .Values.service.type "NodePort" }}
       remote ${MY_IP_ADDR} {{ .Values.service.nodePort }} {{ .Values.openvpn.OVPN_PROTO }}
 {{- else }}
       remote ${MY_IP_ADDR} {{ .Values.service.externalPort }} {{ .Values.openvpn.OVPN_PROTO }}
+{{- end }}
 {{- end }}
       {{ if .Values.openvpn.cipher }}
       cipher {{ .Values.openvpn.cipher }}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -108,6 +108,10 @@ openvpn:
   #  max-clients 100
   #  client-to-client
 
+  ## You can override the 'remote' config host in the client config with this
+  ## e.g. clientConfServer: "vpn.dev.example.com"
+  # clientConfServer: ""
+
   # Lines appended to the end of the client configuration file
   # Example: if all of your clients are Ubuntu (18.04+) you may need to install
   # the update-systemd-resolved package (apt install update-systemd-resolved) then


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds an option to override the server in the remote endpoint
configuration of clients.

This is helpful if the Service is using a LoadBalancer and external-dns to support changes to the LoadBalancer IP when e.g. recreating clusters without needing to rewrite all client configs.

@jasongwartz, @dippynark, I’d be happy about your feedback :) 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
