### PR TITLE
[stable/airflow] Allowing for specifying a NodePort number for Flower

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.2.0
+version: 7.3.0
 appVersion: 1.10.10
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -39,6 +39,7 @@ kubectl exec \
 > NOTE: for chart version numbers, see [Chart.yaml](Chart.yaml) or [helm hub](https://hub.helm.sh/charts/stable/airflow).
 
 For steps you must take when upgrading this chart, please review:
+* [v7.2.X → v7.3.0](UPGRADE.md#v72x--v730)
 * [v7.1.X → v7.2.0](UPGRADE.md#v71x--v720)
 * [v7.0.X → v7.1.0](UPGRADE.md#v70x--v710)
 * [v6.X.X → v7.0.0](UPGRADE.md#v6xx--v700)

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrading Steps
 
+## `v7.2.X` → `v7.3.0`
+
+__The following IMPROVEMENTS have been made:__
+
+* Added an ability to specify a specific port for Flower when using NodePort service type with the value `flower.service.nodePort.http`
+
+__The following values have been ADDED:__
+
+* `flower.service.nodePort.http`
+
 ## `v7.1.X` → `v7.2.0`
 
 __The following IMPROVEMENTS have been made:__

--- a/stable/airflow/templates/service-flower.yaml
+++ b/stable/airflow/templates/service-flower.yaml
@@ -23,6 +23,9 @@ spec:
     - name: flower
       protocol: TCP
       port: {{ .Values.flower.service.externalPort }}
+      {{- if and (eq .Values.flower.service.type "NodePort") (.Values.flower.service.nodePort.http) }}
+      nodePort: {{ .Values.flower.service.nodePort.http }}
+      {{- end }}
       targetPort: 5555
   {{- if eq .Values.flower.service.type "LoadBalancer" }}
   {{- if .Values.flower.service.loadBalancerIP }}

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -27,10 +27,8 @@ spec:
     - name: web
       protocol: TCP
       port: {{ .Values.web.service.externalPort | default 8080 }}
-      {{- if eq .Values.web.service.type "NodePort" }}
-      {{- if .Values.web.service.nodePort.http }}
+      {{- if and (eq .Values.web.service.type "NodePort") (.Values.web.service.nodePort.http) }}
       nodePort: {{ .Values.web.service.nodePort.http }}
-      {{- end }}
       {{- end }}
       targetPort: 8080
   {{- if eq .Values.web.service.type "LoadBalancer" }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -637,6 +637,8 @@ flower:
     externalPort: 5555
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+    nodePort:
+      http: ""
 
   ## the number of seconds to wait (in bash) before starting the flower container
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
There previously was no way to specify a port when using the NodePort service type for Flower, this adds that ability. Adding in the NodePort values the same exact way it is provided for Web. Also changing the multiple `if` lines to a single line.

There was no reason to change the README because it just lists `flower.service.*` and then says `<see values.yaml>`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
