### PR TITLE
[stable/prometheus] Improve Prometheus Server Probes. Fix MD Syntax Issues in README.

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.6.2
+version: 11.7.0
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -339,6 +339,16 @@ Parameter | Description | Default
 `server.statefulSet.headless.gRPC.enabled` | If true, open a second port on the service for gRPC | `false`
 `server.statefulSet.headless.gRPC.servicePort` | Prometheus service gRPC port, (ignored if `server.service.gRPC.enabled` is not `true`) | `10901`
 `server.statefulSet.headless.gRPC.nodePort` | Port to be used as gRPC nodePort in the prometheus service | `0`
+`server.readinessProbeInitialDelay` | the initial delay for the Prometheus server readiness probe | `30`
+`server.readinessProbePeriodSeconds` | how often (in seconds) to perform the Prometheus server readiness probe | `5`
+`server.readinessProbeTimeout` | the timeout for the Prometheus server readiness probe | `30`
+`server.readinessProbeFailureThreshold` | the failure threshold for the Prometheus server readiness probe | `3`
+`server.readinessProbeSuccessThreshold` | the success threshold for the Prometheus server readiness probe | `1`
+`server.livenessProbeInitialDelay` | the initial delay for the Prometheus server liveness probe | `30`
+`server.livenessProbePeriodSeconds` | how often (in seconds) to perform the Prometheus server liveness probe | `15`
+`server.livenessProbeTimeout` | the timeout for the Prometheus server liveness probe  | `30`
+`server.livenessProbeFailureThreshold` | the failure threshold for the Prometheus server liveness probe | `3`
+`server.livenessProbeSuccessThreshold` | the success threshold for the Prometheus server liveness probe | `1`
 `server.resources` | Prometheus server resource requests and limits | `{}`
 `server.verticalAutoscaler.enabled` | If true a VPA object will be created for the controller (either StatefulSet or Deployemnt, based on above configs) | `false`
 `server.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for server containers | `{}`

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/prometheus
+helm install stable/prometheus
 ```
 
 ## Introduction
@@ -21,7 +21,7 @@ This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Ku
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/prometheus
+helm install --name my-release stable/prometheus
 ```
 
 The command deploys Prometheus on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -33,7 +33,7 @@ The command deploys Prometheus on the Kubernetes cluster in the default configur
 To uninstall/delete the `my-release` deployment:
 
 ```console
-$ helm delete my-release
+helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -58,34 +58,34 @@ Assuming you have an existing release of the prometheus chart, named `prometheus
 
 1. Update the `prometheus-old` release. Disable scraping on every component besides the prometheus server, similar to the configuration below:
 
-	```
-	alertmanager:
-	  enabled: false
-	alertmanagerFiles:
-	  alertmanager.yml: ""
-	kubeStateMetrics:
-	  enabled: false
-	nodeExporter:
-	  enabled: false
-	pushgateway:
-	  enabled: false
-	server:
-	  extraArgs:
-	    storage.local.retention: 720h
-	serverFiles:
-	  alerts: ""
-	  prometheus.yml: ""
-	  rules: ""
-	```
+  ```yaml
+  alertmanager:
+    enabled: false
+  alertmanagerFiles:
+    alertmanager.yml: ""
+  kubeStateMetrics:
+    enabled: false
+  nodeExporter:
+    enabled: false
+  pushgateway:
+    enabled: false
+  server:
+    extraArgs:
+      storage.local.retention: 720h
+  serverFiles:
+    alerts: ""
+    prometheus.yml: ""
+    rules: ""
+  ```
 
 1. Deploy a new release of the chart with version 5.0+ using prometheus 2.x. In the values.yaml set the scrape config as usual, and also add the `prometheus-old` instance as a remote-read target.
 
-   ```
-	  prometheus.yml:
-	    ...
-	    remote_read:
-	    - url: http://prometheus-old/api/v1/read
-	    ...
+   ```yaml
+    prometheus.yml:
+      ...
+      remote_read:
+      - url: http://prometheus-old/api/v1/read
+      ...
    ```
 
    Old data will be available when you query the new prometheus instance.
@@ -103,7 +103,7 @@ and [kubernetes_sd_config](https://prometheus.io/docs/prometheus/latest/configur
 
 In order to get prometheus to scrape pods, you must add annotations to the the pods as below:
 
-```
+```yaml
 metadata:
   annotations:
     prometheus.io/scrape: "true"
@@ -291,7 +291,7 @@ Parameter | Description | Default
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.extraFlags` | Additional Prometheus server container flags | `["web.enable-lifecycle"]`
 `server.extraInitContainers` | Init containers to launch alongside the server | `[]`
-`server.prefixURL` | The prefix slug at which the server can be accessed | ``
+`server.prefixURL` | The prefix slug at which the server can be accessed |``
 `server.baseURL` | The external url at which the server can be accessed | ``
 `server.env` | Prometheus server environment variables | `[]`
 `server.extraHostPathMounts` | Additional Prometheus server hostPath mounts | `[]`
@@ -386,14 +386,14 @@ Parameter | Description | Default
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install stable/prometheus --name my-release \
+helm install stable/prometheus --name my-release \
     --set server.terminationGracePeriodSeconds=360
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install stable/prometheus --name my-release -f values.yaml
+helm install stable/prometheus --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -420,10 +420,11 @@ serverFiles:
 ```
 
 ```console
-$ helm install stable/prometheus --name my-release -f values.yaml -f service1-alert.yaml -f service2-alert.yaml
+helm install stable/prometheus --name my-release -f values.yaml -f service1-alert.yaml -f service2-alert.yaml
 ```
 
 ### RBAC Configuration
+
 Roles and RoleBindings resources will be created automatically for `server` service.
 
 To manually setup RBAC you need to set the parameter `rbac.create=false` and specify the service account to be used for each service by setting the parameters: `serviceAccounts.{{ component }}.create` to `false` and `serviceAccounts.{{ component }}.name` to the name of a pre-existing service account.
@@ -431,11 +432,13 @@ To manually setup RBAC you need to set the parameter `rbac.create=false` and spe
 > **Tip**: You can refer to the default `*-clusterrole.yaml` and `*-clusterrolebinding.yaml` files in [templates](templates/) to customize your own.
 
 ### ConfigMap Files
+
 AlertManager is configured through [alertmanager.yml](https://prometheus.io/docs/alerting/configuration/). This file (and any others listed in `alertmanagerFiles`) will be mounted into the `alertmanager` pod.
 
 Prometheus is configured through [prometheus.yml](https://prometheus.io/docs/operating/configuration/). This file (and any others listed in `serverFiles`) will be mounted into the `server` pod.
 
 ### Ingress TLS
+
 If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [kube-lego](https://github.com/jetstack/kube-lego)), please refer to the documentation for that mechanism.
 
 To manually configure TLS, first create/retrieve a key & certificate pair for the address(es) you wish to protect. Then create a TLS secret in the namespace:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -104,6 +104,7 @@ spec:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
             initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
+            periodSeconds: {{ .Values.server.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
             failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
             successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
@@ -112,6 +113,7 @@ spec:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
             initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
+            periodSeconds: {{ .Values.server.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
             failureThreshold: {{ .Values.server.livenessProbeFailureThreshold }}
             successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -103,13 +103,19 @@ spec:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
             initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
+            periodSeconds: {{ .Values.server.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
           livenessProbe:
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
             initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
+            periodSeconds: {{ .Values.server.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.server.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
           volumeMounts:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -868,10 +868,12 @@ server:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   ##
   readinessProbeInitialDelay: 30
+  readinessProbePeriodSeconds: 5
   readinessProbeTimeout: 30
   readinessProbeFailureThreshold: 3
   readinessProbeSuccessThreshold: 1
   livenessProbeInitialDelay: 30
+  livenessProbePeriodSeconds: 15
   livenessProbeTimeout: 30
   livenessProbeFailureThreshold: 3
   livenessProbeSuccessThreshold: 1


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

- Improves the configurability of Prometheus Server Liveness and Readiness probes.
- Adds all configurable options for Prometheus Server's statefulset as well.
- Documents the Prometheus Server's probes in `README.md`.
- Fixes all the MD-specific issues in `README.md`. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
