### PR TITLE
[stable/jenkins] update agent image

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 2.4.0 Update default agent image
+
+`jenkins/jnlp-slave` is deprected and `jenkins/inbound-agent` should be used instead.
+Also updated it to newest version (4.3-4).
+
 ## 2.3.3 correct templating of master.slaveJenkinsUrl
 
 Fixes #22708

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.3.3
+version: 2.4.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -288,9 +288,9 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.alwaysPullImage`    | Always pull agent container image before build  | `false`                |
 | `agent.customJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
 | `agent.enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
-| `agent.image`              | Agent image name                                | `jenkins/jnlp-slave`   |
+| `agent.image`              | Agent image name                                | `jenkins/inbound-agent`|
 | `agent.imagePullSecretName` | Agent image pull secret                        | Not set                |
-| `agent.tag`                | Agent image tag                                 | `3.27-1`               |
+| `agent.tag`                | Agent image tag                                 | `4.3-4`               |
 | `agent.privileged`         | Agent privileged container                      | `false`                |
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}` |
 | `agent.volumes`            | Additional volumes                              | `[]`                   |

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -453,8 +453,8 @@ master:
 
 agent:
   enabled: true
-  image: "jenkins/jnlp-slave"
-  tag: "3.27-1"
+  image: "jenkins/inbound-agent"
+  tag: "4.3-4"
   workingDir: "/home/jenkins"
   customJenkinsLabels: []
   # name of the secret to be used for image pulling


### PR DESCRIPTION
#### What this PR does / why we need it:
`jenkins/jnlp-slave` is deprected and `jenkins/inbound-agent` should be used instead

![image](https://user-images.githubusercontent.com/1743774/87541019-dfcc5a00-c6a0-11ea-8af2-e33207b8cee6.png)

https://hub.docker.com/r/jenkins/inbound-agent

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
