### PR TITLE
[stable/opa] Add extra{containers,ports,volumes} to OPA deployment

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.13.6
+version: 1.14.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -94,3 +94,6 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `timeoutSeconds` | Timeout for a webhook call in seconds. | `` |
 | `securityContext` | Security context for the containers | `{enabled: false, runAsNonRoot: true, runAsUser: 1}` |
 | `deploymentStrategy` | Specify deployment spec rollout strategy | `{}` |
+| `extraContainers` | Additional containers to be added to the deployment | `[]` |
+| `extraVolumes` | Additional volumes to be added to the deployment | `[]` |
+| `extraPorts` | Additional ports to OPA service. Useful to expose `extraContainer` ports. | `[]` |

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -166,6 +166,9 @@ spec:
             - proxy
             - --accept-paths=^/apis/authorization.k8s.io/v1/subjectaccessreviews$
 {{- end }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8}}
+{{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         {{- range $key, $val := .Values.securityContext }}
@@ -187,6 +190,9 @@ spec:
 {{- if or .Values.authz.enabled .Values.bootstrapPolicies}}
         - name: bootstrap
           emptyDir: {}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8}}
+{{- end }}
 {{- end }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/stable/opa/templates/service.yaml
+++ b/stable/opa/templates/service.yaml
@@ -12,3 +12,6 @@ spec:
     protocol: TCP
     port: 443
     targetPort: {{ .Values.port }}
+{{- if .Values.extraPorts }}
+{{ toYaml .Values.extraPorts | indent 2}}
+{{- end }}

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -239,3 +239,33 @@ deploymentStrategy: {}
   #   maxSurge: 1
   #   maxUnavailable: 0
   # type: RollingUpdate
+
+extraContainers: []
+## Additional containers to be added to the opa pod.
+# - name: example-app
+#   image: example/example-app:latest
+#   args:
+#     - "run"
+#     - "--port=11811"
+#     - "--config=/etc/example-app-conf/config.yaml"
+#     - "--opa-endpoint=https://localhost:443"
+#   ports:
+#     - name: http
+#       containerPort: 11811
+#       protocol: TCP
+#   volumeMounts:
+#     - name: example-app-auth-config
+#       mountPath: /etc/example-app-conf
+
+extraVolumes: []
+## Additional volumes to the opa pod.
+# - name: example-app-auth-config
+#   secret:
+#     secretName: example-app-auth-config
+
+extraPorts: []
+## Additional ports to the opa services. Useful to expose extra container ports.
+# - port: 11811
+#   protocol: TCP
+#   name: http
+#   targetPort: http


### PR DESCRIPTION
#### What this PR does / why we need it:

Enables the possibility of adding additional containers to the OPA deployment.
One of the key features of OPA is to be used by applications as a police/rule engine. 
For stateless applications would be awesome to be running alongside OPA container (being benefit of low/0 latency)

#### Which issue this PR fixes
#23168

#### Special notes for your reviewer:
The content of this PR does not modify previous behavior. It's a feature you choose to use or not.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
