### PR TITLE
[stable/prometheus-pushgateway]: Fix release namespace

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/templates/deployment.yaml
+++ b/stable/prometheus-pushgateway/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:

--- a/stable/prometheus-pushgateway/templates/ingress.yaml
+++ b/stable/prometheus-pushgateway/templates/ingress.yaml
@@ -19,6 +19,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   name: {{ template "prometheus-pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}

--- a/stable/prometheus-pushgateway/templates/networkpolicy.yaml
+++ b/stable/prometheus-pushgateway/templates/networkpolicy.yaml
@@ -9,6 +9,7 @@ metadata:
 {{- else -}}
 {{- fail "One of `allowAll` or `customSelectors` must be specified." }}
 {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:

--- a/stable/prometheus-pushgateway/templates/pdb.yaml
+++ b/stable/prometheus-pushgateway/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
 spec:

--- a/stable/prometheus-pushgateway/templates/pushgateway-pvc.yaml
+++ b/stable/prometheus-pushgateway/templates/pushgateway-pvc.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.persistentVolumeLabels) .  }}
   name: {{ template "prometheus-pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.persistentVolume.accessModes | indent 4 }}

--- a/stable/prometheus-pushgateway/templates/service.yaml
+++ b/stable/prometheus-pushgateway/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
 {{ .Values.serviceAnnotations | toYaml | indent 4 }}
   labels:

--- a/stable/prometheus-pushgateway/templates/serviceaccount.yaml
+++ b/stable/prometheus-pushgateway/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-pushgateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceAccountLabels) .  }}
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Add release namespace to resources

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

cc @gianrubio @cstaud