### PR TITLE
[incubator/sparkoperator] Add scheduling.volcano.sh to apiGroup in spark-operator-rbac.yaml

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.7.1
+version: 0.7.2
 appVersion: v1beta2-1.1.2-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -38,7 +38,7 @@ rules:
   verbs: ["*"]
   {{- if .Values.enableBatchScheduler }}
   # This api resources below is configured for the `volcano` batch scheduler.
-- apiGroups: ["scheduling.incubator.k8s.io", "scheduling.sigs.dev"]
+- apiGroups: ["scheduling.incubator.k8s.io", "scheduling.sigs.dev", "scheduling.volcano.sh"]
   resources: ["podgroups"]
   verbs: ["*"]
   {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
Solves podGroup not created issue with batch-scheduling in spark-operator using volcano scheduler - [https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/968](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/968)

#### Which issue this PR fixes
  - fixes #23124

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
