### PR TITLE
[stable/hlf-peer] Add docker config.json secret for private registry

### DIFF
--- a/stable/hlf-peer/Chart.yaml
+++ b/stable/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-peer
-version: 1.4.0
+version: 1.5.0
 appVersion: 1.4.3
 keywords:
   - blockchain

--- a/stable/hlf-peer/README.md
+++ b/stable/hlf-peer/README.md
@@ -97,6 +97,8 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `ingress.hosts`                   | Ingress hostnames                                 | `[]`                      |
 | `ingress.tls`                     | Ingress TLS configuration                         | `[]`                      |
 | `dockerSocketPath`                | Docker Socket path                                | `/var/run/docker.sock`    |
+| `dockerConfig`                    | Docker Config file base 64 encoded                | `null`                    |
+| `dockerConfigMountPath`           | Docker Config file mount path                     | `/root/.docker`           |
 | `peer.databaseType`               | Database type to use (`goleveldb` or `CouchDB`)   | `goleveldb`               |
 | `peer.couchdbInstance`            | CouchDB chart name to use `cdb-peer1`             | `cdb-peer1`               |
 | `peer.mspID`                      | ID of MSP the Peer belongs to                     | `Org1MSP`                 |

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -30,6 +30,14 @@ spec:
         - name: dockersocket
           hostPath:
             path: {{ .Values.dockerSocketPath }}
+        {{- if .Values.dockerConfig }}
+        - name: docker-config
+          secret:
+            secretName: {{ include "hlf-peer.fullname" . }}-dockerconfigjson
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        {{- end }}
         {{- if .Values.secrets.peer.cert }}
         - name: id-cert
           secret:
@@ -163,6 +171,10 @@ spec:
               name: data
             - mountPath: /host/var/run/docker.sock
               name: dockersocket
+            {{- if .Values.dockerConfig }}
+            - name: docker-config
+              mountPath: {{ .Values.dockerConfigMountPath }}
+            {{ end }}
             {{- if .Values.secrets.peer.cert }}
             - mountPath: /var/hyperledger/msp/signcerts
               name: id-cert

--- a/stable/hlf-peer/templates/secret.yaml
+++ b/stable/hlf-peer/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.dockerConfig }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ include "hlf-peer.fullname" . }}-dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.dockerConfig }}
+{{ end }}

--- a/stable/hlf-peer/values.yaml
+++ b/stable/hlf-peer/values.yaml
@@ -13,7 +13,12 @@ service:
   portRequest: 7051
   portEvent: 7053
 
+# Path of the docker socket on the host
 dockerSocketPath: /var/run/docker.sock
+# Docker config to be used to pull the images (base64'd)
+dockerConfig: null
+# Docker config mount path
+dockerConfigMountPath: /root/.docker
 
 ingress:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Kelvin Moutet <kelvin.moutet@owkin.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

https://github.com/helm/charts/pull/23153 allows users to define chaincode builder and runtime images.
In case of using a private registry, we need to pass docker config.json to allow peer to pull images from that private registry.
Moreover people may want to use their own private chaincode builder or private chaincode runtime container.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
