### PR TITLE
[stable/datadog] Support custom check definitions for CLC Runners

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.39
+
+* Propagate `datadog.checksd` to the clusterchecks runner to support custom checks there.
+
 ## 2.3.38
 
 * Add support of DD\_CONTAINER\_{INCLUDE,EXCLUDE}\_{METRICS,LOGS}

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.38
+version: 2.3.39
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         app: {{ template "datadog.fullname" . }}-clusterchecks
       name: {{ template "datadog.fullname" . }}-clusterchecks
+      annotations:
+        {{- if .Values.datadog.checksd }}
+        checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
+        {{- end }}
     spec:
       {{- if .Values.clusterChecksRunner.rbac.dedicated }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
@@ -33,6 +37,34 @@ spec:
       dnsConfig:
 {{ toYaml .Values.clusterChecksRunner.dnsConfig | indent 8 }}
       {{- end }}
+      initContainers:
+      - name: init-volume
+        image: "{{ .Values.agents.image.repository }}:{{ .Values.agents.image.tag }}"
+        imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
+        command: ["bash", "-c"]
+        args:
+          - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+        resources:
+{{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
+      - name: init-config
+        image: "{{ .Values.agents.image.repository }}:{{ .Values.agents.image.tag }}"
+        imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
+        command: ["bash", "-c"]
+        args:
+          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+          {{- if .Values.datadog.checksd }}
+          - name: checksd
+            mountPath: /checks.d
+            readOnly: true
+          {{- end }}
+        resources:
+{{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
       containers:
       - name: agent
         image: "{{ .Values.clusterChecksRunner.image.repository }}:{{ .Values.clusterChecksRunner.image.tag }}"
@@ -104,15 +136,24 @@ spec:
 {{ toYaml .Values.clusterChecksRunner.resources | indent 10 }}
 {{- if .Values.clusterChecksRunner.volumeMounts }}
         volumeMounts:
+          - name: config
+            mountPath: {{ template "datadog.confPath" . }}
 {{ toYaml .Values.clusterChecksRunner.volumeMounts | indent 10 }}
 {{- end }}
         livenessProbe:
 {{ toYaml .Values.clusterChecksRunner.livenessProbe | indent 10 }}
         readinessProbe:
 {{ toYaml .Values.clusterChecksRunner.readinessProbe | indent 10 }}
-{{- if .Values.clusterChecksRunner.volumes }}
       volumes:
+{{- if .Values.clusterChecksRunner.volumes }}
 {{ toYaml .Values.clusterChecksRunner.volumes | indent 8 }}
+{{- end }}
+        - name: config
+          emptyDir: {}
+{{- if .Values.datadog.checksd }}
+        - name: checksd
+          configMap:
+            name: {{ template "datadog.fullname" . }}-checksd
 {{- end }}
       affinity:
 {{- if .Values.clusterChecksRunner.affinity }}


### PR DESCRIPTION
#### What this PR does / why we need it:

It's already possible to define `checksd` and `confd` in the Agent
config, but those options are missing for the Clusterchecks Runner.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
