### PR TITLE
[stable/nextcloud] Explicit command and args

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.12.0
+version: 1.12.1
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -45,124 +45,126 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-| Parameter                                                    | Description                                             | Default                                     |
-| ------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------- |
-| `image.repository`                                           | nextcloud Image name                                    | `nextcloud`                                 |
-| `image.tag`                                                  | nextcloud Image tag                                     | `{VERSION}`                                 |
-| `image.pullPolicy`                                           | Image pull policy                                       | `IfNotPresent`                              |
-| `image.pullSecrets`                                          | Specify image pull secrets                              | `nil`                                       |
-| `ingress.enabled`                                            | Enable use of ingress controllers                       | `false`                                     |
-| `ingress.servicePort`                                        | Ingress' backend servicePort                            | `http`                                      |
-| `ingress.annotations`                                        | An array of service annotations                         | `nil`                                       |
-| `ingress.labels`                                             | An array of service labels                              | `nil`                                       |
-| `ingress.tls`                                                | Ingress TLS configuration                               | `[]`                                        |
-| `nextcloud.host`                                             | nextcloud host to create application URLs               | `nextcloud.kube.home`                       |
-| `nextcloud.username`                                         | User of the application                                 | `admin`                                     |
-| `nextcloud.password`                                         | Application password                                    | `changeme`                                  |
-| `nextcloud.update`                                           | Trigger update if custom command is used                | `0`                                         |
-| `nextcloud.datadir`                                          | nextcloud data dir location                             | `/var/www/html/data`                        |
-| `nextcloud.tableprefix`                                      | nextcloud db table prefix                               | `''`                                        |
-| `nextcloud.mail.enabled`                                     | Whether to enable/disable email settings                | `false`                                     |
-| `nextcloud.mail.fromAddress`                                 | nextcloud mail send from field                          | `nil`                                       |
-| `nextcloud.mail.domain`                                      | nextcloud mail domain                                   | `nil`                                       |
-| `nextcloud.mail.smtp.host`                                   | SMTP hostname                                           | `nil`                                       |
-| `nextcloud.mail.smtp.secure`                                 | SMTP connection `ssl` or empty                          | `''`                                        |
-| `nextcloud.mail.smtp.port`                                   | Optional SMTP port                                      | `nil`                                       |
-| `nextcloud.mail.smtp.authtype`                               | SMTP authentication method                              | `LOGIN`                                     |
-| `nextcloud.mail.smtp.name`                                   | SMTP username                                           | `''`                                        |
-| `nextcloud.mail.smtp.password`                               | SMTP password                                           | `''`                                        |
-| `nextcloud.configs`                                          | Config files created in `/var/www/html/config`          | `{}`                                        |
-| `nextcloud.persistence.subPath`                              | Set the subPath for nextcloud to use in volume          | `nil`                                       |
-| `nextcloud.phpConfigs`                                       | PHP Config files created in `/usr/local/etc/php/conf.d` | `{}`                                        |
-| `nextcloud.defaultConfigs.\.htaccess`                        | Default .htaccess to protect `/var/www/html/config`     | `true`                                      |
-| `nextcloud.defaultConfigs.\.redis\.config\.php`              | Default Redis configuration                             | `true`                                      |
-| `nextcloud.defaultConfigs.\.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls           | `true`                                      |
-| `nextcloud.defaultConfigs.\.apcu\.config\.php`               | Default configuration to define APCu as local cache     | `true`                                      |
-| `nextcloud.defaultConfigs.\.apps\.config\.php`               | Default configuration for apps                          | `true`                                      |
-| `nextcloud.defaultConfigs.\.autoconfig\.php`                 | Default auto-configuration for databases                | `true`                                      |
-| `nextcloud.defaultConfigs.\.smtp\.config\.php`               | Default configuration for smtp                          | `true`                                      |
-| `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones | `type: Recreate`                                      |
-| `nextcloud.extraEnv`                                         | specify additional environment variables                | `{}`                                        |
-| `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod        | `{}`                                        |
-| `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod  | `{}`                                        |
-| `nginx.enabled`                                              | Enable nginx (requires you use php-fpm image)           | `false`                                     |
-| `nginx.image.repository`                                     | nginx Image name                                        | `nginx`                                     |
-| `nginx.image.tag`                                            | nginx Image tag                                         | `alpine`                                    |
-| `nginx.image.pullPolicy`                                     | nginx Image pull policy                                 | `IfNotPresent`                              |
-| `nginx.config.default`                                       | Whether to use nextclouds recommended nginx config      | `true`                                      |
-| `nginx.config.custom`                                        | Specify a custom config for nginx                       | `{}`                                        |
-| `nginx.resources`                                            | nginx resources                                         | `{}`                                        |
-| `lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand      | `nil`                                       |
-| `lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand        | `nil`                                       |
-| `internalDatabase.enabled`                                   | Whether to use internal sqlite database                 | `true`                                      |
-| `internalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                 |
-| `externalDatabase.enabled`                                   | Whether to use external database                        | `false`                                     |
-| `externalDatabase.type`                                      | External database type: `mysql`, `postgresql`           | `mysql`                                     |
-| `externalDatabase.host`                                      | Host of the external database                           | `nil`                                       |
-| `externalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                 |
-| `externalDatabase.user`                                      | Existing username in the external db                    | `nextcloud`                                 |
-| `externalDatabase.password`                                  | Password for the above username                         | `nil`                                       |
-| `externalDatabase.existingSecret.enabled`                    | Whether to use a existing secret or not                 | `false`                                     |
-| `externalDatabase.existingSecret.secretName`                 | Name of the existing secret                             | `nil`                                       |
-| `externalDatabase.existingSecret.usernameKey`                | Name of the key that contains the username              | `nil`                                       |
-| `externalDatabase.existingSecret.passwordKey`                | Name of the key that contains the password              | `nil`                                       |
-| `mariadb.enabled`                                            | Whether to use the MariaDB chart                        | `false`                                     |
-| `mariadb.db.name`                                            | Database name to create                                 | `nextcloud`                                 |
-| `mariadb.db.password`                                        | Password for the database                               | `changeme`                                  |
-| `mariadb.db.user`                                            | Database user to create                                 | `nextcloud`                                 |
-| `mariadb.rootUser.password`                                  | MariaDB admin password                                  | `nil`                                       |
-| `redis.enabled`                                              | Whether to install/use redis for locking                | `false`                                     |
-| `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                     |
-| `cronjob.schedule`                                           | Schedule for the CronJob                                | `*/15 * * * *`                              |
-| `cronjob.annotations`                                        | Annotations to add to the cronjob                       | {}                                          |
-| `cronjob.curlInsecure`                                       | Set insecure (-k) option to curl                        | false                                       |
-| `cronjob.failedJobsHistoryLimit`                             | Specify the number of failed Jobs to keep               | `5`                                         |
-| `cronjob.successfulJobsHistoryLimit`                         | Specify the number of completed Jobs to keep            | `2`                                         |
-| `cronjob.resources`                                          | Cronjob Resources                                       | `nil`                                       |
-| `cronjob.nodeSelector`                                       | Cronjob Node selector                                   | `nil`                                       |
-| `cronjob.tolerations`                                        | Cronjob tolerations                                     | `nil`                                       |
-| `cronjob.affinity`                                           | Cronjob affinity                                        | `nil`                                       |
-| `service.type`                                               | Kubernetes Service type                                 | `ClusterIp`                                 |
-| `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer            | `nil`                                       |
-| `service.nodePort`                                           | NodePort for service type NodePort                      | `nil`                                       |
-| `persistence.enabled`                                        | Enable persistence using PVC                            | `false`                                     |
-| `persistence.annotations`                                    | PVC annotations                                         | `{}`                                        |
-| `persistence.storageClass`                                   | PVC Storage Class for nextcloud volume                  | `nil` (uses alpha storage class annotation) |
-| `persistence.existingClaim`                                  | An Existing PVC name for nextcloud volume               | `nil` (uses alpha storage class annotation) |
-| `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                    | `ReadWriteOnce`                             |
-| `persistence.size`                                           | PVC Storage Request for nextcloud volume                | `8Gi`                                       |
-| `resources`                                                  | CPU/Memory resource requests/limits                     | `{}`                                        |
-| `livenessProbe.enabled`                                      | Turn on and off liveness probe                          | `true`                                      |
-| `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                | `30`                                        |
-| `livenessProbe.periodSeconds`                                | How often to perform the probe                          | `15`                                        |
-| `livenessProbe.timeoutSeconds`                               | When the probe times out                                | `5`                                         |
-| `livenessProbe.failureThreshold`                             | Minimum consecutive failures for the probe              | `3`                                         |
-| `livenessProbe.successThreshold`                             | Minimum consecutive successes for the probe             | `1`                                         |
-| `readinessProbe.enabled`                                     | Turn on and off readiness probe                         | `true`                                      |
-| `readinessProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated               | `30`                                        |
-| `readinessProbe.periodSeconds`                               | How often to perform the probe                          | `15`                                        |
-| `readinessProbe.timeoutSeconds`                              | When the probe times out                                | `5`                                         |
-| `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe              | `3`                                         |
-| `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe             | `1`                                         |
-| `hpa.enabled`                                                | Boolean to create a HorizontalPodAutoscaler             | `false`                                     |
-| `hpa.cputhreshold`                                           | CPU threshold percent for the HorizontalPodAutoscale    | `60`                                        |
-| `hpa.minPods`                                                | Min. pods for the Nextcloud HorizontalPodAutoscaler     | `1`                                         |
-| `hpa.maxPods`                                                | Max. pods for the Nextcloud HorizontalPodAutoscaler     | `10`                                        |
-| `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level           | not set                                     |
-| `podAnnotations`                                             | Annotations to be added at 'pod' level                  | not set                                     |
-| `metrics.enabled`                                            | Start Prometheus metrics exporter                       | `false`                                     |
-| `metrics.https`                                              | Defines if https is used to connect to nextcloud        | `false` (uses http)                         |
-| `metrics.timeout`                                            | When the scrape times out                               | `5s`                                        |
-| `metrics.image.repository`                                   | Nextcloud metrics exporter image name                   | `xperimental/nextcloud-exporter`            |
-| `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                    | `v0.3.0`                                    |
-| `metrics.image.pullPolicy`                                   | Nextcloud metrics exporter image pull policy            | `IfNotPresent`                              |
-| `metrics.podAnnotations`                                     | Additional annotations for metrics exporter             | not set                                     |
-| `metrics.podLabels`                                          | Additional labels for metrics exporter                  | not set                                     |
-| `metrics.service.type`                                       | Metrics: Kubernetes Service type                        | `ClusterIP`                                 |
-| `metrics.service.loadBalancerIP`                             | Metrics: LoadBalancerIp for service type LoadBalancer   | `nil`                                       |
-| `metrics.service.nodePort`                                   | Metrics: NodePort for service type NodePort             | `nil`                                       |
-| `metrics.service.annotations`                                | Additional annotations for service metrics exporter     | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
-| `metrics.service.labels`                                     | Additional labels for service metrics exporter          | `{}`                                        |
+| Parameter                                                    | Description                                                 | Default                                                      |
+|--------------------------------------------------------------|-------------------------------------------------------------|--------------------------------------------------------------|
+| `image.repository`                                           | nextcloud Image name                                        | `nextcloud`                                                  |
+| `image.tag`                                                  | nextcloud Image tag                                         | `{VERSION}`                                                  |
+| `image.pullPolicy`                                           | Image pull policy                                           | `IfNotPresent`                                               |
+| `image.pullSecrets`                                          | Specify image pull secrets                                  | `nil`                                                        |
+| `image.command`                                              | Specify command to be run in the container                  | `Docker image's ENTRYPOINT`                                  |
+| `image.args`                                                 | Specify args for the above command for the container        | `Docker image's COMMAND`                                     |
+| `ingress.enabled`                                            | Enable use of ingress controllers                           | `false`                                                      |
+| `ingress.servicePort`                                        | Ingress' backend servicePort                                | `http`                                                       |
+| `ingress.annotations`                                        | An array of service annotations                             | `nil`                                                        |
+| `ingress.labels`                                             | An array of service labels                                  | `nil`                                                        |
+| `ingress.tls`                                                | Ingress TLS configuration                                   | `[]`                                                         |
+| `nextcloud.host`                                             | nextcloud host to create application URLs                   | `nextcloud.kube.home`                                        |
+| `nextcloud.username`                                         | User of the application                                     | `admin`                                                      |
+| `nextcloud.password`                                         | Application password                                        | `changeme`                                                   |
+| `nextcloud.update`                                           | Trigger update if custom command is used                    | `0`                                                          |
+| `nextcloud.datadir`                                          | nextcloud data dir location                                 | `/var/www/html/data`                                         |
+| `nextcloud.tableprefix`                                      | nextcloud db table prefix                                   | `''`                                                         |
+| `nextcloud.mail.enabled`                                     | Whether to enable/disable email settings                    | `false`                                                      |
+| `nextcloud.mail.fromAddress`                                 | nextcloud mail send from field                              | `nil`                                                        |
+| `nextcloud.mail.domain`                                      | nextcloud mail domain                                       | `nil`                                                        |
+| `nextcloud.mail.smtp.host`                                   | SMTP hostname                                               | `nil`                                                        |
+| `nextcloud.mail.smtp.secure`                                 | SMTP connection `ssl` or empty                              | `''`                                                         |
+| `nextcloud.mail.smtp.port`                                   | Optional SMTP port                                          | `nil`                                                        |
+| `nextcloud.mail.smtp.authtype`                               | SMTP authentication method                                  | `LOGIN`                                                      |
+| `nextcloud.mail.smtp.name`                                   | SMTP username                                               | `''`                                                         |
+| `nextcloud.mail.smtp.password`                               | SMTP password                                               | `''`                                                         |
+| `nextcloud.configs`                                          | Config files created in `/var/www/html/config`              | `{}`                                                         |
+| `nextcloud.persistence.subPath`                              | Set the subPath for nextcloud to use in volume              | `nil`                                                        |
+| `nextcloud.phpConfigs`                                       | PHP Config files created in `/usr/local/etc/php/conf.d`     | `{}`                                                         |
+| `nextcloud.defaultConfigs.\.htaccess`                        | Default .htaccess to protect `/var/www/html/config`         | `true`                                                       |
+| `nextcloud.defaultConfigs.\.redis\.config\.php`              | Default Redis configuration                                 | `true`                                                       |
+| `nextcloud.defaultConfigs.\.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls               | `true`                                                       |
+| `nextcloud.defaultConfigs.\.apcu\.config\.php`               | Default configuration to define APCu as local cache         | `true`                                                       |
+| `nextcloud.defaultConfigs.\.apps\.config\.php`               | Default configuration for apps                              | `true`                                                       |
+| `nextcloud.defaultConfigs.\.autoconfig\.php`                 | Default auto-configuration for databases                    | `true`                                                       |
+| `nextcloud.defaultConfigs.\.smtp\.config\.php`               | Default configuration for smtp                              | `true`                                                       |
+| `nextcloud.strategy`                                         | specifies the strategy used to replace old Pods by new ones | `type: Recreate`                                             |
+| `nextcloud.extraEnv`                                         | specify additional environment variables                    | `{}`                                                         |
+| `nextcloud.extraVolumes`                                     | specify additional volumes for the NextCloud pod            | `{}`                                                         |
+| `nextcloud.extraVolumeMounts`                                | specify additional volume mounts for the NextCloud pod      | `{}`                                                         |
+| `nginx.enabled`                                              | Enable nginx (requires you use php-fpm image)               | `false`                                                      |
+| `nginx.image.repository`                                     | nginx Image name                                            | `nginx`                                                      |
+| `nginx.image.tag`                                            | nginx Image tag                                             | `alpine`                                                     |
+| `nginx.image.pullPolicy`                                     | nginx Image pull policy                                     | `IfNotPresent`                                               |
+| `nginx.config.default`                                       | Whether to use nextclouds recommended nginx config          | `true`                                                       |
+| `nginx.config.custom`                                        | Specify a custom config for nginx                           | `{}`                                                         |
+| `nginx.resources`                                            | nginx resources                                             | `{}`                                                         |
+| `lifecycle.postStartCommand`                                 | Specify deployment lifecycle hook postStartCommand          | `nil`                                                        |
+| `lifecycle.preStopCommand`                                   | Specify deployment lifecycle hook preStopCommand            | `nil`                                                        |
+| `internalDatabase.enabled`                                   | Whether to use internal sqlite database                     | `true`                                                       |
+| `internalDatabase.database`                                  | Name of the existing database                               | `nextcloud`                                                  |
+| `externalDatabase.enabled`                                   | Whether to use external database                            | `false`                                                      |
+| `externalDatabase.type`                                      | External database type: `mysql`, `postgresql`               | `mysql`                                                      |
+| `externalDatabase.host`                                      | Host of the external database                               | `nil`                                                        |
+| `externalDatabase.database`                                  | Name of the existing database                               | `nextcloud`                                                  |
+| `externalDatabase.user`                                      | Existing username in the external db                        | `nextcloud`                                                  |
+| `externalDatabase.password`                                  | Password for the above username                             | `nil`                                                        |
+| `externalDatabase.existingSecret.enabled`                    | Whether to use a existing secret or not                     | `false`                                                      |
+| `externalDatabase.existingSecret.secretName`                 | Name of the existing secret                                 | `nil`                                                        |
+| `externalDatabase.existingSecret.usernameKey`                | Name of the key that contains the username                  | `nil`                                                        |
+| `externalDatabase.existingSecret.passwordKey`                | Name of the key that contains the password                  | `nil`                                                        |
+| `mariadb.enabled`                                            | Whether to use the MariaDB chart                            | `false`                                                      |
+| `mariadb.db.name`                                            | Database name to create                                     | `nextcloud`                                                  |
+| `mariadb.db.password`                                        | Password for the database                                   | `changeme`                                                   |
+| `mariadb.db.user`                                            | Database user to create                                     | `nextcloud`                                                  |
+| `mariadb.rootUser.password`                                  | MariaDB admin password                                      | `nil`                                                        |
+| `redis.enabled`                                              | Whether to install/use redis for locking                    | `false`                                                      |
+| `cronjob.enabled`                                            | Whether to enable/disable cronjob                           | `false`                                                      |
+| `cronjob.schedule`                                           | Schedule for the CronJob                                    | `*/15 * * * *`                                               |
+| `cronjob.annotations`                                        | Annotations to add to the cronjob                           | {}                                                           |
+| `cronjob.curlInsecure`                                       | Set insecure (-k) option to curl                            | false                                                        |
+| `cronjob.failedJobsHistoryLimit`                             | Specify the number of failed Jobs to keep                   | `5`                                                          |
+| `cronjob.successfulJobsHistoryLimit`                         | Specify the number of completed Jobs to keep                | `2`                                                          |
+| `cronjob.resources`                                          | Cronjob Resources                                           | `nil`                                                        |
+| `cronjob.nodeSelector`                                       | Cronjob Node selector                                       | `nil`                                                        |
+| `cronjob.tolerations`                                        | Cronjob tolerations                                         | `nil`                                                        |
+| `cronjob.affinity`                                           | Cronjob affinity                                            | `nil`                                                        |
+| `service.type`                                               | Kubernetes Service type                                     | `ClusterIp`                                                  |
+| `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer                | `nil`                                                        |
+| `service.nodePort`                                           | NodePort for service type NodePort                          | `nil`                                                        |
+| `persistence.enabled`                                        | Enable persistence using PVC                                | `false`                                                      |
+| `persistence.annotations`                                    | PVC annotations                                             | `{}`                                                         |
+| `persistence.storageClass`                                   | PVC Storage Class for nextcloud volume                      | `nil` (uses alpha storage class annotation)                  |
+| `persistence.existingClaim`                                  | An Existing PVC name for nextcloud volume                   | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                        | `ReadWriteOnce`                                              |
+| `persistence.size`                                           | PVC Storage Request for nextcloud volume                    | `8Gi`                                                        |
+| `resources`                                                  | CPU/Memory resource requests/limits                         | `{}`                                                         |
+| `livenessProbe.enabled`                                      | Turn on and off liveness probe                              | `true`                                                       |
+| `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                    | `30`                                                         |
+| `livenessProbe.periodSeconds`                                | How often to perform the probe                              | `15`                                                         |
+| `livenessProbe.timeoutSeconds`                               | When the probe times out                                    | `5`                                                          |
+| `livenessProbe.failureThreshold`                             | Minimum consecutive failures for the probe                  | `3`                                                          |
+| `livenessProbe.successThreshold`                             | Minimum consecutive successes for the probe                 | `1`                                                          |
+| `readinessProbe.enabled`                                     | Turn on and off readiness probe                             | `true`                                                       |
+| `readinessProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated                   | `30`                                                         |
+| `readinessProbe.periodSeconds`                               | How often to perform the probe                              | `15`                                                         |
+| `readinessProbe.timeoutSeconds`                              | When the probe times out                                    | `5`                                                          |
+| `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe                  | `3`                                                          |
+| `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe                 | `1`                                                          |
+| `hpa.enabled`                                                | Boolean to create a HorizontalPodAutoscaler                 | `false`                                                      |
+| `hpa.cputhreshold`                                           | CPU threshold percent for the HorizontalPodAutoscale        | `60`                                                         |
+| `hpa.minPods`                                                | Min. pods for the Nextcloud HorizontalPodAutoscaler         | `1`                                                          |
+| `hpa.maxPods`                                                | Max. pods for the Nextcloud HorizontalPodAutoscaler         | `10`                                                         |
+| `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level               | not set                                                      |
+| `podAnnotations`                                             | Annotations to be added at 'pod' level                      | not set                                                      |
+| `metrics.enabled`                                            | Start Prometheus metrics exporter                           | `false`                                                      |
+| `metrics.https`                                              | Defines if https is used to connect to nextcloud            | `false` (uses http)                                          |
+| `metrics.timeout`                                            | When the scrape times out                                   | `5s`                                                         |
+| `metrics.image.repository`                                   | Nextcloud metrics exporter image name                       | `xperimental/nextcloud-exporter`                             |
+| `metrics.image.tag`                                          | Nextcloud metrics exporter image tag                        | `v0.3.0`                                                     |
+| `metrics.image.pullPolicy`                                   | Nextcloud metrics exporter image pull policy                | `IfNotPresent`                                               |
+| `metrics.podAnnotations`                                     | Additional annotations for metrics exporter                 | not set                                                      |
+| `metrics.podLabels`                                          | Additional labels for metrics exporter                      | not set                                                      |
+| `metrics.service.type`                                       | Metrics: Kubernetes Service type                            | `ClusterIP`                                                  |
+| `metrics.service.loadBalancerIP`                             | Metrics: LoadBalancerIp for service type LoadBalancer       | `nil`                                                        |
+| `metrics.service.nodePort`                                   | Metrics: NodePort for service type NodePort                 | `nil`                                                        |
+| `metrics.service.annotations`                                | Additional annotations for service metrics exporter         | `{prometheus.io/scrape: "true", prometheus.io/port: "9205"}` |
+| `metrics.service.labels`                                     | Additional labels for service metrics exporter              | `{}`                                                         |
 
 > **Note**:
 >

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.image.command }}
+        command: {{ .Values.image.command | nindent 10 }}
+        {{- end -}}
+        {{- if .Values.image.args }}
+        args: {{ .Values.image.args | nindent 10 }}
+        {{- end -}}
         {{- if .Values.lifecycle }}
         lifecycle:
         {{-   if .Values.lifecycle.postStartCommand }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -7,6 +7,18 @@ image:
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName
+  # If not set, defaults will come from the Docker image's ENTRYPOINT==command and COMMAND==args
+  # command: |
+  #   - /bin/bash
+  # This example modifies the /entrypoint.sh script to signal into a file when it's done
+  # setting up the environment, right before launching the apache process
+  # This allows the postStartCommand to wait until php files and the `occ` binary are
+  # properly in /var/www/html to run the occ commands we want to automate
+  # args: |
+  #   - -c
+  #   - sed -i 's!exec "$@"!mkdir /start \&\& echo "Done" > /start/command\nexec "$@"!g'
+  #     /entrypoint.sh && cat /entrypoint.sh && /entrypoint.sh apache2-foreground
+
 
 nameOverride: ""
 fullnameOverride: ""
@@ -53,12 +65,12 @@ ingress:
   #        - nextcloud.kube.home
   labels: {}
 
-
 # Allow configuration of lifecycle hooks
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
 lifecycle: {}
   # postStartCommand: []
   # preStopCommand: []
+
 
 nextcloud:
   host: nextcloud.kube.home


### PR DESCRIPTION
## What this PR does / why we need it:
Adds the ability to override the command and args run by the container, to override the default ENTRYPOINT and COMMAND from the docker image.
A use-case for this is the ability to make the postStartCommand wait until `entrypoint.sh` is done copying over `php` files and the `occ` binary before running the `occ` commands we want to automate. Without it, there is a race condition between the postStartCommand which runs asynchronously with `entrypoint.sh` and in our experience causes at least 1 restart due to the `postStartCommand` failing for not finding `php` files in `/var/www/html/lib/`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
