### PR TITLE
[stable/minio] Support imagePullSecrets for StatefulSet.

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.31
+version: 5.0.32
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/templates/_helpers.tpl
+++ b/stable/minio/templates/_helpers.tpl
@@ -94,3 +94,28 @@ Properly format optional additional arguments to Minio binary
 {{ " " }}{{ . }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "minio.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets: 
+    {{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets: 
+    {{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- end -}}

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -227,9 +227,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- if .Values.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
-{{- end }}
+{{- include "minio.imagePullSecrets" . | indent 6 }}
 {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -25,6 +25,7 @@ spec:
 {{- end }}
     spec:
       restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/stable/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -28,6 +28,7 @@ spec:
       serviceAccountName: {{ $fullName }}-update-prometheus-secret
 {{- end }}
       restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -176,6 +176,9 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+{{- end }}
     {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -176,9 +176,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-{{- if .Values.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
-{{- end }}
+{{- include "minio.imagePullSecrets" . | indent 6 }}
     {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
Signed-off-by: Jonas Rabouli <jonas.h@rabouli.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds imagePullSecret support for StatefulSet.
This is required if anyone wishes to run MinIO in distributed mode, and are pulling images from a private repository.

#### Which issue this PR fixes
  - fixes #23041

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
