### PR TITLE
[stable/traefik] added support for dashboard basePath

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.2
+version: 1.87.3
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -182,6 +182,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `kvprovider.etcd.useAPIV3`             | Use V3 or use V2 API of ETCD                                                                                                 | `false`                                           |
 | `dashboard.enabled`                    | Whether to enable the Traefik dashboard                                                                                      | `false`                                           |
 | `dashboard.domain`                     | Domain for the Traefik dashboard                                                                                             | `traefik.example.com`                             |
+| `dashboard.basePath`                   | BasePath for the Traefik dashboard URI.                                                                                      | None                                              |
 | `dashboard.serviceType`                | ServiceType for the Traefik dashboard Service                                                                                | `ClusterIP`                                       |
 | `dashboard.service.annotations`        | Annotations for the Traefik dashboard Service definition, specified as a map                                                 | None                                              |
 | `dashboard.ingress.annotations`        | Annotations for the Traefik dashboard Ingress definition, specified as a map                                                 | None                                              |
@@ -285,6 +286,19 @@ installing the chart. For example:
 
 ```bash
 $ helm install --name my-release --namespace kube-system --values values.yaml stable/traefik
+```
+
+The below configuration in the YAML file will set the basePath for the Traefik dashboard URI.
+The `PathPrefixStrip` rule-type is required for routing the request when `dashboard.basePath` is used.
+Refer the docs for more [path matcher guidelines](https://docs.traefik.io/v1.7/basics/#path-matcher-usage-guidelines).
+
+```yaml
+dashboard:
+    enabled: true
+    basePath: "/traefik"
+    ingress:
+        annotations:
+            traefik.ingress.kubernetes.io/rule-type: PathPrefixStrip
 ```
 
 ### Clustering / High Availability

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -27,6 +27,9 @@ spec:
       - backend:
           serviceName: {{ template "traefik.fullname" . }}-dashboard
           servicePort: dashboard-http
+        {{- if .Values.dashboard.basePath }}
+        path: {{ .Values.dashboard.basePath }}
+        {{- end }}
   {{- if .Values.dashboard.ingress.tls }}
   tls:
 {{ toYaml .Values.dashboard.ingress.tls | indent 4 }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -360,6 +360,7 @@ acme:
 dashboard:
   enabled: false
   domain: traefik.example.com
+  # basePath: "/traefik"
   # serviceType: ClusterIP
   service: {}
     # annotations:


### PR DESCRIPTION
Signed-off-by: Vignesh Subramanian <vignesh.subramanian93@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
This PR enables support to set the `path` for traefik-dashboard ingress by introducing a new variable `dashboard.basePath`.
When there are multiple services with ingresses listening on the same frontend path (for below ingress example), the path-matching resolution fails to support routing to all such services.
Providing support to configure the basePath for such services solves the issue.

```yaml
...
spec:
  rules:
  - http:
      paths:
      - backend:
          serviceName: traefik-dashboard
          servicePort: dashboard-http
...
```

#### Special notes for your reviewer:
The README is updated with the necessary documentation for the new variable along with an example configuration, which can help everyone to understand.

This variable `dashboard.basePath` is an optional variable. The default configuration makes no change to existing template rendered.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
