### PR TITLE
[stable/datadog] Support admission controller

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.35
+
+* Add support for configuring the Datadog Admission Controller
+
 ## 2.3.34
 
 * Add support for scaling based on `DatadogMetric` CRD

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.34
+version: 2.3.35
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/agent-rbac.yaml
+++ b/stable/datadog/templates/agent-rbac.yaml
@@ -127,6 +127,22 @@ rules:
   verbs:
   - "update"
 {{- end }}
+{{- if .Values.clusterAgent.admissionController.enabled }}
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs: ["get", "list", "watch", "update", "create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "update", "create"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets", "replicasets", "deployments"]
+  verbs: ["get"]
+{{- end }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -44,3 +44,27 @@ spec:
     name: metricsapi
     protocol: TCP
 {{ end }}
+
+{{- if and .Values.clusterAgent.enabled .Values.clusterAgent.admissionController.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+spec:
+  selector:
+    app: {{ template "datadog.fullname" . }}-cluster-agent
+  ports:
+  - port: 443
+    targetPort: 8000
+{{ end }}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -119,6 +119,14 @@ spec:
           - name: DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD
             value: {{ .Values.clusterAgent.metricsProvider.useDatadogMetrics | quote }}
           {{- end }}
+          {{- if .Values.clusterAgent.admissionController.enabled }}
+          - name: DD_ADMISSION_CONTROLLER_ENABLED
+            value: {{ .Values.clusterAgent.admissionController.enabled | quote }}
+          - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
+            value: {{ .Values.clusterAgent.admissionController.mutateUnlabelled | quote }}
+          - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
+            value: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
+          {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED
             value: {{ .Values.datadog.clusterChecks.enabled | quote }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -492,6 +492,18 @@ clusterAgent:
   #
   env: []
 
+  ## @param admissionController - object - required
+  ## Enable the admissionController to be able to inject APM/Dogstatsd config
+  ## and standard tags (env, service, version) automatically into your pods
+  #
+  admissionController:
+    enabled: false
+
+    ## @param mutateUnlabelled - boolean - optional
+    ## Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"'
+    #
+    mutateUnlabelled: false
+
   ## @param confd - list of objects - optional
   ## Provide additional cluster check configurations
   ## Each key will become a file in /conf.d


### PR DESCRIPTION
#### What this PR does / why we need it:

Support configuring the Cluster Agent admission controller

#### Special notes for your reviewer:

Requires Cluster Agent 1.7

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
