### PR TITLE
[stable/datadog] Always add os in nodeSelector based on `targetSystem`

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Datadog changelog
 
+## 2.3.32
+
+* Always add os in nodeSelector based on `targetSystem`
+
 ## 2.3.31
+
 * Fixed daemonset template for go 1.14
 
 ## 2.3.29

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.31
+version: 2.3.32
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -91,6 +91,17 @@ Return the appropriate apiVersion for RBAC APIs.
 {{- end -}}
 
 {{/*
+Return the appropriate os label
+*/}}
+{{- define "label.os" -}}
+{{- if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+kubernetes.io/os
+{{- else -}}
+beta.kubernetes.io/os
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the container runtime socket
 */}}
 {{- define "datadog.dockerOrCriSocketPath" -}}

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -126,8 +126,9 @@ spec:
                 app: {{ template "datadog.fullname" . }}-clusterchecks
             topologyKey: kubernetes.io/hostname
 {{- end }}
-      {{- if .Values.clusterChecksRunner.nodeSelector }}
       nodeSelector:
+        {{ template "label.os" . }}: {{ .Values.targetSystem }}
+      {{- if .Values.clusterChecksRunner.nodeSelector }}
 {{ toYaml .Values.clusterChecksRunner.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.clusterChecksRunner.tolerations }}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -216,5 +216,8 @@ spec:
 {{ toYaml .Values.clusterAgent.affinity | indent 8 }}
       {{- end }}
       nodeSelector:
+        {{ template "label.os" . }}: {{ .Values.targetSystem }}
+      {{- if .Values.clusterAgent.nodeSelector }}
 {{ toYaml .Values.clusterAgent.nodeSelector | indent 8 }}
+      {{- end }}
 {{ end }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -131,10 +131,9 @@ spec:
 {{ toYaml .Values.agents.affinity | indent 8 }}
       serviceAccountName: {{ if .Values.agents.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.agents.rbac.serviceAccountName }}"{{ end }}
       nodeSelector:
+        {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.agents.nodeSelector }}
 {{ toYaml .Values.agents.nodeSelector | indent 8 }}
-      {{- else if eq .Values.targetSystem "windows" }}
-        kubernetes.io/os: windows
       {{- end }}
   updateStrategy:
 {{ toYaml .Values.agents.updateStrategy | indent 4 }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Always add os in nodeSelector based on `targetSystem`

#### Which issue this PR fixes
Fix issues when users have Windows+Linux nodes without any taint.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
