### PR TITLE
 [stable/weave-scope] Weave security context

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: weave-scope
-version: 1.1.10
+version: 1.1.11
 appVersion: 1.12.0
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/README.md
+++ b/stable/weave-scope/README.md
@@ -75,6 +75,8 @@ The **weave-scope-frontend** section controls how the Scope frontend is installe
 | **ingress.paths** |	Ingress paths | [] |
 | **ingress.hosts** | Ingress accepted hostnames | nil |
 | **ingress.tls** |	Ingress TLS configuration |	[] |
+| **securityContext.runAsNonRoot** | Wether the container will not be runned as root | true |
+| **securityContext.readOnlyRootFilesystem** | Wether the container will mount root's FS in read only |	true |
 
 ### Weave Scope agent
 
@@ -94,6 +96,8 @@ The **agent** section controls how the Weave Scope node agent pods are installed
 | **resources.requests.memory** | memory request in MiB (Mi)| |
 | **resources.limits.cpu** | CPU limit in MHz (m) | |
 | **resources.limits.memory** | memory limit in MiB (Mi) | |
+| **securityContext.runAsNonRoot** | Wether the container will not be runned as root | true |
+| **securityContext.readOnlyRootFilesystem** | Wether the container will mount root's FS in read only |	true |
 
 ### Weave Scope cluster agent
 
@@ -115,6 +119,8 @@ The **agent** section controls how the Weave Scope node agent pods are installed
 | **resources.requests.memory** | memory request in MiB (Mi)| |
 | **resources.limits.cpu** | CPU limit in MHz (m) | |
 | **resources.limits.memory** | memory limit in MiB (Mi) | |
+| **securityContext.runAsNonRoot** | Wether the container will not be runned as root | true |
+| **securityContext.readOnlyRootFilesystem** | Wether the container will mount root's FS in read only |	true |
 
 ## Other notes
 

--- a/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -54,6 +54,12 @@ spec:
             {{- end }}
           securityContext:
             privileged: true
+            {{- if .Values.securityContext.runAsNonRoot }}
+            runAsNonRoot: true
+            {{- end }}
+            {{- if .Values.securityContext.readOnlyRootFilesystem}}
+            readOnlyRootFilesystem: true
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
@@ -41,6 +41,14 @@ spec:
             {{- else }}
             - {{ .Values.global.service.name | default (include "toplevel.fullname" .) }}.{{ .Release.Namespace }}.svc:{{ .Values.global.service.port }}
             {{- end }}
+          securityContext:
+            privileged: true
+            {{- if .Values.securityContext.runAsNonRoot }}
+            runAsNonRoot: true
+            {{- end }}
+            {{- if .Values.securityContext.readOnlyRootFilesystem}}
+            readOnlyRootFilesystem: true
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       serviceAccountName: {{ template "weave-scope-cluster-agent.serviceAccountName" . }}

--- a/stable/weave-scope/charts/weave-scope-frontend/templates/deployment.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/templates/deployment.yaml
@@ -30,6 +30,14 @@ spec:
             {{- range $arg := .Values.flags }}
             - {{ $arg | quote }}
             {{- end }}
+          securityContext:
+            privileged: true
+            {{- if .Values.securityContext.runAsNonRoot}}
+            runAsNonRoot: true
+            {{- end }}
+            {{- if .Values.securityContext.readOnlyRootFilesystem}}
+            readOnlyRootFilesystem: true
+            {{- end }}
           ports:
             - name: http
               containerPort: 4040

--- a/stable/weave-scope/values.yaml
+++ b/stable/weave-scope/values.yaml
@@ -135,3 +135,4 @@ weave-scope-cluster-agent:
   securityContext:
     runAsNonRoot: true
     readOnlyRootFilesystem: true
+    

--- a/stable/weave-scope/values.yaml
+++ b/stable/weave-scope/values.yaml
@@ -37,6 +37,10 @@ weave-scope-frontend:
         # weave-scope-frontend.resources.limits.memory: memory limit in MiB (Mi)
         # memory: ""
   flags: []
+  # Security contexts options for weave-scope-frontend. Both to true by default.
+  securityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
   # weave-scope-frontend Ingress
   ingress:
     # If true, weave-scope-frontend ingress will be created
@@ -85,6 +89,10 @@ weave-scope-agent:
       # cpu: ""
       # weave-scope-agent.resources.limits.memory: memory limit in MiB (Mi)
       # memory: ""
+  # Security contexts options for weave-scope-agent. Both to true by default.
+  securityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
 
 # weave-scope-agent.* controls how the Weave Scope node agent pods are installed
 weave-scope-cluster-agent:
@@ -123,3 +131,7 @@ weave-scope-cluster-agent:
       # cpu: ""
       # weave-scope-cluster-agent.resources.limits.memory: memory limit in MiB (Mi)
       # memory: ""
+  # Security contexts options for weave-scope-cluster-agent. Both to true by default.
+  securityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true


### PR DESCRIPTION
#### Is this a new chart
No 

#### What this PR does / why we need it:
This PR brings securityContext option to all weave-scope containers, namely:
```
          securityContext:
            runAsNonRoot: true
            readOnlyRootFilesystem: true
```
Those options, set to true, are considered a security best practice. 

#### Which issue this PR fixes
*`fixes #23008 *

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)