### PR TITLE
[stable/instana-agent] Chart version 1.0.29

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: instana-agent
 sources:
 - https://github.com/instana/instana-agent-docker
-version: 1.0.28
+version: 1.0.29

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -34,7 +34,7 @@ If you're in the EU, you'll probably also want to set the regional equivalent va
 * agent.endpointHost
 * agent.endpointPort
 
-_Note:_ Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
+_Note:_ You can find the options mentioned in the [configuration section below](#configuration)
 
 Optionally, if your infrastructure uses a proxy, you should ensure that you set values for:
 
@@ -119,7 +119,6 @@ The following table lists the configurable parameters of the Instana chart and t
 | `agent.image.tag`                  | The image tag to pull                                                   | `latest`                                                                                                    |
 | `agent.image.pullPolicy`           | Image pull policy                                                       | `Always`                                                                                                    |
 | `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key                                                                         |
-| `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                                                                                     |
 | `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                                                                                       |
 | `agent.mode`                       | Agent mode (Supported values are APM, INFRASTRUCTURE, AWS)              | `APM`                                                                                                       |
 | `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                                                                                        |
@@ -135,9 +134,12 @@ The following table lists the configurable parameters of the Instana chart and t
 | `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                                                                                       |
 | `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                                                                                        |
 | `agent.env`                        | Additional environment variables for the agent                          | `{}`                                                                                                        |
-| `agent.redactKubernetesSecrets`    | Enable additional secrets redaction for selected Kubernetes resources   | `nil` See [Kubernetes secrets](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#secrets) for more details.   |
+| `agent.redactKubernetesSecrets`    | Enable additional secrets redaction for selected Kubernetes resources   | `nil` See [Kubernetes secrets](https://docs.instana.io/setup_and_manage/host_agent/on/kubernetes/#secrets) for more details.   |
 | `cluster.name`                     | Display name of the monitored cluster                                   | Value of `zone.name`                                                                                        |
-| `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#podsecuritypolicy) for more details. |
+| `leaderElector.port`               | Instana leader elector sidecar port                                     | `42655`                                                                                                     |
+| `leaderElector.image.name`         | The elector image name to pull                                          | `instana/leader-elector`                                                                                             |
+| `leaderElector.image.tag`          | The elector image tag to pull                                           | `0.5.4`                                                                                                    |
+| `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/setup_and_manage/host_agent/on/kubernetes/#podsecuritypolicy) for more details. |
 | `podSecurityPolicy.name`           | Name of an _existing_ PodSecurityPolicy to authorize for the Instana Agent pods. If not provided and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created for you. | `nil` |
 | `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                                                                                      |
 | `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                                                                                      |
@@ -159,4 +161,4 @@ To configure the agent, you can either:
 - edit the [config map](templates/configmap.yaml), or
 - provide the configuration via the `agent.configuration_yaml` parameter in [values.yaml](values.yaml)
 
-This configuration will be used for all Instana Agents on all nodes. Visit the [agent configuration documentation](https://docs.instana.io/quick_start/agent_configuration/#configuration) for more details on configuration options.
+This configuration will be used for all Instana Agents on all nodes. Visit the [agent configuration documentation](https://docs.instana.io/setup_and_manage/host_agent/#agent-configuration-file) for more details on configuration options.

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -47,7 +47,7 @@ The name of the PodSecurityPolicy used.
 */}}
 {{- define "instana-agent.podSecurityPolicyName" -}}
 {{- if .Values.podSecurityPolicy.enable -}}
-    {{ default (include "instana-agent.fullname" .) .Values.podSecurityPolicy.name }}
+{{ default (include "instana-agent.fullname" .) .Values.podSecurityPolicy.name }}
 {{- end -}}
 {{- end -}}
 
@@ -55,11 +55,10 @@ The name of the PodSecurityPolicy used.
 Add Helm metadata to resource labels.
 */}}
 {{- define "instana-agent.commonLabels" -}}
-{{- if .Values.templating -}}
 app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+{{ if .Values.templating -}}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- else -}}
-app.kubernetes.io/name: {{ include "instana-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "instana-agent.chart" . }}
@@ -70,10 +69,8 @@ helm.sh/chart: {{ include "instana-agent.chart" . }}
 Add Helm metadata to selector labels specifically for deployments/daemonsets/statefulsets.
 */}}
 {{- define "instana-agent.selectorLabels" -}}
-{{- if .Values.templating -}}
 app.kubernetes.io/name: {{ include "instana-agent.name" . }}
-{{- else -}}
-app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+{{ if not .Values.templating -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -17,7 +17,7 @@ rules:
 - apiGroups: ["batch"]
   resources:
     - "jobs"
-    - 'cronjobs'
+    - "cronjobs"
   verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -31,12 +31,12 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-        - name: {{ template "instana-agent.name" . }}
+        - name: instana-agent
           image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           env:
             - name: INSTANA_AGENT_LEADER_ELECTOR_PORT
-              value: {{ .Values.agent.leaderElectorPort | quote }}
+              value: {{ .Values.leaderElector.port | quote }}
             - name: INSTANA_ZONE
               value: {{ .Values.zone.name | quote }}
               {{- if .Values.cluster.name }}
@@ -149,8 +149,8 @@ spec:
               cpu: {{ default 1.5 .Values.agent.pod.limits.cpu }}
           ports:
             - containerPort: 42699
-        - name: {{ template "instana-agent.name" . }}-leader-elector
-          image: instana/leader-elector:0.5.4
+        - name: instana-agent-leader-elector
+          image: "{{ .Values.leaderElector.image.name }}:{{ .Values.leaderElector.image.tag }}"
           env:
             - name: INSTANA_AGENT_POD_NAME
               valueFrom:
@@ -159,7 +159,7 @@ spec:
           command:
             - "/busybox/sh"
             - "-c"
-            - "sleep 12 && /app/server --election=instana --http=localhost:{{ default 42655 .Values.agent.leaderElectorPort }} --id=$(INSTANA_AGENT_POD_NAME)"
+            - "sleep 12 && /app/server --election=instana --http=localhost:{{ .Values.leaderElector.port }} --id=$(INSTANA_AGENT_POD_NAME)"
           resources:
             requests:
               cpu: 0.1
@@ -171,7 +171,7 @@ spec:
             initialDelaySeconds: 300
             timeoutSeconds: 3
           ports:
-            - containerPort: {{ .Values.agent.leaderElectorPort }}
+            - containerPort: {{ .Values.leaderElector.port }}
       {{- if .Values.agent.pod.tolerations }}
       tolerations:
         {{- toYaml .Values.agent.pod.tolerations | nindent 8 }}

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -1,10 +1,6 @@
 # name is the value which will be used as the base resource name for various resources associated with the agent.
 # name: instana-agent
 
-zone:
-  # zone.name is the custom zone that detected technologies will be assigned to
-  name: null
-
 agent:
   # agent.key is the secret token which your agent uses to authenticate to Instana's servers.
   key: null
@@ -14,8 +10,6 @@ agent:
   # downloadKey: null
   # agent.listenAddress is the IP address the agent HTTP server will listen to.
   # listenAddress: *
-  # agent.leaderElectorPort is the port on which the leader elector sidecar is exposed.
-  leaderElectorPort: 42655
 
   # agent.endpointHost is the hostname of the Instana server your agents will connect to.
   endpointHost: ingress-red-saas.instana.io
@@ -81,6 +75,18 @@ agent:
   # agent.supportOpenshift specifies whether the cluster role should include openshift permissions
   # supportOpenshift: true
 
+cluster:
+  # cluster.name represents the name that will be assigned to this cluster in Instana
+  name: null
+
+leaderElector:
+  image:
+    # leaderElector.image.name is the name of the container image of the leader elector.
+    name: instana/leader-elector
+    # leaderElector.image.tag is the tag name of the agent container image.
+    tag: 0.5.4
+  port: 42655
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
@@ -100,6 +106,6 @@ podSecurityPolicy:
   # If not set and `enable` is true, a PodSecurityPolicy will be created with a name generated using the fullname template.
   name: null
 
-cluster:
-  # cluster.name represents the name that will be assigned to this cluster in Instana
+zone:
+  # zone.name is the custom zone that detected technologies will be assigned to
   name: null


### PR DESCRIPTION
#### What this PR does / why we need it:

Expose new configuration options:
- `leaderElector.image.name`
- `leaderElector.image.tag`

Changed the existing `agent.leaderElectorPort` configuration value to `leaderElector.port` to be consistent with the other leader elector configurations.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
