### PR TITLE
[stable/datadog] Handling of valueFrom for env entries

### DIFF
--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -99,7 +99,11 @@ spec:
                 fieldPath: spec.nodeName
         {{- range $value := .Values.clusterChecksRunner.env }}
           - name: {{ $value.name }}
+            {{- if $value.value }}
             value: {{ $value.value | quote }}
+            {{- else if $value.valueFrom }}
+            valueFrom: {{ toYaml $value.valueFrom | nindent 14 }}
+            {{- end }}
         {{- end }}
         resources:
 {{ toYaml .Values.clusterChecksRunner.resources | indent 10 }}

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -81,7 +81,11 @@
     {{- end }}
   {{- range $value := .Values.agents.containers.agent.env }}
     - name: {{ $value.name }}
+      {{- if $value.value }}
       value: {{ $value.value | quote }}
+      {{- else if $value.valueFrom }}
+      valueFrom: {{ toYaml $value.valueFrom | nindent 8 }}
+      {{- end }}
   {{- end }}
   volumeMounts:
     - name: config

--- a/stable/datadog/templates/container-process-agent.yaml
+++ b/stable/datadog/templates/container-process-agent.yaml
@@ -24,7 +24,11 @@
     {{- end }}
   {{- range $value := .Values.agents.containers.processAgent.env }}
     - name: {{ $value.name }}
+      {{- if $value.value }}
       value: {{ $value.value | quote }}
+      {{- else if $value.valueFrom }}
+      valueFrom: {{ toYaml $value.valueFrom | nindent 8 }}
+      {{- end }}
   {{- end }}
   volumeMounts:
     - name: config

--- a/stable/datadog/templates/container-system-probe.yaml
+++ b/stable/datadog/templates/container-system-probe.yaml
@@ -11,7 +11,11 @@
       value: {{ .Values.agents.containers.systemProbe.logLevel | default .Values.datadog.logLevel | quote }}
   {{- range $value := .Values.agents.containers.systemProbe.env }}
     - name: {{ $value.name }}
+      {{- if $value.value }}
       value: {{ $value.value | quote }}
+      {{- else if $value.valueFrom }}
+      valueFrom: {{ toYaml $value.valueFrom | nindent 8 }}
+      {{- end }}
   {{- end }}
   resources:
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -31,7 +31,11 @@
   {{- end }}
   {{- range $value := .Values.agents.containers.traceAgent.env }}
     - name: {{ $value.name }}
+      {{- if $value.value }}
       value: {{ $value.value | quote }}
+      {{- else if $value.valueFrom }}
+      valueFrom: {{ toYaml $value.valueFrom | nindent 8 }}
+      {{- end }}
   {{- end }}
   volumeMounts:
     - name: config

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -47,7 +47,11 @@
 {{- end }}
 {{- range $value := .Values.datadog.env }}
 - name: {{ $value.name }}
+  {{- if $value.value }}
   value: {{ $value.value | quote }}
+  {{- else if $value.valueFrom }}
+  valueFrom: {{ toYaml $value.valueFrom | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- if .Values.datadog.acInclude }}
 - name: DD_AC_INCLUDE


### PR DESCRIPTION
Adds back support for `valueFrom` in environment variables (`env` sections).  Currently it only support `value`.
 
This in fact is a change in behaviour introduced with [[stable/datadog] fix several reported issues (#22006)](https://github.com/helm/charts/commit/54704dde751ff6b3c9f61b8ce4b81f37117ae7d5).