### PR TITLE
[stable/logdna-agent] Add the ability to set affinity on daemonset

### DIFF
--- a/stable/logdna-agent/Chart.yaml
+++ b/stable/logdna-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: logdna-agent
 description: Run this, get logs. All cluster containers. LogDNA collector agent daemonset for Kubernetes.
-version: 2.0.0
+version: 2.1.0
 appVersion: 2.1.9
 keywords:
 - logs

--- a/stable/logdna-agent/README.md
+++ b/stable/logdna-agent/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the LogDNA Agent chart
 Parameter | Description | Default
 --- | --- | ---
 `daemonset.tolerations` | List of node taints to tolerate | `[]`
+`daemonset.affinity` | Affinity settings for pods | `{}`
 `daemonset.updateStrategy` | Optionally set an update strategy on the daemonset. | None
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `logdna.key` | LogDNA Ingestion Key (Required) | None

--- a/stable/logdna-agent/templates/daemon_set.yaml
+++ b/stable/logdna-agent/templates/daemon_set.yaml
@@ -111,4 +111,6 @@ spec:
 {{- end }}
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 8 }}
+      affinity:
+{{ toYaml .Values.daemonset.affinity | indent 8 }}
 {{- end -}}

--- a/stable/logdna-agent/values.yaml
+++ b/stable/logdna-agent/values.yaml
@@ -22,6 +22,7 @@ daemonset:
   # updateStrategy:
   #   type: "RollingUpdate"
   tolerations: []
+  affinity: {}
 
 priorityClassName: ""
 


### PR DESCRIPTION
Signed-off-by: Lucas Heinlen <lheinlen@onecause.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Adds the ability to configure affinity settings for the pods created by the DaemonSet.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
