### PR TITLE
[stable/hlf-peer] (URGENT) Configure chaincode builder and chaincode runtime image 

### DIFF
--- a/stable/hlf-peer/Chart.yaml
+++ b/stable/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-peer
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.4.3
 keywords:
   - blockchain

--- a/stable/hlf-peer/README.md
+++ b/stable/hlf-peer/README.md
@@ -74,7 +74,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | Parameter                         | Description                                       | Default                   |
 | --------------------------------- | ------------------------------------------------- | ------------------------- |
 | `image.repository`                | `hlf-peer` image repository                       | `hyperledger/fabric-peer` |
-| `image.tag`                       | `hlf-peer` image tag                              | `1.4.3`            |
+| `image.tag`                       | `hlf-peer` image tag                              | `1.4.3`                   |
 | `image.pullPolicy`                | Image pull policy                                 | `IfNotPresent`            |
 | `service.portRequest`             | TCP port for requests to Peer                     | `7051`                    |
 | `service.portEvent`               | TCP port for event service on Peer                | `7053`                    |
@@ -107,6 +107,10 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `peer.gossip.useLeaderElection`   | Gossip use leader election                        | `"true"`                  |
 | `peer.tls.server.enabled`         | Do we enable server-side TLS?                     | `false`                   |
 | `peer.tls.client.enabled`         | Do we enable client-side TLS?                     | `false`                   |
+| `peer.chaincode.builder`          | Image of the chaincode builder                    | ``                        |
+| `peer.chaincode.runtime.golang`   | Image of the chaincode runtime for Go             | ``                        |
+| `peer.chaincode.runtime.java`     | Image of the chaincode runtime for Java           | ``                        |
+| `peer.chaincode.runtime.node`     | Image of the chaincode runtime for Node.js        | ``                        |
 | `secrets.peer.cred`               | Credentials: 'CA_USERNAME' and 'CA_PASSWORD'      | ``                        |
 | `secrets.peer.cert`               | Certificate: as 'cert.pem'                        | ``                        |
 | `secrets.peer.key`                | Private key: as 'key.pem'                         | ``                        |

--- a/stable/hlf-peer/templates/configmap--peer.yaml
+++ b/stable/hlf-peer/templates/configmap--peer.yaml
@@ -41,6 +41,21 @@ data:
   CORE_PEER_GOSSIP_EXTERNALENDPOINT: {{ .Values.peer.gossip.externalEndpoint | quote }}
   CORE_PEER_GOSSIP_ORGLEADER: {{ .Values.peer.gossip.orgLeader | quote }}
   CORE_PEER_GOSSIP_USELEADERELECTION: {{ .Values.peer.gossip.useLeaderElection | quote }}
+  #############
+  # CHAINCODE #
+  #############
+  {{- if .Values.peer.chaincode.builder }}
+  CORE_CHAINCODE_BUILDER: {{ .Values.peer.chaincode.builder | quote }}
+  {{- end}}
+  {{- if .Values.peer.chaincode.runtime.golang }}
+  CORE_CHAINCODE_GOLANG_RUNTIME: {{ .Values.peer.chaincode.runtime.golang | quote }}
+  {{- end}}
+  {{- if .Values.peer.chaincode.runtime.java }}
+  CORE_CHAINCODE_JAVA_RUNTIME: {{ .Values.peer.chaincode.runtime.java | quote }}
+  {{- end}}
+  {{- if .Values.peer.chaincode.runtime.node }}
+  CORE_CHAINCODE_NODE_RUNTIME: {{ .Values.peer.chaincode.runtime.node | quote }}
+  {{- end}}
   ##########
   # TLS    #
   ##########

--- a/stable/hlf-peer/values.yaml
+++ b/stable/hlf-peer/values.yaml
@@ -54,6 +54,7 @@ logging:
   msp: warning
   policies: warning
 
+
 ##################################
 ## Peer configuration options    #
 ##################################
@@ -76,7 +77,13 @@ peer:
       enabled: "false"
     client:
       enabled: "false"
-
+  chaincode:
+    # define the ccenv image used by the peer
+    builder: ""
+    runtime:
+      golang: ""
+      java: ""
+      node: ""
 # Secrets references, empty by default, fill in with your secrets (particularly adminCert) or add Peer Admin certificate manually after launching chart.
 secrets:
   ## These secrets should contain the Orderer crypto materials and credentials


### PR DESCRIPTION
#### What this PR does / why we need it: 
Since hyperledger deleted the `latest` tag from `hyperledger/fabric-ccenv` on [Dockerhub](https://hub.docker.com/r/hyperledger/fabric-ccenv) the chart is currently unusable.
Setting these env variables we can tell the peer to pull a different chaincode builder and not the one tagged latest.

It is also useful for people that want to use their own chaincode builder or chaincode runtime container.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
