### PR TITLE
[stable/stackdriver-exporter] Allow to specify service account annotations

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.2.3
+version: 1.3.0
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -66,6 +66,7 @@ Parameter                           | Description                               
 `resources`                         | Resource requests & limits                                                      | `{}`
 `serviceAccount.name`               | Name of Kubernetes service account to use                                       | `""` (defaults to `default`)
 `serviceAccount.create`             | Toggle for service account creation                                             | `false`
+`serviceAccount.annotations`        | Annotations for service account. Only used if `create` is `true`.               | `nil`
 `service.type`                      | Type of service to create                                                       | `ClusterIP`
 `service.httpPort`                  | Port for the http service                                                       | `9255`
 `stackdriver.projectId`             | GCP Project ID                                                                  | ``

--- a/stable/stackdriver-exporter/templates/serviceaccount.yaml
+++ b/stable/stackdriver-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   name: {{ template "stackdriver-exporter.serviceAccountName" . }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 {{- end -}}

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -83,6 +83,7 @@ serviceAccount:
   # If not set and create is false, 'default' is used
   # If not set and create is true, a name is generated using the fullname template
   name:
+  annotations: {}
 
 # Enable this if you're using https://github.com/coreos/prometheus-operator
 serviceMonitor:


### PR DESCRIPTION
#### What this PR does / why we need it:

This change enables the usage of [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
