### PR TITLE
incubator/kube-downscaler - Expand configuration options for service account

### DIFF
--- a/incubator/kube-downscaler/Chart.yaml
+++ b/incubator/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: 0.5.0
+version: 0.6.0
 appVersion: 20.5.0
 description: A Helm chart for kube-downscaler
 home: https://github.com/hjacobs/kube-downscaler

--- a/incubator/kube-downscaler/README.md
+++ b/incubator/kube-downscaler/README.md
@@ -42,29 +42,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the kube-downscaler chart and their default values.
 
-| Parameter                 | Description                                                                                          | Default                                                           |
-| ------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `replicaCount`            | Number of replicas to run                                                                            | `1`                                                               |
-| `name`                    | How to name resources created by this chart                                                          | `kube-downscaler`                                                 |
-| `debug.enable`            | Do you want to start the downscaler in debug mode                                                    | `false`                                                           |
-| `namespace.active_in`     | Which namespace does the downscaler scans for deployment/statefulsets to downscale (`''` equals all) | `''`                                                              |
-| `interval`                | Interval between scans, in seconds                                                                   | `60`                                                              |
-| `image.repository`        | Downscaler container image repository                                                                | `hjacobs/kube-downscaler`                                         |
-| `image.tag`               | Downscaler container image tag                                                                       | `20.5.0`                                                          |
-| `image.pullPolicy`        | Downscaler container image pull policy                                                               | `IfNotPresent`                                                    |
-| `nodeSelector`            | Node labels for downscaler pod assignment                                                            | `{}`                                                              |
-| `tolerations`             | Downscaler pod toleration for taints                                                                 | `[]`                                                              |
-| `affinity`                | Downscaler pod affinity                                                                              | `{}`                                                              |
-| `podAnnotations`          | Annotations to be added to downscaler pod                                                            | `{}`                                                              |
-| `podLabels`               | Labels to be added to downscaler pod                                                                 | `{}`                                                              |
-| `resources`               | Downscaler pod resource requests & limits                                                            | `{}`                                                              |
-| `securityContext`         | SecurityContext to apply to the downscaler pod                                                       | `{}`                                                              |
-| `rbac.create`             | If true, create & use RBAC resources                                                                 | `true`                                                            |
-| `rbac.serviceAccountName` | ServiceAccount downscaler will use (ignored if rbac.create=true)                                     | `default`                                                         |
-| `downscaleResources`      | Resources the downscaler is allowed to manage                                                        | `[deployments, statefulsets, horizontalpodautoscalers, cronjobs]` |
-| `excludedDeployments`     | Deployments to exclude from the downscaler                                                           | `[]`                                                              |
-| `excludedNamespaces`      | Namespaces to exclude from the downscaler                                                            | `[]`                                                              |
-| `extraArgs`               | Add extra args to docker command                                                                     | `[]`                                                              |
+| Parameter                    | Description                                                                                             | Default                                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `replicaCount`               | Number of replicas to run                                                                               | `1`                                                               |
+| `name`                       | How to name resources created by this chart                                                             | `kube-downscaler`                                                 |
+| `debug.enable`               | Do you want to start the downscaler in debug mode                                                       | `false`                                                           |
+| `namespace.active_in`        | Which namespace does the downscaler scans for deployment/statefulsets to downscale (`''` equals all)    | `''`                                                              |
+| `interval`                   | Interval between scans, in seconds                                                                      | `60`                                                              |
+| `image.repository`           | Downscaler container image repository                                                                   | `hjacobs/kube-downscaler`                                         |
+| `image.tag`                  | Downscaler container image tag                                                                          | `20.5.0`                                                          |
+| `image.pullPolicy`           | Downscaler container image pull policy                                                                  | `IfNotPresent`                                                    |
+| `nodeSelector`               | Node labels for downscaler pod assignment                                                               | `{}`                                                              |
+| `tolerations`                | Downscaler pod toleration for taints                                                                    | `[]`                                                              |
+| `affinity`                   | Downscaler pod affinity                                                                                 | `{}`                                                              |
+| `podAnnotations`             | Annotations to be added to downscaler pod                                                               | `{}`                                                              |
+| `podLabels`                  | Labels to be added to downscaler pod                                                                    | `{}`                                                              |
+| `resources`                  | Downscaler pod resource requests & limits                                                               | `{}`                                                              |
+| `securityContext`            | SecurityContext to apply to the downscaler pod                                                          | `{}`                                                              |
+| `rbac.create`                | If true, create & use RBAC resources                                                                    | `true`                                                            |
+| `serviceAccount.create`      | If true, create & use a ServiceAccount                                                                  | `true`                                                            |
+| `serviceAccount.name`        | Custom ServiceAccount name                                                                              | `""`                                                              |
+| `serviceAccount.annotations` | Custom annotations for the ServiceAccount. Ignored if serviceAccount.create is false.                   | `{}`                                                              |
+| `imagePullSecretsNames`      | List of names for imagePullSecrets to use.                                                              | `[]`                                                              |
+| `downscaleResources`         | Resources the downscaler is allowed to manage                                                           | `[deployments, statefulsets, horizontalpodautoscalers, cronjobs]` |
+| `excludedDeployments`        | Deployments to exclude from the downscaler                                                              | `[]`                                                              |
+| `excludedNamespaces`         | Namespaces to exclude from the downscaler                                                               | `[]`                                                              |
+| `extraArgs`                  | Add extra args to docker command                                                                        | `[]`                                                              |
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 

--- a/incubator/kube-downscaler/templates/_helpers.tpl
+++ b/incubator/kube-downscaler/templates/_helpers.tpl
@@ -29,3 +29,14 @@ Create chart name and version as used by the chart label.
 {{- define "kube-downscaler.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-downscaler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "kube-downscaler.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/kube-downscaler/templates/clusterrolebinding.yaml
+++ b/incubator/kube-downscaler/templates/clusterrolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: "{{ template "kube-downscaler.fullname" . }}"
 subjects:
   - kind: ServiceAccount
-    name: "{{ template "kube-downscaler.fullname" . }}"
+    name: {{ include "kube-downscaler.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/incubator/kube-downscaler/templates/deployment.yaml
+++ b/incubator/kube-downscaler/templates/deployment.yaml
@@ -52,6 +52,12 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.imagePullSecretsNames }}
+      imagePullSecrets:
+    {{- range $secretName := . }}
+      - name: {{ $secretName }}
+    {{- end }}
+    {{- end }}
     {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}
@@ -68,4 +74,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-downscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ include "kube-downscaler.serviceAccountName" . }}

--- a/incubator/kube-downscaler/templates/serviceaccount.yaml
+++ b/incubator/kube-downscaler/templates/serviceaccount.yaml
@@ -1,11 +1,16 @@
-{{ if .Values.rbac.create -}}
+{{ if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kube-downscaler.fullname" . }}
+  name: {{ include "kube-downscaler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "kube-downscaler.name" . }}
     helm.sh/chart: {{ include "kube-downscaler.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end}}
 {{- end -}}

--- a/incubator/kube-downscaler/values.yaml
+++ b/incubator/kube-downscaler/values.yaml
@@ -31,13 +31,22 @@ interval: 60
 rbac:
   # If true, create & use RBAC resources
   create: true
-  # Ignored if rbac.create is true
-  serviceAccountName: default
+
+serviceAccount:
+  # If true, create & use a ServiceAccount
+  create: true
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Custom annotations for the ServiceAccount. Ignored if serviceAccount.create is false.
+  annotations: {}
 
 image:
   repository: hjacobs/kube-downscaler
   tag: 20.5.0
   pullPolicy: IfNotPresent
+
+# Names of imagePullSecrets to use.
+imagePullSecretsNames: []
 
 resources:
   limits: {}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The present introduces support for imagePullSecrets, annotations, and extra labels for ServiceAccount in use

I moved SA options out of RBAC tree to decouple SA configuration from the one for roles.

I took the liberty of incrementing minor version of the chart as the change is a feature increment.

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
