### PR TITLE
[stable/prometheus] enable overide alertRelabelConfigs by local values file 

### DIFF
--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -1558,7 +1558,7 @@ extraScrapeConfigs:
 
 # Adds option to add alert_relabel_configs to avoid duplicate alerts in alertmanager
 # useful in H/A prometheus with different external labels but the same alerts
-alertRelabelConfigs:
+alertRelabelConfigs: {} 
   # alert_relabel_configs:
   # - source_labels: [dc]
   #   regex: (.+)\d+


### PR DESCRIPTION
without the '{}' it's not possible as helm need that it will be dict . 

`coalesce.go:165: warning: skipped value for alertRelabelConfigs: Not a table`


