### PR TITLE
[stable/openvpn] Add PodSecurityPolicy to OpenVPN

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.2.3
+version: 4.3.0
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -70,6 +70,12 @@ and can be overwritten via the helm `--set` flag.
 
 Parameter | Description | Default
 ---                                  | ---                                                                  | ---
+`serviceAccount.create`              | Whether to create a service account or not                           | `true`
+`serviceAccount.name`                | Override the name of the service account                             | `""` (full name)
+`serviceAccount.annotations`         | ServiceAccount annotations                                           | `{}`
+`rbac.create`                        | Create and use RBAC resources                                        | `true`
+`rbac.pspEnabled`                    | Create PodSecurityPolicy                                             | `true`
+`rbac.pspUseAppArmor`                | Enforce AppArmor in created PodSecurityPolicy                        | `true`
 `replicaCount`                       | amount of parallel openvpn replicas to be started                    | `1`
 `updateStrategy`                     | update strategy for deployment                                       | `{}`
 `image.repository`                   | `openvpn` image repository                                           | `jfelten/openvpn-docker`

--- a/stable/openvpn/templates/_helpers.tpl
+++ b/stable/openvpn/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "openvpn.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "openvpn.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "openvpn.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -28,6 +28,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ template "openvpn.serviceAccountName" . }}
 {{- if .Values.ipForwardInitContainer }}
       initContainers:
         - args:

--- a/stable/openvpn/templates/openvpn-psp.yaml
+++ b/stable/openvpn/templates/openvpn-psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "openvpn.fullname" . }}
+  labels:
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    {{- if .Values.rbac.pspUseAppArmor }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - NET_ADMIN
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  {{- if .Values.service.hostPort }}
+  hostPorts:
+  - min: {{ .Values.service.hostPort }}
+    max: {{ .Values.service.hostPort }}
+  {{- end }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/stable/openvpn/templates/openvpn-role.yaml
+++ b/stable/openvpn/templates/openvpn-role.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "openvpn.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if or .Values.rbac.pspEnabled }}
+{{- if .Values.rbac.pspEnabled }}
 rules:
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']

--- a/stable/openvpn/templates/openvpn-role.yaml
+++ b/stable/openvpn/templates/openvpn-role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "openvpn.fullname" . }}
+  labels:
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if or .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "openvpn.fullname" . }}]
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/stable/openvpn/templates/openvpn-rolebinding.yaml
+++ b/stable/openvpn/templates/openvpn-rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "openvpn.fullname" . }}
+  labels:
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "openvpn.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "openvpn.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/openvpn/templates/openvpn-serviceaccount.yaml
+++ b/stable/openvpn/templates/openvpn-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "openvpn.serviceAccountName" . }}
+  labels:
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -1,6 +1,17 @@
 # Default values for openvpn.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  create: true
+  pspEnabled: true
+  pspUseAppArmor: true
+
 replicaCount: 1
 
 updateStrategy: {}


### PR DESCRIPTION
Signed-off-by: Gorka Maiztegi <gmaiztegi@reviewpro.com>

#### Is this a new chart
No.

#### What this PR does / why we need it:
OpenVPN needs to run in privileged mode in order to work. If your cluster's default PodSecurityPolicy does not allow this (which it shouldn't!) then it won't work. This PR adds the PSP and the RBAC stuff to make this work.

#### Which issue this PR fixes
Not applicable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
