### PR TITLE
[stable/oauth2-proxy] Use newer ingress API to be compatible with Kubernetes 1.16

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.0
+version: 3.2.1
 apiVersion: v1
 appVersion: 5.1.0
 home: https://pusher.github.io/oauth2_proxy/

--- a/stable/oauth2-proxy/templates/ingress.yaml
+++ b/stable/oauth2-proxy/templates/ingress.yaml
@@ -3,7 +3,11 @@
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   labels:

--- a/stable/oauth2-proxy/templates/ingress.yaml
+++ b/stable/oauth2-proxy/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
#### What this PR does / why we need it:

Kubernetes 1.16 deprecates various APIs and therefore manifests require updates.
This PR updates the ingress API version and is backwards compatible so it can still be used with older Kubernetes versions.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
