### PR TITLE
[stable/prometheus-pushgateway] Fix networkPolicy podSelector and ingress rule

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/templates/networkpolicy.yaml
+++ b/stable/prometheus-pushgateway/templates/networkpolicy.yaml
@@ -15,13 +15,12 @@ spec:
   podSelector:
     matchLabels:
       app: {{ template "prometheus-pushgateway.name" .}}
+      release: {{ .Release.Name }}
   ingress:
     - ports:
       - port: {{ .Values.service.targetPort }}
 {{- if .Values.networkPolicy.customSelectors }}
-    - from:
+      from:
 {{ toYaml .Values.networkPolicy.customSelectors | indent 8 }}
-{{- else if .Values.networkPolicy.allowAll }}
-    - {}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

* Fix `podSelector` by adding `release` label
* Fix ingress rule by ensuring port is restricted

  Before it was:

    * Source: any, Port: `targetPort`
    * Source: `customSelectors`, Port: any

  Now it is:

    * Source: `customSelectors`, Port: `targetPort`

  and `allowAll` does not add an any/any rule anymore.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

cc @gianrubio @cstaud