### PR TITLE
stable/grafana: support setting revisionHistoryLimit on deployment

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.3.4
+version: 5.3.5
 appVersion: 7.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.3.5
+version: 5.3.6
 appVersion: 7.0.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -169,6 +169,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `downloadDashboardsImage.tag`             | Curl docker image tag                         | `7.68.0`                                                |
 | `downloadDashboardsImage.pullPolicy`      | Curl docker image pull policy                 | `IfNotPresent`                                          |
 | `namespaceOverride`                       | Override the deployment namespace             | `""` (`Release.Namespace`)                              |
+| `revisionHistoryLimit`                    | Number of ReplicaSets to retain in history    | `10`                                                    |
 
 ### Example ingress with path
 

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "grafana.selectorLabels" . | nindent 6 }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -516,3 +516,7 @@ sidecar:
 ## Override the deployment namespace
 ##
 namespaceOverride: ""
+
+## Number of ReplicaSets to keep around for history
+##
+revisionHistoryLimit: 10


### PR DESCRIPTION
#### What this PR does / why we need it:
Makes revisionHistoryLimit configurable/disable-able. Default in `values.yaml` set to k8s default of 10, so upgrade will provide no change in behavior -- bumped chart version nonetheless.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
