### PR TITLE
[incubator/zookeeper] Add podManagementPolicy to the statefulSet template and values file

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.4
+version: 2.1.5
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   serviceName: {{ template "zookeeper.headless" . }}
   replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}  
   selector:
     matchLabels:
       app: {{ template "zookeeper.name" . }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -7,6 +7,15 @@ replicaCount: 3  # Desired quantity of ZooKeeper pods. This should always be (1,
 podDisruptionBudget:
   maxUnavailable: 1  # Limits how many Zokeeper pods may be unavailable due to voluntary disruptions.
 
+
+## StatefulSet allows you to relax its ordering guarantees while preserving
+## its uniqueness and identity guarantees via its `.spec.podManagementPolicy field`.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+##
+## There are two valid pod management policies: OrderedReady and Parallel
+## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+podManagementPolicy: OrderedReady
+
 terminationGracePeriodSeconds: 1800  # Duration in seconds a Zokeeper pod needs to terminate gracefully.
 
 updateStrategy:


### PR DESCRIPTION
Signed-off-by: stackedsax <alex.scammon@gresearch.co.uk>

#### What this PR does / why we need it:
This adds podManagementPolicy to the incubator/zookeeper chart so that users can choose to start Zookeerper statefulSets in parallel if they wish.  

I left the default as `OrderedReady` so that this change will have no effect unless someone chooses to change to Parallel.

#### Special notes for your reviewer:
@lachie83, @kow3ns, let me know if you want me to trim down the comment preceding the podManagementPolicy in the value file at all or if you have any other concerns.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

- [ish] Variables are documented in the README.md
  - The current docs only refer to the values.yaml file directly as documentation of the variables.  This is something I would like to change, but for the moment I simply commented the new value as verbosely as I could.