### PR TITLE
[stable/grafana] Don't specify default digest for docker images

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.4.0
+version: 5.4.1
 appVersion: 7.0.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -67,7 +67,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `service.loadBalancerIP`                  | IP address to assign to load balancer (if supported) | `nil`                                            |
 | `service.loadBalancerSourceRanges`        | list of IP CIDRs allowed access to lb (if supported) | `[]`                                             |
 | `service.externalIPs`                     | service external IP addresses                 | `[]`                                                    |
-| `extraExposePorts`                        | Additional service ports for sidecar containers| `[]`                                                   | 
+| `extraExposePorts`                        | Additional service ports for sidecar containers| `[]`                                                   |
 | `ingress.enabled`                         | Enables Ingress                               | `false`                                                 |
 | `ingress.annotations`                     | Ingress annotations (values are templated)    | `{}`                                                    |
 | `ingress.labels`                          | Custom labels                                 | `{}`                                                    |
@@ -95,7 +95,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
 | `initChownData.image.repository`          | init-chown-data container image repository    | `busybox`                                               |
 | `initChownData.image.tag`                 | init-chown-data container image tag           | `1.31.1`                                                |
-| `initChownData.image.sha`                 | init-chown-data container image sha (optional)| `fb1f7b885314372fa4aecbb2ba98a70dfed1d60d85e1191075ee616e55df577b` |
+| `initChownData.image.sha`                 | init-chown-data container image sha (optional)| `""`                                                    |
 | `initChownData.image.pullPolicy`          | init-chown-data container image pull policy   | `IfNotPresent`                                          |
 | `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
@@ -124,7 +124,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
 | `sidecar.image.repository`                | Sidecar image repository                      | `kiwigrid/k8s-sidecar`                                  |
 | `sidecar.image.tag`                       | Sidecar image tag                             | `0.1.151`                                               |
-| `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `7b98eecdf6d117b053622e9f317c632a4b2b97636e8b2e96b311a5fd5c68d211` |
+| `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |
 | `sidecar.dashboards.enabled`              | Enables the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
@@ -170,7 +170,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `downloadDashboards.resources`            | Resources of `download-dashboards` container  | `{}`                                                    |
 | `downloadDashboardsImage.repository`      | Curl docker image repo                        | `curlimages/curl`                                       |
 | `downloadDashboardsImage.tag`             | Curl docker image tag                         | `7.70.0`                                                |
-| `downloadDashboardsImage.sha`             | Curl docker image sha (optional)              | `4643760807987d54154af5767b0028861b1b279108af7f70bf820b948069c366` |
+| `downloadDashboardsImage.sha`             | Curl docker image sha (optional)              | `""`                                                    |
 | `downloadDashboardsImage.pullPolicy`      | Curl docker image pull policy                 | `IfNotPresent`                                          |
 | `namespaceOverride`                       | Override the deployment namespace             | `""` (`Release.Namespace`)                              |
 

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -51,7 +51,7 @@ livenessProbe:
 image:
   repository: grafana/grafana
   tag: 7.0.5
-  sha: 17cbd08b9515fda889ca959e9d72ee6f3327c8f1844a3336dfd952134f38e2fe
+  sha: ""
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -93,7 +93,7 @@ extraEmptyDirMounts: []
 downloadDashboardsImage:
   repository: curlimages/curl
   tag: 7.70.0
-  sha: 4643760807987d54154af5767b0028861b1b279108af7f70bf820b948069c366
+  sha: ""
   pullPolicy: IfNotPresent
 
 downloadDashboards:
@@ -228,7 +228,7 @@ initChownData:
   image:
     repository: busybox
     tag: "1.31.1"
-    sha: fb1f7b885314372fa4aecbb2ba98a70dfed1d60d85e1191075ee616e55df577b
+    sha: ""
     pullPolicy: IfNotPresent
 
   ## initChownData resource requests and limits
@@ -470,7 +470,7 @@ sidecar:
   image:
     repository: kiwigrid/k8s-sidecar
     tag: 0.1.151
-    sha: 7b98eecdf6d117b053622e9f317c632a4b2b97636e8b2e96b311a5fd5c68d211
+    sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}
 #   limits:


### PR DESCRIPTION
#### What this PR does / why we need it:
- Don't specify default digest for docker images (pointed out by @calvinbui [here](https://github.com/helm/charts/pull/23195#discussion_r456274260))

> calvinbui 1 hour ago Contributor
when users who are using a different image tag than 7.0.3 update to this chart version they'd had issues though

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
