### PR TITLE
[stable/datadog]  add systemProbe.collectDNSStats

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.27
+
+* add systemProbe.collectDNSStats option
+
 ## 2.3.26
 
 * fix PodSecurityContext configuration

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.26
+version: 2.3.27
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/system-probe-configmap.yaml
+++ b/stable/datadog/templates/system-probe-configmap.yaml
@@ -20,6 +20,9 @@ data:
       bpf_debug: {{ $.Values.datadog.systemProbe.bpfDebug }}
       enable_tcp_queue_length: {{ $.Values.datadog.systemProbe.enableTCPQueueLength }}
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
+      {{- if $.Values.datadog.systemProbe.collectDNSStats }}
+      collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
+      {{- end }}
 
 {{- if eq .Values.datadog.systemProbe.seccomp "localhost/system-probe" }}
 ---

--- a/stable/datadog/templates/system-probe-configmap.yaml
+++ b/stable/datadog/templates/system-probe-configmap.yaml
@@ -20,9 +20,7 @@ data:
       bpf_debug: {{ $.Values.datadog.systemProbe.bpfDebug }}
       enable_tcp_queue_length: {{ $.Values.datadog.systemProbe.enableTCPQueueLength }}
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
-      {{- if $.Values.datadog.systemProbe.collectDNSStats }}
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
-      {{- end }}
 
 {{- if eq .Values.datadog.systemProbe.seccomp "localhost/system-probe" }}
 ---

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -372,6 +372,11 @@ datadog:
     #
     enableOOMKill: false
 
+    ## @param collectDNSStats - boolean - optional
+    ## Enable DNS stat collection
+    #
+    collectDNSStats: false
+
   orchestratorExplorer:
     ## @param enabled - boolean - required
     ## Set this to true to enable the orchestrator explorer.


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds collectDNSStats which enabled the system_probe.collect_dns_stats
flag. The flag is only rendered into system-probe.yaml if set to true.
This will allow the agent default to changed to true down the line
without requiring a chart bump.

Also rollback part of https://github.com/helm/charts/pull/22529/files which broke the chart on my non-SELinux enabled cluster.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
