### PR TITLE
[stable/elasticsearch-curator] Make sure we can specify startingDeadlineSeconds

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.7.6"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.1.5
+version: 2.2.0
 home: https://github.com/elastic/curator
 keywords:
 - curator
@@ -16,3 +16,5 @@ maintainers:
     email: cedric.dsm@gmail.com
   - name: gianrubio
     email: gianrubio@gmail.com
+  - name: haad
+    email: adam.hamsik@lablabs.io

--- a/stable/elasticsearch-curator/OWNERS
+++ b/stable/elasticsearch-curator/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - desaintmartin
   - gianrubio
+  - haad
 reviewers:
   - desaintmartin
   - gianrubio
+  - haad

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -52,6 +52,7 @@ their default values.
 | `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep                   | `nil`                                        |
 | `cronjob.successfulJobsHistoryLimit` | Specify the number of completed Jobs to keep                | `nil`                                        |
 | `cronjob.jobRestartPolicy`           | Control the Job restartPolicy                               | `Never`                                      |
+| `cronjob.startingDeadlineSeconds`    | Amount of time to try reschedule job if we can't run on time| `nil`                                         |
 | `pod.annotations`                    | Annotations to add to the pod                               | {}                                           |
 | `pod.labels`                         | Labels to add to the pod                                    | {}                                           |
 | `dryrun`                             | Run Curator in dry-run mode                                 | `false`                                      |

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -25,6 +25,9 @@ spec:
   {{- with .Values.cronjob.successfulJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ . }}
   {{- end }}
+  {{- with .Values.cronjob.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end }}
   jobTemplate:
     metadata:
       labels:

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -11,6 +11,7 @@ cronjob:
   failedJobsHistoryLimit: ""
   successfulJobsHistoryLimit: ""
   jobRestartPolicy: Never
+  startingDeadlineSeconds: ""
 
 pod:
   annotations: {}


### PR DESCRIPTION
Add support for customizing startingDeadlineSeconds per cronjob

#### Special notes for your reviewer:

#### Checklist
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
