### PR TITLE
[stable/kube-state-metrics] Fix STS role for Autosharding

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.11
+version: 2.8.12
 appVersion: 1.9.7
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/stsdiscovery-role.yaml
+++ b/stable/kube-state-metrics/templates/stsdiscovery-role.yaml
@@ -19,9 +19,11 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - kube-state-metrics
+  - {{ template "kube-state-metrics.fullname" . }}
   resources:
   - statefulsets
   verbs:
   - get
+  - list
+  - watch
 {{- end }}


### PR DESCRIPTION
```
Currently, Get, List and Watch are required. List and Watch are provided
by the ClusterRole related to collectors. The STS collector can be
disabled breaking the current AutoSharding role permissions.

Moreover, the resourceNames depends of the RELEASE_NAME as defined in
deployment.yaml so we need to reflect this or we won't have the correct
permission to read our STS.
```
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Currently, there are two things missing for Autosharding to work properly. The first having the correct permissions. When you are using this chart but disabling the STS collector, you end up having only the "Get" permission which is not enough to have a ListWatch.
The second is the STS name. This chart defines it as:
https://github.com/helm/charts/blob/39b30b5a042198fc749e21c38ab78589f3ddf90f/stable/kube-state-metrics/templates/deployment.yaml#L8

The Role however, specify `kube-state-metrics` which does not match the real name (and hence not provide you the permissions).

#### Which issue this PR fixes

No issue yet.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
