### PR TITLE
[stable/percona-xtradb-cluster] Fixes #23207

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona-xtradb-cluster
-version: 1.0.4
+version: 1.0.5
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -63,6 +63,10 @@ The following table lists the configurable parameters of the Percona chart and t
 | `mysqlUser`                | Username of new user to create.    | `nil`                                                      |
 | `mysqlPassword`            | Password for the new user.         | `nil`                                                      |
 | `mysqlDatabase`            | Name for new database to create.   | `nil`                                                      |
+| `serviceAccountName`       | Name for the pod's serviceAccount  | `nil`                                                      |
+| `securityContext.runAsUser` | Run the pod with this uid         | `nil`                                                      |
+| `securityContext.runAsGroup` | Run the pod with this gid         | `nil`                                                      |
+| `securityContext.fsGroup`  | Set GID for mounted volumes        | `nil`                                                      |
 | `persistence.enabled`      | Create a volume to store data      | false                                                       |
 | `persistence.size`         | Size of persistent volume claim    | 8Gi RW                                                     |
 | `persistence.storageClass` | Type of persistent volume claim    | nil  (uses alpha storage class annotation)                 |

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -25,6 +25,13 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
     spec:
+      {{- with .Values.serviceAccountName }}
+      serviceAccountName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{ . | toYaml | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: "remove-lost-found"
         image: "busybox:1.25.0"
@@ -101,7 +108,7 @@ spec:
           timeoutSeconds: 2
         readinessProbe:
           exec:
-            command: ["mysql", "-h", "127.0.0.1", "-e", "SELECT 1"]
+            command: ["mysql", "--defaults-extra-file=/root/.my.cnf", "-h", "127.0.0.1", "-e", "SELECT 1"]
           initialDelaySeconds: 30
           timeoutSeconds: 2
         volumeMounts:

--- a/stable/percona-xtradb-cluster/values.yaml
+++ b/stable/percona-xtradb-cluster/values.yaml
@@ -167,3 +167,16 @@ podDisruptionBudget:
 service:
   percona:
     headless: false
+
+## Set the serviceAccountName.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+# serviceAccountName:
+
+## Set the securityContext parameters.
+## 999 is the UID of mysql user.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+#securityContext:
+#  runAsUser: 999
+#  runAsGroup: 999
+#  fsGroup: 999
+

--- a/stable/percona-xtradb-cluster/values.yaml
+++ b/stable/percona-xtradb-cluster/values.yaml
@@ -175,8 +175,7 @@ service:
 ## Set the securityContext parameters.
 ## 999 is the UID of mysql user.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-#securityContext:
-#  runAsUser: 999
-#  runAsGroup: 999
-#  fsGroup: 999
-
+# securityContext:
+#   runAsUser: 999
+#   runAsGroup: 999
+#   fsGroup: 999


### PR DESCRIPTION
Signed-off-by: Rafael Rivero <myspambox.rafael@gmail.com>

#### Is this a new chart

No, it's a fix for issue #23207 for chart stable/percona-xtradb-cluster.

#### What this PR does / why we need it:

Adds support for serviceAccount and securityContext parameters, to allow the chart to run on Openshift.

#### Which issue this PR fixes

Issue #23207 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
