### PR TITLE
[stable/datadog] fix daemonset templates for go 1.14

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Datadog changelog
 
 ## 2.3.30
-* Fixed daemoset template for go 1.14
+* Fixed daemonset template for go 1.14
 
 ## 2.3.29
 

--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 2.3.30
+* Fixed daemoset template for go 1.14
+
 ## 2.3.29
 
 * Change the default port for the Cluster Agent's External Metrics Provider

--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 2.3.30
+## 2.3.31
 * Fixed daemonset template for go 1.14
 
 ## 2.3.29

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.29
+version: 2.3.30
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.30
+version: 2.3.31
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
 {{ toYaml .Values.agents.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if (.Values.datadog.securityContext) and .Values.datadog.securityContext.seLinuxOptions }}
+      {{- if and (.Values.datadog.securityContext) .Values.datadog.securityContext.seLinuxOptions }}
       securityContext:
         seLinuxOptions:
 {{ toYaml .Values.datadog.securityContext.seLinuxOptions | indent 10 }}


### PR DESCRIPTION
Signed-off-by: Shun Yamamoto <shun-yamamoto@m3.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
- Current daemonset templates is not compatible with go 1.14, this PR fix that
  - related: https://github.com/helm/charts/pull/21888

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fieldas.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
