### PR TITLE
[stable/fluentd] Add podLabels

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.4.3
+version: 2.5.0
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `output.sslVersion` | output ssl version | `TLSv1`
 `output.buffer_chunk_limit` | output buffer chunk limit | `2M`
 `output.buffer_queue_limit` | output buffer queue limit | `8`
+`deployment.labels` | Additional labels for pods | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `gcr.io/google-containers/fluentd-elasticsearch`
 `image.tag` | Image tag | `v2.4.0`
@@ -70,7 +71,6 @@ Parameter | Description | Default
 `resources` | pod resource requests & limits | `{}`
 `plugins.enabled` | Enable Plugins Installation | `false`
 `plugins.pluginsList` | List of plugins to install | `[]`
-`podLabels` | Additional labels for pods | `{}`
 `rbac.create` | Specifies whether RBAC resources should be created | `true`
 `serviceAccount.create` | Specifies whether a service account should be created. | `true`
 `serviceAccount.name` | Name of the service account.

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -70,6 +70,7 @@ Parameter | Description | Default
 `resources` | pod resource requests & limits | `{}`
 `plugins.enabled` | Enable Plugins Installation | `false`
 `plugins.pluginsList` | List of plugins to install | `[]`
+`podLabels` | Additional labels for pods | `{}`
 `rbac.create` | Specifies whether RBAC resources should be created | `true`
 `serviceAccount.create` | Specifies whether a service account should be created. | `true`
 `serviceAccount.name` | Name of the service account.

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       labels:
         app: {{ template "fluentd.name" . }}
         release: {{ .Release.Name }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.annotations }}

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       labels:
         app: {{ template "fluentd.name" . }}
         release: {{ .Release.Name }}
-{{- with .Values.podLabels }}
+{{- with .Values.deployment.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -64,12 +64,13 @@ metrics:
     # interval: 30s
     # scrapeTimeout: 10s
 
-## Pod Labels
-podLabels: {}
-
 annotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "24231"
+
+# Pod Labels
+deployment:
+  labels: {}
 
 ingress:
   enabled: false

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -64,6 +64,9 @@ metrics:
     # interval: 30s
     # scrapeTimeout: 10s
 
+## Pod Labels
+podLabels: {}
+
 annotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "24231"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No.

#### What this PR does / why we need it:

Adds possibility to set an additional labels for pods created by deployment. This is useful, for example, when you need to associate pods created by this chart with existing service. (I'm testing canary deployment of `fluentd` and need to route traffic via existing `ClusterIP` service, not related to this chart).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
