### PR TITLE
[stable/prometheus-mongodb-exporter] Possibility to also add a custom key in the existing secret

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.6.0
+version: 2.7.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -16,7 +16,7 @@ This command deploys the MongoDB Exporter with the default configuration. The [c
 ## Using the Chart
 
 To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string)
-or an existing secret (in the releases namespace) containing the key `mongodb-uri` with the URI is referred via `existingSecret.name`.
+or an existing secret (in the releases namespace) containing the key defined on `existingSecret.key`, with the URI is referred via `existingSecret.name`. If no secret key is defined, the default value is `mongodb-uri`.
 If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports
 connecting to either a MongoDB replica set member, shard, or standalone instance.
 
@@ -36,7 +36,8 @@ podAnnotations:
 |-----------|-------------|---------|
 | `affinity` | Node/pod affinities | `{}` |
 | `annotations` | Annotations to be added to the pods | `{}` |
-| `existingSecret.name` | Refer to an existing secret instead of using `mongodb.uri` | `` |
+| `existingSecret.name` | Refer to an existing secret name instead of using `mongodb.uri` | `` |
+| `existingSecret.key` | Refer to an existing secret key | `mongodb-uri` |
 | `extraArgs` | The extra command line arguments to pass to the MongoDB Exporter  | See values.yaml |
 | `fullnameOverride` | Override the full chart name | `` |
 | `image.pullPolicy` | MongoDB Exporter image pull policy | `IfNotPresent` |

--- a/stable/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ include "prometheus-mongodb-exporter.secretName" . }}
-                key: mongodb-uri
+                key: {{ .Values.existingSecret.key }}
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -70,4 +70,3 @@ spec:
       terminationGracePeriodSeconds: 30
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
-

--- a/stable/prometheus-mongodb-exporter/templates/secret.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/secret.yaml
@@ -10,5 +10,5 @@ metadata:
     helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
 type: Opaque
 data:
-  mongodb-uri: {{ required "A MongoDB URI is required" .Values.mongodb.uri | b64enc }}
+  {{ .Values.existingSecret.key }} : {{ required "A MongoDB URI is required" .Values.mongodb.uri | b64enc }}
 {{- end -}}

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -32,6 +32,7 @@ mongodb:
 # If this is provided, the value mongodb.uri is ignored.
 existingSecret:
   name: ""
+  key: "mongodb-uri"
 
 nameOverride: ""
 


### PR DESCRIPTION
Signed-off-by: William Tavares <wtc@hellofresh.com>

#### What this PR does / why we need it:

We have a special case when using the MongoDB Atlas Service Broker, the secret key is defined as `connection_string`, so in this case, we need also to provide the secret key. If no value is provided the default `mongodb-uri ` is provided as usual. 

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
