### PR TITLE
[stable/prometheus] bump alertmanager v0.21.0 and prometheus v2.19.2

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.7.0
+version: 11.8.0
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -565,7 +565,7 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v2.19.0
+    tag: v2.19.2
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -45,7 +45,7 @@ alertmanager:
   ##
   image:
     repository: prom/alertmanager
-    tag: v0.20.0
+    tag: v0.21.0
     pullPolicy: IfNotPresent
 
   ## alertmanager priorityClassName


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the Alertmanager image version to v0.21.0, as was intended in #22849 but probably missed by mistake.

Also includes minor update to Prometheus from v2.19.0 to v2.19.2.

#### Which issue this PR fixes

  - corrects missing update in #22849

#### Special notes for your reviewer:

Alertmanager version 0.21.0 removes support from HipChat ([see release notes](https://github.com/prometheus/alertmanager/releases/tag/v0.21.0)).

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] ~Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
