### PR TITLE
[stable/datadog] Fix daemonset generation if `datadog.securityContext==nil`

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.28
+
+* fix daemonset template generation if `datadog.securityContext` is set to `nil`
+
 ## 2.3.27
 
 * add systemProbe.collectDNSStats option

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.27
+version: 2.3.28
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/ci/securitycontext-nil.yaml
+++ b/stable/datadog/ci/securitycontext-nil.yaml
@@ -1,0 +1,6 @@
+# Test the support of `securitContext` set to `nil`
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  
+  securityContext:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
 {{ toYaml .Values.agents.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if and .Values.datadog.securityContext .Values.datadog.securityContext.seLinuxOptions }}
+      {{- if (.Values.datadog.securityContext) and .Values.datadog.securityContext.seLinuxOptions }}
       securityContext:
         seLinuxOptions:
 {{ toYaml .Values.datadog.securityContext.seLinuxOptions | indent 10 }}


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

If the `datadog.securityContext` value is set to `nil` instead of `{}`
when a user want to remove the default `securityContext`, helm is not
able to generate the Daemonset manifest.

To support this configuration we have change how we test the value.
With the new `{{ if ...}}` check we don't check the second comparison
if the first already return false.

#### Which issue this PR fixes
  - fixes #23084

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
