### PR TITLE
[stable/airflow] Adding basic auth values for flower

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.1.6
+version: 7.2.0
 appVersion: 1.10.10
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -39,6 +39,7 @@ kubectl exec \
 > NOTE: for chart version numbers, see [Chart.yaml](Chart.yaml) or [helm hub](https://hub.helm.sh/charts/stable/airflow).
 
 For steps you must take when upgrading this chart, please review:
+* [v7.1.X → v7.2.0](UPGRADE.md#v71x--v720)
 * [v7.0.X → v7.1.0](UPGRADE.md#v70x--v710)
 * [v6.X.X → v7.0.0](UPGRADE.md#v6xx--v700)
 * [v5.X.X → v6.0.0](UPGRADE.md#v5xx--v600)
@@ -538,7 +539,6 @@ __Airflow Scheduler values:__
 | `scheduler.podLabels` | Pod labels for the scheduler Deployment | `{}` |
 | `scheduler.annotations` | annotations for the scheduler Deployment | `{}` |
 | `scheduler.podAnnotations` | Pod Annotations for the scheduler Deployment | `{}` |
-| `scheduler.podAnnotations` | Pod Annotations for the scheduler Deployment | `{}` |
 | `scheduler.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the scheduler | `<see values.yaml>` |
 | `scheduler.connections` | custom airflow connections for the airflow scheduler | `[]` |
 | `scheduler.variables` | custom airflow variables for the airflow scheduler | `"{}"` |
@@ -608,6 +608,8 @@ __Airflow Flower Values:__
 | `flower.podLabels` | Pod labels for the flower Deployment | `{}` |
 | `flower.annotations` | annotations for the flower Deployment | `{}` |
 | `flower.podAnnotations` | Pod annotations for the flower Deployment | `{}` |
+| `flower.basicAuthSecret` | the name of a pre-created secret containing the basic authentication value for flower | `""` |
+| `flower.basicAuthSecretKey` | the key within `flower.basicAuthSecret` containing the basic authentication string | `""` |
 | `flower.urlPrefix` | sets `AIRFLOW__CELERY__FLOWER_URL_PREFIX` | `""` |
 | `flower.service.*` | configs for the Service of the flower Pods | `<see values.yaml>` |
 | `flower.initialStartupDelay` | the number of seconds to wait (in bash) before starting the flower container | `0` |
@@ -658,7 +660,7 @@ __Airflow Database (Internal PostgreSQL) Values:__
 | `postgresql.postgresqlUsername` | the postgres user to create | `postgres` |
 | `postgresql.postgresqlPassword` | the postgres user's password | `airflow` |
 | `postgresql.existingSecret` | the name of a pre-created secret containing the postgres password | `""` |
-| `postgresql.existingSecretKey` | the name of a pre-created secret containing the postgres password | `postgresql-password` |
+| `postgresql.existingSecretKey` | the key within `postgresql.passwordSecret` containing the password string | `postgresql-password` |
 | `postgresql.persistence.*` | configs for the PVC of postgresql | `<see values.yaml>` |
 
 __Airflow Database (External) Values:__
@@ -680,7 +682,7 @@ __Airflow Redis (Internal) Values:__
 | `redis.enabled` | if the `stable/redis` chart is used | `true` |
 | `redis.password` | the redis password | `airflow` |
 | `redis.existingSecret` | the name of a pre-created secret containing the redis password | `""` |
-| `redis.existingSecretKey` | the key in `redis.existingSecret` containing the password string | `redis-password` |
+| `redis.existingSecretKey` | the key within `redis.existingSecret` containing the password string | `redis-password` |
 | `redis.cluster.*` | configs for redis cluster mode | `<see values.yaml>` |
 | `redis.master.*` | configs for the redis master | `<see values.yaml>` |
 | `redis.slave.*` | configs for the redis slaves | `<see values.yaml>` |
@@ -693,7 +695,7 @@ __Airflow Redis (External) Values:__
 | `externalRedis.port` | the port of the external redis | `6379` |
 | `externalRedis.databaseNumber` | the database number to use within the the external redis | `1` |
 | `externalRedis.passwordSecret` | the name of a pre-created secret containing the external redis password | `""` |
-| `externalRedis.passwordSecretKey` | the name of a pre-created secret containing the external redis password | `redis-password` |
+| `externalRedis.passwordSecretKey` | the key within `externalRedis.passwordSecret` containing the password string | `redis-password` |
 
 __Airflow Prometheus Values:__
 

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrading Steps
 
+## `v7.1.X` → `v7.2.0`
+
+__The following IMPROVEMENTS have been made:__
+
+* Fixed Flower's liveness probe when Basic Authentication is enabled for Flower.
+  You can specify a basic auth value via a Kubernetes Secret using the values `flower.basicAuthSecret` and `flower.basicAuthSecretKey`.
+  The secret value will get encoded and included in the liveness probe's header.
+
+__The following values have been ADDED:__
+
+* `flower.basicAuthSecret`
+* `flower.basicAuthSecretKey`
+
 ## `v7.0.X` → `v7.1.0`
 
 __The following IMPROVEMENTS have been made:__

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -166,6 +166,16 @@ When applicable, we use the secrets created by the postgres/redis charts (which 
 {{- end }}
 {{- end }}
 {{- /* ---------------------------- */ -}}
+{{- /* ---------- FLOWER ---------- */ -}}
+{{- /* ---------------------------- */ -}}
+{{- if and (.Values.flower.basicAuthSecret) (not .Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH) }}
+- name: AIRFLOW__CELERY__FLOWER_BASIC_AUTH
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.flower.basicAuthSecret }}
+      key: {{ .Values.flower.basicAuthSecretKey }}
+{{- end }}
+{{- /* ---------------------------- */ -}}
 {{- /* ---------- EXTRAS ---------- */ -}}
 {{- /* ---------------------------- */ -}}
 {{- if .Values.airflow.extraEnv }}

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -113,6 +113,19 @@ spec:
                && echo "*** running flower..." \
                && exec airflow flower
           livenessProbe:
+            {{- if and (.Values.flower.basicAuthSecret) (not .Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH) }}
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "curl -H 'Authorization: Basic $(echo -n $AIRFLOW__CELERY__FLOWER_BASIC_AUTH | base64)' 'http://localhost:5555
+                  {{- if .Values.ingress.flower.livenessPath -}}
+                  {{ .Values.ingress.flower.livenessPath }}
+                  {{- else -}}
+                  {{ .Values.ingress.flower.path }}/
+                  {{- end -}}
+                  '"
+            {{- else }}
             httpGet:
               {{- if .Values.ingress.flower.livenessPath }}
               path: "{{ .Values.ingress.flower.livenessPath }}"
@@ -120,6 +133,12 @@ spec:
               path: "{{ .Values.ingress.flower.path }}/"
               {{- end }}
               port: flower
+              {{- if .Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH | b64enc }}
+              {{- end }}
+            {{- end }}
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 1

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -611,6 +611,17 @@ flower:
   ##
   podAnnotations: {}
 
+  ## the name of a pre-created secret containing the basic authentication value for flower
+  ##
+  ## NOTE:
+  ## - This sets `AIRFLOW__CELERY__FLOWER_BASIC_AUTH`
+  ##
+  basicAuthSecret: ""
+
+  ## the key within `flower.basicAuthSecret` containing the basic authentication string
+  ##
+  basicAuthSecretKey: ""
+
   ## sets `AIRFLOW__CELERY__FLOWER_URL_PREFIX`
   ##
   ## NOTE:
@@ -1113,7 +1124,7 @@ postgresql:
   ##
   existingSecret: ""
 
-  ## the key in `postgresql.existingSecret` containing the password string
+  ## the key within `postgresql.existingSecret` containing the password string
   ##
   existingSecretKey: "postgresql-password"
 
@@ -1197,7 +1208,7 @@ redis:
   ##
   existingSecret: ""
 
-  ## the key in `redis.existingSecret` containing the password string
+  ## the key within `redis.existingSecret` containing the password string
   ##
   existingSecretKey: "redis-password"
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Adds the values:
| Parameter | Description | Default |
| --- | --- | --- |
| `flower.basicAuthSecret` | the name of a pre-created secret containing the basic authentication value for flower | `""` |
| `flower.basicAuthSecretKey` | the key within `flower.basicAuthSecret` containing the basic authentication string | `""` |

This will allow specifying a secret that will set the config setting `AIRFLOW__CELERY__FLOWER_BASIC_AUTH`.

The main reason for adding `flower.basicAuthSecret` and `flower.basicAuthSecretKey` (other than making it easier to provide the secret) is so if it is set it will change the Liveness Probe method from `httpGet` to `exec` with the command `curl` using an `Authorization` header containing the environment variable `AIRFLOW__CELERY__FLOWER_BASIC_AUTH` base64 encoded.

Also added is support for including the `Authorization` header if you specify `AIRFLOW__CELERY__FLOWER_BASIC_AUTH` in `airflow.config`.

More explanation of the Liveness Probe issue can be found in issue #23031

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #23031

#### Special notes for your reviewer:
Also fixed some of the readme and docstrings for the other secret values so they are all consistant.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
