### PR TITLE
[stable/nginx-ingress] Fix regex in ingress config.

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.41.0
-appVersion: v0.34.0
+version: 1.41.1
+appVersion: v0.34.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -10,7 +10,7 @@ controller:
     #  asia.gcr.io
     registry: us.gcr.io
     repository: k8s-artifacts-prod/ingress-nginx/controller
-    tag: "v0.34.0"
+    tag: "v0.34.1"
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
     pullPolicy: IfNotPresent
     # www-data -> uid 101


### PR DESCRIPTION
@a7i @ChiefAlexander @taharah 
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR updates ingress-nginx to a minor revision containing a regression fix.

Commit 69df60c pushed 2 days ago updated to v0.34.0 of nginx, which contains a regression preventing regex wildcards in ingress extensions from matching, 

#### Which issue this PR fixes
Upstream: kubernetes/ingress-nginx#5890

Example ingress yaml showing the issue
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: core-ingress
  annotations:
    kubernetes.io/ingress.class: "nginx"
    cert-manager.io/cluster-issuer: "letsencrypt-prod"
    nginx.ingress.kubernetes.io/rewrite-target: /$1
spec:
  tls:
  - hosts:
    - example.com
    secretName: example-cert-secret
  rules:
  - host: example.com
    http:
      paths:
      - path: /echo?(.*)
        backend:
          serviceName: echo-service
          servicePort: 80
```

#### Special notes for your reviewer:
You will notice values.yaml contains a sha256sum which I left unchanged. This is because that shasum instead points to the update v0.34.1 version, yet it referenced v0.34.0 - This makes me suspect the _intent_ of the previous commit may have actually been to use the fixed revision v0.34.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
