### PR TITLE
[incubator/druid] modify the default value by nano-quickstart to decrease memory cost

### DIFF
--- a/incubator/druid/Chart.yaml
+++ b/incubator/druid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: Apache Druid is a high performance real-time analytics database.
 name: druid
-version: 0.2.6
+version: 0.2.7
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
 maintainers:

--- a/incubator/druid/values.yaml
+++ b/incubator/druid/values.yaml
@@ -71,10 +71,10 @@ broker:
   resources: {}
     # limits:
     #   cpu: 1
-    #   memory: 8Gi
+    #   memory: 1Gi
     # requests:
     #   cpu: 250m
-    #   memory: 4Gi
+    #   memory: 512Mi
 
   nodeSelector: {}
 
@@ -115,7 +115,7 @@ coordinator:
   resources: {}
     # limits:
     #   cpu: 500m
-    #   memory: 2Gi
+    #   memory: 1Gi
     # requests:
     #   cpu: 250m
     #   memory: 512Mi
@@ -179,6 +179,7 @@ historical:
     druid_processing_numMergeBuffers: 2
     druid_processing_numThreads: 1
     # druid_monitoring_monitors: '["org.apache.druid.client.cache.CacheMonitor", "org.apache.druid.server.metrics.HistoricalMetricsMonitor", "org.apache.druid.server.metrics.QueryCountStatsMonitor"]'
+    # druid_segmentCache_locations: '[{"path":"/var/druid/segment-cache","maxSize":300000000000}]'
 
   ingress:
     enabled: false
@@ -209,15 +210,14 @@ historical:
 
   resources: {}
     # limits:
-    #   cpu: 1
-    #   memory: 8Gi
+    #   cpu: 2
+    #   memory: 2Gi
     # requests:
-    #   cpu: 250m
-    #   memory: 4Gi
+    #   cpu: 500m
+    #   memory: 512Mi
 
   ## (dict) If specified, apply these annotations to each master Pod
   podAnnotations: {}
-  #   example: master-foo
 
   podDisruptionBudget:
     enabled: false
@@ -290,10 +290,10 @@ middleManager:
   resources: {}
     # limits:
     #   cpu: 500m
-    #   memory: 2Gi
+    #   memory: 1Gi
     # requests:
     #   cpu: 250m
-    #   memory: 512Mi
+    #   memory: 256Mi
 
   ## (dict) If specified, apply these annotations to each master Pod
   podAnnotations: {}
@@ -335,11 +335,11 @@ router:
 
   resources: {}
     # limits:
-    #   cpu: 500m
-    #   memory: 2Gi
-    # requests:
     #   cpu: 250m
-    #   memory: 512Mi
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
   nodeSelector: {}
 

--- a/incubator/druid/values.yaml
+++ b/incubator/druid/values.yaml
@@ -13,28 +13,25 @@ configMap:
 
 ## Define the key value pairs in the configmap
 configVars:
-  DRUID_XMX: 1g
-  DRUID_XMS: 1g
-  DRUID_MAXNEWSIZE: 250m
-  DRUID_NEWSIZE: 250m
-  DRUID_MAXDIRECTMEMORYSIZE: 10000m
+  ## DRUID env vars. ref: https://github.com/apache/druid/blob/master/distribution/docker/druid.sh#L29
+  # DRUID_LOG_LEVEL: "warn"
+  # DRUID_LOG4J: <?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
   DRUID_USE_CONTAINER_IP: "true"
-  druid_processing_numThreads: "3"
+
+  ## Druid Common Configurations. ref: https://druid.apache.org/docs/latest/configuration/index.html#common-configurations
   druid_extensions_loadList: '["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage"]'
   druid_metadata_storage_type: postgresql
   druid_metadata_storage_connector_connectURI: jdbc:postgresql://postgres:5432/druid
   druid_metadata_storage_connector_user: druid
   druid_metadata_storage_connector_password: druid
-  druid_coordinator_balancer_strategy: cachingCost
-  druid_indexer_runner_javaOptsArray: '["-server", "-Xmx1g", "-Xms1g", "-XX:MaxDirectMemorySize=3g", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]'
-  druid_indexer_fork_property_druid_processing_buffer_sizeBytes: '268435456'
   druid_storage_type: local
   druid_indexer_logs_type: file
   druid_indexer_logs_directory: /opt/data/indexing-logs
+
+  ## Druid Emitting Metrics. ref: https://druid.apache.org/docs/latest/configuration/index.html#emitting-metrics
   druid_emitter: noop
   druid_emitter_logging_logLevel: debug
   druid_emitter_http_recipientBaseUrl: http://druid_exporter_url:druid_exporter_port/druid
-  DRUID_LOG4J: <?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
 
 gCloudStorage:
   enabled: false
@@ -50,7 +47,12 @@ broker:
   serviceType: ClusterIP
 
   config:
-    JAVA_OPTS: "-Xms2G -Xmx2G -XX:MaxDirectMemorySize=8g"
+    DRUID_XMX: 512m
+    DRUID_XMS: 512m
+    DRUID_MAXDIRECTMEMORYSIZE: 400m
+    druid_processing_buffer_sizeBytes: '50000000'
+    druid_processing_numMergeBuffers: 2
+    druid_processing_numThreads: 1
     # druid_monitoring_monitors: '["org.apache.druid.client.cache.CacheMonitor", "org.apache.druid.server.metrics.QueryCountStatsMonitor"]'
 
   ingress:
@@ -92,7 +94,9 @@ coordinator:
   serviceType: ClusterIP
 
   config:
-    JAVA_OPTS: "-Xms1G -Xmx1G"
+    DRUID_XMX: 256m
+    DRUID_XMS: 256m
+    druid_coordinator_balancer_strategy: cachingCost
     # druid_monitoring_monitors: '["org.apache.druid.server.metrics.TaskCountStatsMonitor"]'
 
   ingress:
@@ -168,7 +172,12 @@ historical:
   serviceType: ClusterIP
 
   config:
-    JAVA_OPTS: "-Xms2G -Xmx2G -XX:MaxDirectMemorySize=8g"
+    DRUID_XMX: 512m
+    DRUID_XMS: 512m
+    DRUID_MAXDIRECTMEMORYSIZE: 400m
+    druid_processing_buffer_sizeBytes: '50000000'
+    druid_processing_numMergeBuffers: 2
+    druid_processing_numThreads: 1
     # druid_monitoring_monitors: '["org.apache.druid.client.cache.CacheMonitor", "org.apache.druid.server.metrics.HistoricalMetricsMonitor", "org.apache.druid.server.metrics.QueryCountStatsMonitor"]'
 
   ingress:
@@ -228,8 +237,10 @@ middleManager:
   serviceType: ClusterIP
 
   config:
-    JAVA_OPTS: "-Xms1G -Xmx1G"
-    # druid_monitoring_monitors: '["org.apache.druid.java.util.metrics.SysMonitor"]'
+    DRUID_XMX: 64m
+    DRUID_XMS: 64m
+    druid_indexer_runner_javaOptsArray: '["-server", "--Xms256m", "-Xmx256m", "-XX:MaxDirectMemorySize=300m", "-Duser.timezone=UTC", "-Dfile.encoding=UTF-8", "-XX:+ExitOnOutOfMemoryError", "-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]'
+    druid_indexer_fork_property_druid_processing_buffer_sizeBytes: '25000000'
 
   autoscaling:
     enabled: false
@@ -286,7 +297,6 @@ middleManager:
 
   ## (dict) If specified, apply these annotations to each master Pod
   podAnnotations: {}
-  #   example: master-foo
 
   podDisruptionBudget:
     enabled: false
@@ -306,7 +316,9 @@ router:
   serviceType: ClusterIP
 
   config:
-    JAVA_OPTS: "-Xms1G -Xmx1G"
+    DRUID_XMX: 128m
+    DRUID_XMS: 128m
+    DRUID_MAXDIRECTMEMORYSIZE: 128m
 
   ingress:
     enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No
#### What this PR does / why we need it:

Bug:
If there are `DRUID_XMX`, `DRUID_XMS`, `DRUID_MAXDIRECTMEMORYSIZE` at env vars, then `JAVA_OPTS` can not work. On the other hand, different role want different **java jvm settings**.

Solution:
remove `DRUID_XMX`, `DRUID_XMS`, `DRUID_MAXDIRECTMEMORYSIZE`, `DRUID_MAXNEWSIZE`, `DRUID_NEWSIZE` so on settings from common `configVars` to role's `config`

BTW, modify the default value by [nano-quickstart](https://github.com/apache/druid/tree/master/examples/conf/druid/single-server/nano-quickstart). It only cost 1.7Gi memory to install the *nano-quickstart* incubator/druid for a demo.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #22778

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
