### PR TITLE
[stable/prometheus-operator] Add docker checksum option

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.0.1
+version: 9.1.0
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -193,7 +193,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.admissionWebhooks.patch.image.pullPolicy` | Image pull policy for the webhook integration jobs | `IfNotPresent` |
 | `prometheusOperator.admissionWebhooks.patch.image.repository` | Repository to use for the webhook integration jobs | `jettech/kube-webhook-certgen` |
 | `prometheusOperator.admissionWebhooks.patch.image.tag` | Tag to use for the webhook integration jobs | `v1.2.1` |
-| `prometheusOperator.admissionWebhooks.patch.image.sha` | Sha to use for the webhook integration jobs (optional) | `3e6adf0140f5749427a83a750cc436c532872fa7bf01d01b25bb163737dab245` |
+| `prometheusOperator.admissionWebhooks.patch.image.sha` | Sha to use for the webhook integration jobs (optional) | `` |
 | `prometheusOperator.admissionWebhooks.patch.resources` | Resource limits for admission webhook | `{}` |
 | `prometheusOperator.admissionWebhooks.patch.nodeSelector` | Node selector for running admission hook patch jobs | `nil` |
 | `prometheusOperator.admissionWebhooks.patch.podAnnotations` | Annotations for the webhook job pods | `nil` |
@@ -204,7 +204,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.configReloaderMemory` | Set the prometheus config reloader side-car memory limit. If unset, uses the prometheus-operator project default | `nil` |
 | `prometheusOperator.configmapReloadImage.repository` | Repository for configmapReload image | `docker.io/jimmidyson/configmap-reload` |
 | `prometheusOperator.configmapReloadImage.tag` | Tag for configmapReload image | `v0.3.0` |
-| `prometheusOperator.configmapReloadImage.sha` | Sha for configmapReload image (optional) | `1ec6625fda2f541d4df87514c8a48e52a563fbb744e857c5d9b41a75c9139413` |
+| `prometheusOperator.configmapReloadImage.sha` | Sha for configmapReload image (optional) | `` |
 | `prometheusOperator.createCustomResource` | Create CRDs. Required if deploying anything besides the operator itself as part of the release. The operator will create / update these on startup. If your Helm version < 2.10 you will have to either create the CRDs first or deploy the operator first, then the rest of the resources. Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation | `true` |
 | `prometheusOperator.namespaces` |  Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with `denyNamespaces`. Setting this to an empty object will disable the configuration | `{}` |
 | `prometheusOperator.namespaces.releaseNamespace` | Include the release namespace | `false` |
@@ -215,11 +215,11 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.hyperkubeImage.pullPolicy` | Image pull policy for hyperkube image used to perform maintenance tasks | `IfNotPresent` |
 | `prometheusOperator.hyperkubeImage.repository` | Repository for hyperkube image used to perform maintenance tasks | `k8s.gcr.io/hyperkube` |
 | `prometheusOperator.hyperkubeImage.tag` | Tag for hyperkube image used to perform maintenance tasks | `v1.16.12` |
-| `prometheusOperator.hyperkubeImage.sha` | Sha for hyperkube image used to perform maintenance tasks | `c94da4ddf6f50a55ee739c9b5d32eb92687578ca0f38bb4a12529cffaac33b7e` |
+| `prometheusOperator.hyperkubeImage.sha` | Sha for hyperkube image used to perform maintenance tasks | `` |
 | `prometheusOperator.image.pullPolicy` | Pull policy for prometheus operator image | `IfNotPresent` |
 | `prometheusOperator.image.repository` | Repository for prometheus operator image | `quay.io/coreos/prometheus-operator` |
 | `prometheusOperator.image.tag` | Tag for prometheus operator image | `v0.38.1` |
-| `prometheusOperator.image.sha` | Sha for prometheus operator image  (optional) | `62b8cf466e9b238a9fcf0bcba74562c8833e7451042321e323a46de3f1dbe1bc` |
+| `prometheusOperator.image.sha` | Sha for prometheus operator image  (optional) | `` |
 | `prometheusOperator.kubeletService.enabled` | If true, the operator will create and maintain a service for scraping kubelets | `true` |
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
@@ -231,7 +231,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.priorityClassName` | Name of Priority Class to assign pods | `nil` |
 | `prometheusOperator.prometheusConfigReloaderImage.repository` | Repository for config-reloader image | `quay.io/coreos/prometheus-config-reloader` |
 | `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.38.1` |
-| `prometheusOperator.prometheusConfigReloaderImage.sha` | Sha for config-reloader image (optional) | `d1cce64093d4a850d28726ec3e48403124808f76567b5bd7b26e4416300996a7` |
+| `prometheusOperator.prometheusConfigReloaderImage.sha` | Sha for config-reloader image (optional) | `` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.securityContext` | SecurityContext for prometheus operator | `{"fsGroup": 65534, "runAsGroup": 65534, "runAsNonRoot": true, "runAsUser": 65534}` |
 | `prometheusOperator.service.annotations` | Annotations to be added to the prometheus operator service | `{}` |
@@ -252,7 +252,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.tlsProxy.enabled` | Enable a TLS proxy container. Only the `squareup/ghostunnel` command line arguments are currently supported and the secret where the cert is loaded from is expected to be provided by the admission webhook | `true` |
 | `prometheusOperator.tlsProxy.image.repository` | Repository for the TLS proxy container | `squareup/ghostunnel` |
 | `prometheusOperator.tlsProxy.image.tag` | Repository for the TLS proxy container | `v1.5.2` |
-| `prometheusOperator.tlsProxy.image.sha` | Sha for the TLS proxy container (optional) | `70f4cf270425dee074f49626ec63fc96e6712e9c0eedf127e7254e8132d25063` |
+| `prometheusOperator.tlsProxy.image.sha` | Sha for the TLS proxy container (optional) | `` |
 | `prometheusOperator.tlsProxy.image.pullPolicy` | Image pull policy for the TLS proxy container | `IfNotPresent` |
 | `prometheusOperator.tlsProxy.resources` | Resource requests and limits for the TLS proxy container | `{}` |
 | `prometheusOperator.tolerations` | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
@@ -304,7 +304,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.prometheusSpec.externalUrl` | The external URL the Prometheus instances will be available under. This is necessary to generate correct URLs. This is necessary if Prometheus is not served from root of a DNS name. | `""` |
 | `prometheus.prometheusSpec.image.repository` | Base image to use for a Prometheus deployment. | `quay.io/prometheus/prometheus` |
 | `prometheus.prometheusSpec.image.tag` | Tag of Prometheus container image to be deployed. | `v2.18.2` |
-| `prometheus.prometheusSpec.image.sha` | Sha of Prometheus container image to be deployed (optional). | `4d3303d1eb424e345cf48969bb7575d4d58472ad783ac41ea07fba92686f7ef5` |
+| `prometheus.prometheusSpec.image.sha` | Sha of Prometheus container image to be deployed (optional). | `` |
 | `prometheus.prometheusSpec.listenLocal` | ListenLocal makes the Prometheus server listen on loopback, so that it does not bind against the Pod IP. | `false` |
 | `prometheus.prometheusSpec.logFormat` | Log format for Prometheus to be configured with. | `logfmt` |
 | `prometheus.prometheusSpec.logLevel` | Log level for Prometheus to be configured with. | `info` |
@@ -388,7 +388,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.alertmanagerSpec.externalUrl` | The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. | `""` |
 | `alertmanager.alertmanagerSpec.image.repository` | Base image that is used to deploy pods, without tag. | `quay.io/prometheus/alertmanager` |
 | `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.21.0` |
-| `alertmanager.alertmanagerSpec.image.sha` | Sha of Alertmanager container image to be deployed (optional). | `24a5204b418e8fa0214cfb628486749003b039c279c56b5bddb5b10cd100d926` |
+| `alertmanager.alertmanagerSpec.image.sha` | Sha of Alertmanager container image to be deployed (optional). | `` |
 | `alertmanager.alertmanagerSpec.listenLocal` | ListenLocal makes the Alertmanager server listen on loopback, so that it does not bind against the Pod IP. Note this is only for the Alertmanager UI, not the gossip communication. | `false` |
 | `alertmanager.alertmanagerSpec.logFormat` | Log format for Alertmanager to be configured with. | `logfmt` |
 | `alertmanager.alertmanagerSpec.logLevel` | Log level for Alertmanager to be configured with. | `info` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -193,6 +193,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.admissionWebhooks.patch.image.pullPolicy` | Image pull policy for the webhook integration jobs | `IfNotPresent` |
 | `prometheusOperator.admissionWebhooks.patch.image.repository` | Repository to use for the webhook integration jobs | `jettech/kube-webhook-certgen` |
 | `prometheusOperator.admissionWebhooks.patch.image.tag` | Tag to use for the webhook integration jobs | `v1.2.1` |
+| `prometheusOperator.admissionWebhooks.patch.image.sha` | Sha to use for the webhook integration jobs (optional) | `3e6adf0140f5749427a83a750cc436c532872fa7bf01d01b25bb163737dab245` |
 | `prometheusOperator.admissionWebhooks.patch.resources` | Resource limits for admission webhook | `{}` |
 | `prometheusOperator.admissionWebhooks.patch.nodeSelector` | Node selector for running admission hook patch jobs | `nil` |
 | `prometheusOperator.admissionWebhooks.patch.podAnnotations` | Annotations for the webhook job pods | `nil` |
@@ -203,6 +204,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.configReloaderMemory` | Set the prometheus config reloader side-car memory limit. If unset, uses the prometheus-operator project default | `nil` |
 | `prometheusOperator.configmapReloadImage.repository` | Repository for configmapReload image | `docker.io/jimmidyson/configmap-reload` |
 | `prometheusOperator.configmapReloadImage.tag` | Tag for configmapReload image | `v0.3.0` |
+| `prometheusOperator.configmapReloadImage.sha` | Sha for configmapReload image (optional) | `1ec6625fda2f541d4df87514c8a48e52a563fbb744e857c5d9b41a75c9139413` |
 | `prometheusOperator.createCustomResource` | Create CRDs. Required if deploying anything besides the operator itself as part of the release. The operator will create / update these on startup. If your Helm version < 2.10 you will have to either create the CRDs first or deploy the operator first, then the rest of the resources. Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation | `true` |
 | `prometheusOperator.namespaces` |  Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with `denyNamespaces`. Setting this to an empty object will disable the configuration | `{}` |
 | `prometheusOperator.namespaces.releaseNamespace` | Include the release namespace | `false` |
@@ -213,9 +215,11 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.hyperkubeImage.pullPolicy` | Image pull policy for hyperkube image used to perform maintenance tasks | `IfNotPresent` |
 | `prometheusOperator.hyperkubeImage.repository` | Repository for hyperkube image used to perform maintenance tasks | `k8s.gcr.io/hyperkube` |
 | `prometheusOperator.hyperkubeImage.tag` | Tag for hyperkube image used to perform maintenance tasks | `v1.16.12` |
+| `prometheusOperator.hyperkubeImage.sha` | Sha for hyperkube image used to perform maintenance tasks | `c94da4ddf6f50a55ee739c9b5d32eb92687578ca0f38bb4a12529cffaac33b7e` |
 | `prometheusOperator.image.pullPolicy` | Pull policy for prometheus operator image | `IfNotPresent` |
 | `prometheusOperator.image.repository` | Repository for prometheus operator image | `quay.io/coreos/prometheus-operator` |
 | `prometheusOperator.image.tag` | Tag for prometheus operator image | `v0.38.1` |
+| `prometheusOperator.image.sha` | Sha for prometheus operator image  (optional) | `62b8cf466e9b238a9fcf0bcba74562c8833e7451042321e323a46de3f1dbe1bc` |
 | `prometheusOperator.kubeletService.enabled` | If true, the operator will create and maintain a service for scraping kubelets | `true` |
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
@@ -227,6 +231,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.priorityClassName` | Name of Priority Class to assign pods | `nil` |
 | `prometheusOperator.prometheusConfigReloaderImage.repository` | Repository for config-reloader image | `quay.io/coreos/prometheus-config-reloader` |
 | `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.38.1` |
+| `prometheusOperator.prometheusConfigReloaderImage.sha` | Sha for config-reloader image (optional) | `d1cce64093d4a850d28726ec3e48403124808f76567b5bd7b26e4416300996a7` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.securityContext` | SecurityContext for prometheus operator | `{"fsGroup": 65534, "runAsGroup": 65534, "runAsNonRoot": true, "runAsUser": 65534}` |
 | `prometheusOperator.service.annotations` | Annotations to be added to the prometheus operator service | `{}` |
@@ -247,6 +252,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.tlsProxy.enabled` | Enable a TLS proxy container. Only the `squareup/ghostunnel` command line arguments are currently supported and the secret where the cert is loaded from is expected to be provided by the admission webhook | `true` |
 | `prometheusOperator.tlsProxy.image.repository` | Repository for the TLS proxy container | `squareup/ghostunnel` |
 | `prometheusOperator.tlsProxy.image.tag` | Repository for the TLS proxy container | `v1.5.2` |
+| `prometheusOperator.tlsProxy.image.sha` | Sha for the TLS proxy container (optional) | `70f4cf270425dee074f49626ec63fc96e6712e9c0eedf127e7254e8132d25063` |
 | `prometheusOperator.tlsProxy.image.pullPolicy` | Image pull policy for the TLS proxy container | `IfNotPresent` |
 | `prometheusOperator.tlsProxy.resources` | Resource requests and limits for the TLS proxy container | `{}` |
 | `prometheusOperator.tolerations` | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
@@ -298,6 +304,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.prometheusSpec.externalUrl` | The external URL the Prometheus instances will be available under. This is necessary to generate correct URLs. This is necessary if Prometheus is not served from root of a DNS name. | `""` |
 | `prometheus.prometheusSpec.image.repository` | Base image to use for a Prometheus deployment. | `quay.io/prometheus/prometheus` |
 | `prometheus.prometheusSpec.image.tag` | Tag of Prometheus container image to be deployed. | `v2.18.2` |
+| `prometheus.prometheusSpec.image.sha` | Sha of Prometheus container image to be deployed (optional). | `4d3303d1eb424e345cf48969bb7575d4d58472ad783ac41ea07fba92686f7ef5` |
 | `prometheus.prometheusSpec.listenLocal` | ListenLocal makes the Prometheus server listen on loopback, so that it does not bind against the Pod IP. | `false` |
 | `prometheus.prometheusSpec.logFormat` | Log format for Prometheus to be configured with. | `logfmt` |
 | `prometheus.prometheusSpec.logLevel` | Log level for Prometheus to be configured with. | `info` |
@@ -381,6 +388,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.alertmanagerSpec.externalUrl` | The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. | `""` |
 | `alertmanager.alertmanagerSpec.image.repository` | Base image that is used to deploy pods, without tag. | `quay.io/prometheus/alertmanager` |
 | `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.21.0` |
+| `alertmanager.alertmanagerSpec.image.sha` | Sha of Alertmanager container image to be deployed (optional). | `24a5204b418e8fa0214cfb628486749003b039c279c56b5bddb5b10cd100d926` |
 | `alertmanager.alertmanagerSpec.listenLocal` | ListenLocal makes the Alertmanager server listen on loopback, so that it does not bind against the Pod IP. Note this is only for the Alertmanager UI, not the gossip communication. | `false` |
 | `alertmanager.alertmanagerSpec.logFormat` | Log format for Alertmanager to be configured with. | `logfmt` |
 | `alertmanager.alertmanagerSpec.logLevel` | Log level for Alertmanager to be configured with. | `info` |

--- a/stable/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -11,6 +11,9 @@ spec:
 {{- if .Values.alertmanager.alertmanagerSpec.image }}
   baseImage: {{ .Values.alertmanager.alertmanagerSpec.image.repository }}
   version: {{ .Values.alertmanager.alertmanagerSpec.image.tag }}
+  {{- if .Values.alertmanager.alertmanagerSpec.image.sha }}
+  sha: {{ .Values.alertmanager.alertmanagerSpec.image.sha }}
+  {{- end }}
 {{- end }}
   replicas: {{ .Values.alertmanager.alertmanagerSpec.replicas }}
   listenLocal: {{ .Values.alertmanager.alertmanagerSpec.listenLocal }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -31,7 +31,11 @@ spec:
       {{- end }}
       containers:
         - name: create
+          {{- if .Values.prometheusOperator.admissionWebhooks.patch.image.sha }}
+          image: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.repository }}:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.tag }}@sha256:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.sha }}
+          {{- else }}
           image: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.repository }}:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.tag }}
+          {{- end }}
           imagePullPolicy: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - create

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -31,7 +31,11 @@ spec:
       {{- end }}
       containers:
         - name: patch
+          {{- if .Values.prometheusOperator.admissionWebhooks.patch.image.sha }}
+          image: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.repository }}:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.tag }}@sha256:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.sha }}
+          {{- else }}
           image: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.repository }}:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.tag }}
+          {{- end }}
           imagePullPolicy: {{ .Values.prometheusOperator.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - patch

--- a/stable/prometheus-operator/templates/prometheus-operator/cleanup-crds.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/cleanup-crds.yaml
@@ -24,7 +24,11 @@ spec:
     {{- end }}
       containers:
         - name: kubectl
+          {{- if .Values.prometheusOperator.hyperkubeImage.sha }}
+          image: {{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}@sha256:{{ .Values.prometheusOperator.hyperkubeImage.sha }}
+          {{- else }}
           image: "{{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}"
+          {{- end }}
           imagePullPolicy: "{{ .Values.prometheusOperator.hyperkubeImage.pullPolicy }}"
           command:
           - /bin/sh

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -32,7 +32,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ template "prometheus-operator.name" . }}
+          {{- if .Values.prometheusOperator.image.sha }}
+          image: "{{ .Values.prometheusOperator.image.repository }}:{{ .Values.prometheusOperator.image.tag }}@sha256:{{ .Values.prometheusOperator.image.sha }}"
+          {{- else }}
           image: "{{ .Values.prometheusOperator.image.repository }}:{{ .Values.prometheusOperator.image.tag }}"
+          {{- end }}
           imagePullPolicy: "{{ .Values.prometheusOperator.image.pullPolicy }}"
           args:
           {{- if semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag }}
@@ -59,8 +63,16 @@ spec:
           {{- end }}
             - --logtostderr=true
             - --localhost=127.0.0.1
+            {{- if .Values.prometheusOperator.prometheusConfigReloaderImage.sha }}
+            - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}@sha256:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.sha }}
+            {{- else }}
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.configmapReloadImage.sha }}
+            - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}@sha256:{{ .Values.prometheusOperator.configmapReloadImage.sha }}
+            {{- else }}
             - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}
+            {{- end }}
             - --config-reloader-cpu={{ .Values.prometheusOperator.configReloaderCpu }}
             - --config-reloader-memory={{ .Values.prometheusOperator.configReloaderMemory }}
           ports:
@@ -73,7 +85,11 @@ spec:
             readOnlyRootFilesystem: true
         {{- if .Values.prometheusOperator.tlsProxy.enabled }}
         - name: tls-proxy
+          {{- if .Values.prometheusOperator.tlsProxy.image.sha }}
+          image: {{ .Values.prometheusOperator.tlsProxy.image.repository }}:{{ .Values.prometheusOperator.tlsProxy.image.tag }}@sha256:{{ .Values.prometheusOperator.tlsProxy.image.sha }}
+          {{- else }}
           image: {{ .Values.prometheusOperator.tlsProxy.image.repository }}:{{ .Values.prometheusOperator.tlsProxy.image.tag }}
+          {{- end }}
           imagePullPolicy: {{ .Values.prometheusOperator.tlsProxy.image.pullPolicy }}
           args:
             - server

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -34,6 +34,9 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.image }}
   baseImage: {{ .Values.prometheus.prometheusSpec.image.repository }}
   version: {{ .Values.prometheus.prometheusSpec.image.tag }}
+  {{- if .Values.prometheus.prometheusSpec.image.sha }}
+  sha: {{ .Values.prometheus.prometheusSpec.image.sha }}
+  {{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.externalLabels }}
   externalLabels:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -336,6 +336,7 @@ alertmanager:
     image:
       repository: quay.io/prometheus/alertmanager
       tag: v0.21.0
+      sha: 24a5204b418e8fa0214cfb628486749003b039c279c56b5bddb5b10cd100d926
 
     ## If true then the user will be responsible to provide a secret with alertmanager configuration
     ## So when true the config part will be ignored (including templateFiles) and the one in the secret will be used
@@ -1139,6 +1140,7 @@ prometheusOperator:
     image:
       repository: squareup/ghostunnel
       tag: v1.5.2
+      sha: 70f4cf270425dee074f49626ec63fc96e6712e9c0eedf127e7254e8132d25063
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -1156,6 +1158,7 @@ prometheusOperator:
       image:
         repository: jettech/kube-webhook-certgen
         tag: v1.2.1
+        sha: 3e6adf0140f5749427a83a750cc436c532872fa7bf01d01b25bb163737dab245
         pullPolicy: IfNotPresent
       resources: {}
       ## Provide a priority class name to the webhook patching job
@@ -1332,6 +1335,7 @@ prometheusOperator:
   image:
     repository: quay.io/coreos/prometheus-operator
     tag: v0.38.1
+    sha: 62b8cf466e9b238a9fcf0bcba74562c8833e7451042321e323a46de3f1dbe1bc
     pullPolicy: IfNotPresent
 
   ## Configmap-reload image to use for reloading configmaps
@@ -1339,12 +1343,14 @@ prometheusOperator:
   configmapReloadImage:
     repository: docker.io/jimmidyson/configmap-reload
     tag: v0.3.0
+    sha: 1ec6625fda2f541d4df87514c8a48e52a563fbb744e857c5d9b41a75c9139413
 
   ## Prometheus-config-reloader image to use for config and rule reloading
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/coreos/prometheus-config-reloader
     tag: v0.38.1
+    sha: d1cce64093d4a850d28726ec3e48403124808f76567b5bd7b26e4416300996a7
 
   ## Set the prometheus config reloader side-car CPU limit
   ##
@@ -1359,6 +1365,7 @@ prometheusOperator:
   hyperkubeImage:
     repository: k8s.gcr.io/hyperkube
     tag: v1.16.12
+    sha: c94da4ddf6f50a55ee739c9b5d32eb92687578ca0f38bb4a12529cffaac33b7e
     pullPolicy: IfNotPresent
 
 ## Deploy a Prometheus instance
@@ -1579,6 +1586,7 @@ prometheus:
     image:
       repository: quay.io/prometheus/prometheus
       tag: v2.18.2
+      sha: 4d3303d1eb424e345cf48969bb7575d4d58472ad783ac41ea07fba92686f7ef5
 
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -336,7 +336,7 @@ alertmanager:
     image:
       repository: quay.io/prometheus/alertmanager
       tag: v0.21.0
-      sha: 24a5204b418e8fa0214cfb628486749003b039c279c56b5bddb5b10cd100d926
+      sha: ""
 
     ## If true then the user will be responsible to provide a secret with alertmanager configuration
     ## So when true the config part will be ignored (including templateFiles) and the one in the secret will be used
@@ -1140,7 +1140,7 @@ prometheusOperator:
     image:
       repository: squareup/ghostunnel
       tag: v1.5.2
-      sha: 70f4cf270425dee074f49626ec63fc96e6712e9c0eedf127e7254e8132d25063
+      sha: ""
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -1158,7 +1158,7 @@ prometheusOperator:
       image:
         repository: jettech/kube-webhook-certgen
         tag: v1.2.1
-        sha: 3e6adf0140f5749427a83a750cc436c532872fa7bf01d01b25bb163737dab245
+        sha: ""
         pullPolicy: IfNotPresent
       resources: {}
       ## Provide a priority class name to the webhook patching job
@@ -1335,7 +1335,7 @@ prometheusOperator:
   image:
     repository: quay.io/coreos/prometheus-operator
     tag: v0.38.1
-    sha: 62b8cf466e9b238a9fcf0bcba74562c8833e7451042321e323a46de3f1dbe1bc
+    sha: ""
     pullPolicy: IfNotPresent
 
   ## Configmap-reload image to use for reloading configmaps
@@ -1343,14 +1343,14 @@ prometheusOperator:
   configmapReloadImage:
     repository: docker.io/jimmidyson/configmap-reload
     tag: v0.3.0
-    sha: 1ec6625fda2f541d4df87514c8a48e52a563fbb744e857c5d9b41a75c9139413
+    sha: ""
 
   ## Prometheus-config-reloader image to use for config and rule reloading
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/coreos/prometheus-config-reloader
     tag: v0.38.1
-    sha: d1cce64093d4a850d28726ec3e48403124808f76567b5bd7b26e4416300996a7
+    sha: ""
 
   ## Set the prometheus config reloader side-car CPU limit
   ##
@@ -1365,7 +1365,7 @@ prometheusOperator:
   hyperkubeImage:
     repository: k8s.gcr.io/hyperkube
     tag: v1.16.12
-    sha: c94da4ddf6f50a55ee739c9b5d32eb92687578ca0f38bb4a12529cffaac33b7e
+    sha: ""
     pullPolicy: IfNotPresent
 
 ## Deploy a Prometheus instance
@@ -1586,7 +1586,7 @@ prometheus:
     image:
       repository: quay.io/prometheus/prometheus
       tag: v2.18.2
-      sha: 4d3303d1eb424e345cf48969bb7575d4d58472ad783ac41ea07fba92686f7ef5
+      sha: ""
 
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
#### What this PR does / why we need it:
- Adds optional docker checksum option to improve security for the deployed containers

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
