### PR TITLE
[incubator/buzzfeed-sso] Allow disabling auth ingress

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.2.3
+version: 0.2.4
 appVersion: 2.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `auth.service.type` | type of auth service to create | `ClusterIP`
 `auth.service.port` | port for the http auth service | `80`
 `auth.secret` | secrets to be generated randomly with `openssl rand -base64 32 | head -c 32`. | REQUIRED if `auth.customSecret` is not set
+`auth.ingressEnabled` | enable auth ingress. | `true`
 `auth.ingressPath` | auth ingress path. | `/`
 `auth.tls` | tls configuration for central sso auth ingress. | `{}`
 `auth.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `auth.secret` is not set

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
 {{- if or .Values.auth.tls .Values.ingress.tls }}
   tls:
-  {{- if .Values.auth.tls }}
+  {{- if and .Values.auth.ingressEnabled .Values.auth.tls }}
     - hosts:
         - {{ $authDomain }}
       secretName: {{ .Values.auth.tls.secretName -}}
@@ -45,6 +45,7 @@ spec:
               serviceName: {{ $fullName }}-proxy
               servicePort: http
   {{- end }}
+  {{- if .Values.auth.ingressEnabled }}
     # Global SSO used in the callback for login
     - host: {{ $authDomain }}
       http:
@@ -53,5 +54,6 @@ spec:
             backend:
               serviceName: {{ $fullName }}-auth
               servicePort: http
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -27,6 +27,9 @@ auth:
     # cookieSecret: ''
   # # Or if you do not want to create the secret via helm
   # customSecret: my-sso-auth-secret
+  # Include Auth application in ingress, useful if auth component is 
+  # exposed independently.
+  ingressEnabled: true
   # Auth application ingress path.
   # For GKE and AWS ALB ingresses use "/*"
   # For Nginx ingress use "/"


### PR DESCRIPTION
Add the ability to enable/disable the auth ingress. Useful if auth ingress is to be handled separately.

Signed-off-by: Damian Peckett <damian.peckett@kloeckner.com>

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)