### PR TITLE
[stable/openvpn] Additional routes can be added to openvpn.conf

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.2.3
+version: 4.2.4
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -105,6 +105,8 @@ Parameter | Description | Default
 `openvpn.OVPN_K8S_SVC_NETWORK`       | Kubernetes service network (optional)                                | `nil`
 `openvpn.OVPN_K8S_SVC_SUBNET`        | Kubernetes service network subnet (optional)                         | `nil`
 `openvpn.DEFAULT_ROUTE_ENABLED`      | Push a route which openvpn sets by default                           | `true`
+`openvpn.additionalConfigs.enabled`  | Enables additional routes to be added to openvpn.conf                | `false`
+`openvpn.additionalConfigs.routes`   | Push additional routes to openvpn                                    | `[]`
 `openvpn.dhcpOptionDomain`           | Push a `dhcp-option DOMAIN` config                                   | `true`
 `openvpn.serverConf`                 | Lines appended to the end of the server configuration file (optional)| `nil`
 `openvpn.clientConf`                 | Lines appended into the client configuration file (optional)         | `nil`

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -216,7 +216,6 @@ data:
       push "route {{ .Values.openvpn.OVPN_K8S_SVC_NETWORK }} {{ .Values.openvpn.OVPN_K8S_SVC_SUBNET }}"
 {{ end }}
 
-# Add any additional routes if specified:
 {{ if .Values.openvpn.additionalConfigs.enabled }}
   {{ range .Values.openvpn.additionalConfigs.routes }}
       push "{{ . }}"

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -216,6 +216,13 @@ data:
       push "route {{ .Values.openvpn.OVPN_K8S_SVC_NETWORK }} {{ .Values.openvpn.OVPN_K8S_SVC_SUBNET }}"
 {{ end }}
 
+# Add any additional routes if specified:
+{{ if .Values.openvpn.additionalConfigs.enabled }}
+  {{ range .Values.openvpn.additionalConfigs.routes }}
+      push "{{ . }}"
+  {{ end }}
+{{ end }}
+
 {{ if .Values.openvpn.dhcpOptionDomain }}
       OVPN_K8S_SEARCH
 {{ end }}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -88,6 +88,15 @@ openvpn:
   # OVPN_K8S_SVC_SUBNET:
   # Set default route which openvpn figures basing on network routes inside openvpn pod
   DEFAULT_ROUTE_ENABLED: true
+  
+  additionalConfigs:
+    enabled: false
+    # Additional routes to add to openvpn.conf:
+    routes: []
+    # Example:
+    # - "route 10.0.0.0 255.255.0.0"
+    # The above example adds: `push "route 10.0.0.0 255.255.0.0"` to openvpn.conf
+
   # Server certificate data
   # keystoreSecret:
   # secret with openvpn certificates. If specified, certificates are taken from the secret

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -88,7 +88,7 @@ openvpn:
   # OVPN_K8S_SVC_SUBNET:
   # Set default route which openvpn figures basing on network routes inside openvpn pod
   DEFAULT_ROUTE_ENABLED: true
-  
+
   additionalConfigs:
     enabled: false
     # Additional routes to add to openvpn.conf:


### PR DESCRIPTION
### What this PR does / why we need it:
- Adds the ability to have custom routes for openvpn.conf to push.
  - Set `openvpn.additionalConfigs.enabled` to true and add list of strings in format:  `- "route <NETWORK> <SUBNET>"` to `openvpn.additionalConfigs.routes`
  - These will be added to the openvpn.conf in format: `push "route <NETWORK> <SUBNET>"`


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
