### PR TITLE
[incubator/buzzfeed-sso] Split Deployment Support

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.2.3
+version: 0.2.4
 appVersion: 2.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -55,6 +55,7 @@ Parameter | Description | Default
 `rootDomain` | the parent domain used for protecting your backends | REQUIRED
 `whitelistedEmails` | comma-seperated list of emails which should be whitelisted | OPTIONAL
 `cluster` | the cluster name for SSO | `dev`
+`auth.enabled` | enable auth component | `true`
 `auth.annotations` | extra annotations for auth pods | `{}`
 `auth.domain` | the auth domain used for OAuth callbacks | REQUIRED
 `auth.extraEnv` | extra auth env vars | `[]`
@@ -69,6 +70,7 @@ Parameter | Description | Default
 `auth.ingressPath` | auth ingress path. | `/`
 `auth.tls` | tls configuration for central sso auth ingress. | `{}`
 `auth.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `auth.secret` is not set
+`proxy.enabled` | enable proxy component | `true`
 `proxy.annotations` | extra annotations for proxy pods | `{}`
 `proxy.providerUrlInternal` | url for split dns deployments |
 `proxy.extraEnv` | extra proxy env vars | `[]`

--- a/incubator/buzzfeed-sso/templates/NOTES.txt
+++ b/incubator/buzzfeed-sso/templates/NOTES.txt
@@ -11,7 +11,7 @@ The email domain is required for the auth and proxy deployments.
 
 {{- end }}
 
-{{- if eq .Values.rootDomain "<your_root_domain>" }}
+{{- if and .Values.auth.enabled (eq .Values.rootDomain "<your_root_domain>") }}
 
 ###############################################################################
 ####   ERROR: You did not provide a root domain.                           ####
@@ -33,7 +33,7 @@ For instance, "sso-auth.mydomain.foo".
 
 {{- end }}
 
-{{- if not (or .Values.auth.secret .Values.auth.customSecret) }}
+{{- if and .Values.auth.enabled (not (or .Values.auth.secret .Values.auth.customSecret)) }}
 
 ###############################################################################
 ####   ERROR: You did not provide proper auth secrets.                     ####

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.auth.customSecret .Values.auth.secret) (or .Values.provider.google.customSecret .Values.provider.google.secret) (ne .Values.auth.domain "<your_auth_domain>") -}}
+{{- if and .Values.auth.enabled (and (or .Values.auth.customSecret .Values.auth.secret) (or .Values.provider.google.customSecret .Values.provider.google.secret) (ne .Values.auth.domain "<your_auth_domain>")) -}}
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $googleSecret := .Values.provider.google.customSecret | default (printf "%s-google" ($fullName)) -}}
 {{- $authSecret := .Values.auth.customSecret | default ($fullName) -}}
@@ -34,7 +34,7 @@ spec:
         component: {{ $name }}-auth
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.provider.google }}
+    {{- if .Values.provider.google.secret.serviceAccount }}
       volumes:
         - name: google-service-account
           secret:

--- a/incubator/buzzfeed-sso/templates/auth-service.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.auth.enabled -}}
 {{- $name := include "buzzfeed-sso.name" . -}}
 apiVersion: v1
 kind: Service
@@ -20,3 +21,4 @@ spec:
     app: {{ $name }}
     component: {{ $name }}-auth
     release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/buzzfeed-sso/templates/configmap.yaml
+++ b/incubator/buzzfeed-sso/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.proxy.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,5 @@ data:
   upstream_configs.yml: |-
 {{- with .Values.upstreams }}
 {{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/incubator/buzzfeed-sso/templates/google-secret.yaml
+++ b/incubator/buzzfeed-sso/templates/google-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.provider.google.secret }}
+{{- if and .Values.auth.enabled .Values.provider.google.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,6 +13,8 @@ data:
 {{- with .Values.provider.google.secret }}
   google-client-id: {{ .clientId | b64enc }}
   google-client-secret: {{ .clientSecret | b64enc }}
+  {{- if .serviceAccount }}
   service-account: {{ .serviceAccount | b64enc }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -19,9 +19,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if or .Values.auth.tls .Values.ingress.tls }}
+{{- if or (and .Values.auth.enabled .Values.auth.tls) .Values.ingress.tls }}
   tls:
-  {{- if .Values.auth.tls }}
+  {{- if and .Values.auth.enabled .Values.auth.tls }}
     - hosts:
         - {{ $authDomain }}
       secretName: {{ .Values.auth.tls.secretName -}}
@@ -45,6 +45,7 @@ spec:
               serviceName: {{ $fullName }}-proxy
               servicePort: http
   {{- end }}
+  {{- if .Values.auth.enabled }}
     # Global SSO used in the callback for login
     - host: {{ $authDomain }}
       http:
@@ -53,5 +54,6 @@ spec:
             backend:
               serviceName: {{ $fullName }}-auth
               servicePort: http
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.proxy.customSecret .Values.proxy.secret -}}
+{{- if and .Values.proxy.enabled (or .Values.proxy.customSecret .Values.proxy.secret) -}}
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $proxySecret := .Values.proxy.customSecret | default ($fullName) -}}
 {{- $name := include "buzzfeed-sso.name" . -}}

--- a/incubator/buzzfeed-sso/templates/proxy-service.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.proxy.enabled -}}
 {{- $name := include "buzzfeed-sso.name" . -}}
 apiVersion: v1
 kind: Service
@@ -24,3 +25,4 @@ spec:
     app: {{ $name }}
     component: {{ $name }}-proxy
     release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/buzzfeed-sso/templates/secret.yaml
+++ b/incubator/buzzfeed-sso/templates/secret.yaml
@@ -12,8 +12,12 @@ type: Opaque
 data:
 {{- with .Values.proxy.secret }}
   proxy-client-id: {{ .clientId | b64enc }}
+  {{- if .clientSecret }}
   proxy-client-secret: {{ .clientSecret | b64enc }}
+  {{- end }}
+  {{- if .cookieSecret }}
   proxy-cookie-secret: {{ .cookieSecret | b64enc }}
+  {{- end }}
 {{- end }}
 {{- with .Values.auth.secret }}
   auth-code-secret: {{ .codeSecret | b64enc }}

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -6,6 +6,7 @@ rootDomain: "<your_root_domain>"  # Required. e.g "mydomain.foo"
 cluster: dev
 
 auth:
+  enabled: true
   annotations: {}
   domain: "<your_auth_domain>"  # Required. e.g "sso-auth.mydomain.foo"
   extraEnv: []
@@ -35,6 +36,7 @@ auth:
     # secretName: sso-auth-tls-secret
 
 proxy:
+  enabled: true
   annotations: {}
   extraEnv:
     - name: STATSD_HOST


### PR DESCRIPTION
Add the ability to deploy the auth and proxy components separately, and do not mandate supplying a Google service account.

Signed-off-by: Damian Peckett <damian.peckett@kloeckner.com>

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
