### PR TITLE
stable/jenkins: Switch from Deployment to StatefulSet

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.3.0
+version: 2.4.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-sts.yaml
+++ b/stable/jenkins/templates/jenkins-master-sts.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1beta1
 {{- end }}
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "jenkins.fullname" . }}
   namespace: {{ template "jenkins.namespace" . }}
@@ -21,12 +21,10 @@ metadata:
 {{ toYaml .Values.master.deploymentAnnotations | indent 4 }}
   {{- end }}
 spec:
+  serviceName: {{ template "jenkins.fullname" . }}
   replicas: 1
-  strategy:
-    type: {{ if .Values.persistence.enabled }}Recreate{{ else }}RollingUpdate
-    rollingUpdate:
-{{ toYaml .Values.master.rollingUpdate | indent 6 }}
-    {{- end }}
+  updateStrategy:
+{{ toYaml .Values.master.updateStrategy | indent 4 }}
   selector:
     matchLabels:
       "app.kubernetes.io/component": "{{ .Values.master.componentName }}"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -112,7 +112,8 @@ master:
   # This values should not be changed unless you use your custom image of jenkins or any devired from. If you want to use
   # Cloudbees Jenkins Distribution docker, you should set jenkinsRef: "/usr/share/cloudbees-jenkins-distribution/ref"
   jenkinsRef: "/usr/share/jenkins/ref"
-  rollingUpdate: {}
+  updateStrategy:
+    type: RollingUpdate
   # Ignored if Persistence is enabled
   # maxSurge: 1
   # maxUnavailable: 25%


### PR DESCRIPTION
As jenkins uses a PV, it should be a StatefulSet so it keeps track of
the correct PV and PVC on restart/upgrades.
