### PR TITLE
[stable/fluentd] Update Fluentd image, service account annotations and documentation

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,13 +2,12 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.5.1
-appVersion: v2.4.0
+version: 3.0.0
+appVersion: 3.0.4
 home: https://www.fluentd.org/
 sources:
 - https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image
-- https://quay.io/repository/coreos/fluentd-kubernetes
-- https://github.com/coreos/fluentd-kubernetes-daemonset
+- https://quay.io/repository/fluentd_elasticsearch/fluentd
 - https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 maintainers:
 - name: rendhalver

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -42,59 +42,61 @@ The autoscaling is disabled by default for backward compatibility
 
 The following table lists the configurable parameters of the fluentd chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`useStatefulSet` | Deploy as a StatefulSet regardless of whether autoscaling is enabled | `nil`
-`affinity` | node/pod affinities | `{}`
-`configMaps` | Fluentd configuration | See [values.yaml](values.yaml)
-`output.host` | output host | `elasticsearch-client.default.svc.cluster.local`
-`output.port` | output port | `9200`
-`output.scheme` | output scheme | `http`
-`output.sslVersion` | output ssl version | `TLSv1`
-`output.buffer_chunk_limit` | output buffer chunk limit | `2M`
-`output.buffer_queue_limit` | output buffer queue limit | `8`
-`deployment.labels` | Additional labels for pods | `{}`
-`image.pullPolicy` | Image pull policy | `IfNotPresent`
-`image.repository` | Image repository | `gcr.io/google-containers/fluentd-elasticsearch`
-`image.tag` | Image tag | `v2.4.0`
-`imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
-`extraEnvVars` | Adds additional environment variables to the deployment (in yaml syntax) | `{}` See [values.yaml](values.yaml)
-`extraVolumeMounts` | Mount extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)
-`extraVolumes` | Extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)
-`ingress.enabled` | enable ingress | `false`
-`ingress.labels` | list of labels for the ingress rule | See [values.yaml](values.yaml)
-`ingress.annotations` | list of annotations for the ingress rule | `kubernetes.io/ingress.class: nginx` See [values.yaml](values.yaml)
-`ingress.hosts` | host definition for ingress | See [values.yaml](values.yaml)
-`ingress.tls` | tls rules for ingress | See [values.yaml](values.yaml)
-`nodeSelector` | node labels for pod assignment | `{}`
-`replicaCount` | desired number of pods | `1` ???
-`resources` | pod resource requests & limits | `{}`
-`plugins.enabled` | Enable Plugins Installation | `false`
-`plugins.pluginsList` | List of plugins to install | `[]`
-`rbac.create` | Specifies whether RBAC resources should be created | `true`
-`serviceAccount.create` | Specifies whether a service account should be created. | `true`
-`serviceAccount.name` | Name of the service account.
-`priorityClassName` | priorityClassName | `nil`
-`service.loadBalancerIP` | If `service.type` is `LoadBalancer` set custom IP load balancer IP address | `nil`
-`service.ports` | port definition for the service | See [values.yaml](values.yaml)
-`service.type` | type of service | `ClusterIP`
-`service.annotations` | list of annotations for the service | `{}`
-`tolerations` | List of node taints to tolerate | `[]`
-`persistence.enabled` | Enable buffer persistence | `false`
-`persistence.accessMode` | Access mode for buffer persistence | `ReadWriteOnce`
-`persistence.size` | Volume size for buffer persistence | `10Gi`
-`autoscaling.enabled` | Set this to `true` to enable autoscaling | `false`
-`autoscaling.minReplicas` | Set minimum number of replicas | `2`
-`autoscaling.maxReplicas` | Set maximum number of replicas | `5`
-`autoscaling.metrics` | metrics used for autoscaling | See [values.yaml](values.yaml)
-`terminationGracePeriodSeconds` | Optional duration in seconds the pod needs to terminate gracefully | `30`
-`metrics.enabled`                         | Set this to `true` to enable Prometheus metrics HTTP endpoint                         | `false`
-`metrics.service.port`                    | Prometheus metrics HTTP endpoint port                                                 | `24231`
-`metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`
-`metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
-`metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                  | `nil`
-`metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used           | `nil`
-`metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used             | `nil`
+| Parameter                                 | Description                                                                           | Default                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `image.repository`                        | Image repository                                                                      | `quay.io/fluentd_elasticsearch/fluentd`                             |
+| `image.tag`                               | Image tag                                                                             | `v3.0.4`                                                            |
+| `image.pullPolicy`                        | Image pull policy                                                                     | `IfNotPresent`                                                      |
+| `image.pullSecrets`                       | Specify image pull secrets                                                            | `nil`                                                               |
+| `useStatefulSet`                          | Deploy as a StatefulSet regardless of whether autoscaling is enabled                  | `false`                                                             |
+| `replicaCount`                            | desired number of pods                                                                | `1`                                                                 |
+| `affinity`                                | node/pod affinities                                                                   | `{}`                                                                |
+| `configMaps`                              | Fluentd configuration                                                                 | See [values.yaml](values.yaml)                                      |
+| `output.host`                             | output host                                                                           | `elasticsearch-client.default.svc.cluster.local`                    |
+| `output.port`                             | output port                                                                           | `9200`                                                              |
+| `output.scheme`                           | output scheme                                                                         | `http`                                                              |
+| `output.sslVersion`                       | output ssl version                                                                    | `TLSv1`                                                             |
+| `output.buffer_chunk_limit`               | output buffer chunk limit                                                             | `2M`                                                                |
+| `output.buffer_queue_limit`               | output buffer queue limit                                                             | `8`                                                                 |
+| `deployment.labels`                       | Additional labels for pods                                                            | `{}`                                                                |
+| `extraEnvVars`                            | Adds additional environment variables to the deployment (in yaml syntax)              | `{}` See [values.yaml](values.yaml)                                 |
+| `extraVolumeMounts`                       | Mount extra volumes (in yaml syntax)                                                  | `` See [values.yaml](values.yaml)                                   |
+| `extraVolumes`                            | Extra volumes (in yaml syntax)                                                        | `` See [values.yaml](values.yaml)                                   |
+| `ingress.enabled`                         | enable ingress                                                                        | `false`                                                             |
+| `ingress.labels`                          | list of labels for the ingress rule                                                   | See [values.yaml](values.yaml)                                      |
+| `ingress.annotations`                     | list of annotations for the ingress rule                                              | `kubernetes.io/ingress.class: nginx` See [values.yaml](values.yaml) |
+| `ingress.hosts`                           | host definition for ingress                                                           | See [values.yaml](values.yaml)                                      |
+| `ingress.tls`                             | tls rules for ingress                                                                 | See [values.yaml](values.yaml)                                      |
+| `nodeSelector`                            | node labels for pod assignment                                                        | `{}`                                                                |
+| `resources`                               | pod resource requests & limits                                                        | `{}`                                                                |
+| `plugins.enabled`                         | Enable Plugins Installation                                                           | `false`                                                             |
+| `plugins.runCommand`                      | The command to run after the plugins have been installed to start fluentd             | `/entrypoint.sh`                                                    |
+| `plugins.pluginsList`                     | List of plugins to install                                                            | `[]`                                                                |
+| `rbac.create`                             | Specifies whether RBAC resources should be created                                    | `true`                                                              |
+| `serviceAccount.create`                   | Specifies whether a service account should be created                                 | `true`                                                              |
+| `serviceAccount.name`                     | Name of the service account                                                           | `nil`                                                               |
+| `serviceAccount.annotations`              | Annotations to add to the service account                                             | `{}`                                                                |
+| `priorityClassName`                       | priorityClassName                                                                     | `nil`                                                               |
+| `service.loadBalancerIP`                  | If `service.type` is `LoadBalancer` set custom IP load balancer IP address            | `nil`                                                               |
+| `service.ports`                           | port definition for the service                                                       | See [values.yaml](values.yaml)                                      |
+| `service.type`                            | type of service                                                                       | `ClusterIP`                                                         |
+| `service.annotations`                     | list of annotations for the service                                                   | `{}`                                                                |
+| `tolerations`                             | List of node taints to tolerate                                                       | `[]`                                                                |
+| `persistence.enabled`                     | Enable buffer persistence                                                             | `false`                                                             |
+| `persistence.accessMode`                  | Access mode for buffer persistence                                                    | `ReadWriteOnce`                                                     |
+| `persistence.size`                        | Volume size for buffer persistence                                                    | `10Gi`                                                              |
+| `autoscaling.enabled`                     | Set this to `true` to enable autoscaling                                              | `false`                                                             |
+| `autoscaling.minReplicas`                 | Set minimum number of replicas                                                        | `2`                                                                 |
+| `autoscaling.maxReplicas`                 | Set maximum number of replicas                                                        | `5`                                                                 |
+| `autoscaling.metrics`                     | metrics used for autoscaling                                                          | See [values.yaml](values.yaml)                                      |
+| `terminationGracePeriodSeconds`           | Optional duration in seconds the pod needs to terminate gracefully                    | `30`                                                                |
+| `metrics.enabled`                         | Set this to `true` to enable Prometheus metrics HTTP endpoint                         | `false`                                                             |
+| `metrics.service.port`                    | Prometheus metrics HTTP endpoint port                                                 | `24231`                                                             |
+| `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                                                             |
+| `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                                                                |
+| `metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                  | `nil`                                                               |
+| `metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used           | `nil`                                                               |
+| `metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used             | `nil`                                                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/fluentd/templates/configmap.yaml
+++ b/stable/fluentd/templates/configmap.yaml
@@ -33,5 +33,5 @@ data:
   {{- range $plugin := .Values.plugins.pluginsList }}
     fluent-gem install {{ $plugin }}
   {{- end }}
-    exec /run.sh
+    exec {{ .Values.plugins.runCommand }}
 {{- end }}

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -16,14 +16,14 @@ spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
-{{- if .Values.autoscaling.enabled }}
+{{- if $statefulSet }}
   serviceName: {{ template "fluentd.name" . }}
 {{- end }}
   selector:
     matchLabels:
       app: {{ template "fluentd.name" . }}
       release: {{ .Release.Name }}
-  {{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) }}
+  {{- if and .Values.persistence.enabled (not $statefulSet) }}
   strategy:
     type: Recreate
   {{- end }}

--- a/stable/fluentd/templates/hpa.yaml
+++ b/stable/fluentd/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.autoscaling.enabled}}
+{{- if .Values.autoscaling.enabled}}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/stable/fluentd/templates/serviceaccount.yaml
+++ b/stable/fluentd/templates/serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluentd.serviceAccountName" . }}
+  annotations:
+  {{- if .Values.serviceAccount.annotations }}
+    {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ template "fluentd.name" . }}
     chart: {{ template "fluentd.chart" . }}

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -1,7 +1,6 @@
 # Default values for fluentd.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 1
 
 image:
   repository: quay.io/fluentd_elasticsearch/fluentd

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -4,12 +4,15 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/google-containers/fluentd-elasticsearch
-  tag: v2.4.0
+  repository: quay.io/fluentd_elasticsearch/fluentd
+  tag: v3.0.4
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - secret1
   #   - secret2
+
+useStatefulSet: false
+replicaCount: 1
 
 output:
   host: elasticsearch-client.default.svc.cluster.local
@@ -41,6 +44,7 @@ extraEnvVars:
 
 plugins:
   enabled: false
+  runCommand: "/entrypoint.sh"
   pluginsList: []
 
 service:
@@ -178,6 +182,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  annotations: {}
 
 ## Persist data to a persistent volume
 persistence:


### PR DESCRIPTION
#### Is this a new chart

This is an existing chart and it needs updating in this repo as there are no other charts currently available that do everything this one does. With these changes hopefully this chart will be more relevant to the ongoing work on `fluent/fluentd` (currently only a daemonset).

#### What this PR does / why we need it:

- Update the docker image (both registry and tag) to bring it up to date
- Allow for a dynamic command to be run after installing plugins to support other images
- Add support for service account annotations which are required for AWS IRSA support
- Tidy up documentation

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

This PR can replace #22842 (open) and #22424 (closed due to inactivity).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
