### PR TITLE
[stable/prometheus-blackbox-exporter] added network policy

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.2.2
+version: 4.3.0
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -71,6 +71,8 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
 | `livenessProbe`                           | Container liveness probe                                                         | See values.yaml                                                              |
 | `readinessProbe`                          | Container readiness probe                                                        | See values.yaml                                                              |
+| `networkPolicy.enabled`                   | Enable network policy and allow access from anywhere                             | `false`                                                                      |
+| `networkPolicy.allowMonitoringNamespace`  | Limit access only from monitoring namespace                                      | `false`                                                                      |
 | `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
 | `service.labels`                          | additional labels for the service                                                | None                                                                         |
 | `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |

--- a/stable/prometheus-blackbox-exporter/ci/networkpolicy-values.yaml
+++ b/stable/prometheus-blackbox-exporter/ci/networkpolicy-values.yaml
@@ -1,0 +1,2 @@
+networkPolicy:
+  enabled: true

--- a/stable/prometheus-blackbox-exporter/templates/networkpolicy.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" $ }}
+  ingress:
+{{- if .Values.networkPolicy.allowMonitoringNamespace }}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - port: {{ .Values.service.port }}
+      protocol: TCP
+{{- else }}
+  - {}
+{{- end }}
+  policyTypes:
+  - Ingress
+{{- end }}
+

--- a/stable/prometheus-blackbox-exporter/templates/networkpolicy.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.networkPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -149,3 +149,10 @@ prometheusRule:
   additionalLabels: {}
   namespace: ""
   rules: []
+
+## Network policy for chart
+networkPolicy:
+  # Enable network policy and allow access from anywhere
+  enabled: false
+  # Limit access only from monitoring namespace
+  allowMonitoringNamespace: false


### PR DESCRIPTION
Signed-off-by: Nikolay Aksenov <aksenk55@gmail.com>

#### What this PR does / why we need it:

These PR allow to create network policies for prometheus-blackbox-exporter.
Now there are 2 possible situations:
1) allowed from all (if just networkPolicy.enabled == true)
by default it is false (network policies will not be created).
2) allowed from namespace monitoring (if networkPolicy.allowMonitoringNamespace == true)
by default it is false (allow from all)

#### Special notes for your reviewer:

Currently, the chart does not work in environments that have network policies.
I think PR will cover the needs of most people who use network policies (for others, this can be expanded in the future)

@desaintmartin
@gianrubio
@rsotnychenko

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
