### PR TITLE
[stable/datadog] Align ENV var handling (avoid ranging through them to allow any K8S valid syntax)

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.25
+
+* Use directly .env var YAML block for all agents (was already the case for Cluster Agent)
+
 ## 2.3.24
 
 * Allow enabling Orchestrator Explorer data collection from the process-agent

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.24
+version: 2.3.25
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -97,10 +97,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        {{- range $value := .Values.clusterChecksRunner.env }}
-          - name: {{ $value.name }}
-            value: {{ $value.value | quote }}
-        {{- end }}
+{{- if .Values.clusterChecksRunner.env }}
+{{ toYaml .Values.clusterChecksRunner.env | indent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.clusterChecksRunner.resources | indent 10 }}
 {{- if .Values.clusterChecksRunner.volumeMounts }}

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -79,10 +79,9 @@
       value: "clusterchecks endpointschecks"
     {{- end }}
     {{- end }}
-  {{- range $value := .Values.agents.containers.agent.env }}
-    - name: {{ $value.name }}
-      value: {{ $value.value | quote }}
-  {{- end }}
+{{- if .Values.agents.containers.agent.env }}
+{{ toYaml .Values.agents.containers.agent.env | indent 4 }}
+{{- end }}
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/stable/datadog/templates/container-process-agent.yaml
+++ b/stable/datadog/templates/container-process-agent.yaml
@@ -31,10 +31,9 @@
           name: datadog-cluster-id
           key: id
     {{- end }}
-  {{- range $value := .Values.agents.containers.processAgent.env }}
-    - name: {{ $value.name }}
-      value: {{ $value.value | quote }}
-  {{- end }}
+{{- if .Values.agents.containers.processAgent.env }}
+{{ toYaml .Values.agents.containers.processAgent.env | indent 4 }}
+{{- end }}
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/stable/datadog/templates/container-system-probe.yaml
+++ b/stable/datadog/templates/container-system-probe.yaml
@@ -9,10 +9,9 @@
   env:
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.systemProbe.logLevel | default .Values.datadog.logLevel | quote }}
-  {{- range $value := .Values.agents.containers.systemProbe.env }}
-    - name: {{ $value.name }}
-      value: {{ $value.value | quote }}
-  {{- end }}
+{{- if .Values.agents.containers.systemProbe.env }}
+{{ toYaml .Values.agents.containers.systemProbe.env | indent 4 }}
+{{- end }}
   resources:
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
   volumeMounts:

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -29,10 +29,9 @@
     - name: DD_APM_RECEIVER_SOCKET
       value: {{ .Values.datadog.apm.socketPath | quote }}
   {{- end }}
-  {{- range $value := .Values.agents.containers.traceAgent.env }}
-    - name: {{ $value.name }}
-      value: {{ $value.value | quote }}
-  {{- end }}
+{{- if .Values.agents.containers.traceAgent.env }}
+{{ toYaml .Values.agents.containers.traceAgent.env | indent 4 }}
+{{- end }}
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -45,9 +45,8 @@
 - name: DD_DD_URL
   value: {{ .Values.datadog.dd_url | quote }}
 {{- end }}
-{{- range $value := .Values.datadog.env }}
-- name: {{ $value.name }}
-  value: {{ $value.value | quote }}
+{{- if .Values.datadog.env  }}
+{{ toYaml .Values.datadog.env }}
 {{- end }}
 {{- if .Values.datadog.acInclude }}
 - name: DD_AC_INCLUDE


### PR DESCRIPTION
Signed-off-by: Vincent Boulineau <vincent.boulineau@datadoghq.com>

#### What this PR does / why we need it:

Use direct YAML block from user in `.env` instead of ranging through them.
Replaces #23067

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
