### PR TITLE
[incubator/kafka] Add support for mirror kafka clusters.

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.21.2
+version: 0.21.3
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -138,6 +138,16 @@ following configurable parameters:
 | `configJob.backoffLimit`                              | Number of retries before considering kafka-config job as failed                                                                                                          | `6`                                                                |
 | `topics`                                              | List of topics to create & configure. Can specify name, partitions, replicationFactor, reassignPartitions, config. See values.yaml                                       | `[]` (Empty list)                                                  |
 | `testsEnabled`                                        | Enable/disable the chart's tests                                                                                                                                         | `true`                                                             |
+
+| `mirror.enabled`                                      | Deploy Kafka Mirror service | `false` |
+| `mirror.replicas`                                     | Number of Kafka mirror replicas | `1`  |
+| `mirror.resources`                                    | Kafka mirror pod Resources  | `{}` |
+| `mirror.num.streams`                                  | Number of streams used by kafka mirror to replicate topics | `1`  |
+| `mirror.whitelist`                                    | White list mirrored topics | `""` |
+| `mirror.config.consumer`                              | Consumer configuration, relevant options are `bootstrap.servers`, `group.id`, `auto.offset.reset`. See kafka mirror documentation for more options. | `{}` |
+| `mirror.config.producer`                              | Producer configuration, relevant options are `bootstrap.servers`, `compression.type`, `batch.size` See kafka mirror documentation for more options. | `{}` |
+| `mirror.log4j`                                        | Kafka Mirror log4j configuration | `{}` |
+
 | `zookeeper.enabled`                                   | If True, installs Zookeeper Chart                                                                                                                                        | `true`                                                             |
 | `zookeeper.resources`                                 | Zookeeper resource requests and limits                                                                                                                                   | `{}`                                                               |
 | `zookeeper.env`                                       | Environmental variables provided to Zookeeper Zookeeper                                                                                                                  | `{ZK_HEAP_SIZE: "1G"}`                                             |

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 2.1.0
-digest: sha256:f50b0b5f50f4938a5369c5ea479030a4f87e99aecb7752ab434f75a6c39f304a
-generated: "2019-11-05T16:37:25.868424523-06:00"
+  version: 2.1.4
+digest: sha256:772239b316c0fa9c215e3c00a18d40a2122277d54137c13a34191f1d43a6a613
+generated: "2020-07-20T22:38:42.565162+02:00"

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: zookeeper
-  version: 2.1.0
+  version: 2.1.4
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: kafka.zookeeper.enabled,zookeeper.enabled

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -1,4 +1,4 @@
-### Connecting to Kafka from inside Kubernetes
+# Connecting to Kafka from inside Kubernetes
 
 You can connect to Kafka by running a simple pod in the K8s cluster like this with a configuration like this:
 
@@ -40,7 +40,8 @@ To end the producer session try: Ctrl+C
 If you specify "zookeeper.connect" in configurationOverrides, please replace "{{ .Release.Name }}-zookeeper:2181" with the value of "zookeeper.connect", or you will get error.
 
 {{ if .Values.external.enabled }}
-### Connecting to Kafka from outside Kubernetes
+
+# Connecting to Kafka from outside Kubernetes
 
 You have enabled the external access feature of this chart.
 
@@ -73,4 +74,25 @@ To view JMX configuration (pull request/updates to improve defaults are encourag
   {{ else }}
   kubectl -n {{ .Release.Namespace }} describe configmap {{ include "kafka.fullname" . }}-metrics
   {{- end }}
+{{- end }}
+
+{{ if .Values.mirror.enabled }}
+You have enabled Kafka mirror between clusters for future reference here is configuration.
+
+Consumer:
+  {{ template "consumer.bootstrap.servers" . }}
+{{- range $key, $value := .Values.mirror.config.consumer }}
+  {{ $key }}={{ $value }}
+{{- end }}
+
+Producer:
+{{- range $key, $value := .Values.mirror.config.producer }}
+  {{ $key }}={{ $value }}
+{{- end }}
+
+log4j:
+{{- range $key, $value := .Values.mirror.config.log4j }}
+  {{ $key }}={{ $value }}
+{{- end }}
+
 {{- end }}

--- a/incubator/kafka/templates/_helpers.tpl
+++ b/incubator/kafka/templates/_helpers.tpl
@@ -114,6 +114,7 @@ app.kubernetes.io/component: kafka-monitor
 {{- define "kafka.monitor.labels" -}}
 {{ include "kafka.common.metaLabels" . }}
 {{ include "kafka.monitor.matchLabels" . }}
+{{- end -}}
 
 {{/*
 Test if bootstrap.servers is defined in kafka mirror config for consumer and if not use our service

--- a/incubator/kafka/templates/configmap-mirror.yaml
+++ b/incubator/kafka/templates/configmap-mirror.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.mirror.enabled -}}
+{{- $zk := include "zookeeper.url" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "kafka.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "kafka.fullname" . }}-mirror-config
+data:
+  consumer.properties: |
+    {{ template "consumer.bootstrap.servers" . }}
+
+  {{- range $key, $value := .Values.mirror.config.consumer }}
+    {{ $key }}={{ $value }}
+  {{- end }}
+
+  producer.properties: |
+    {{- range $key, $value := .Values.mirror.config.producer }}
+      {{ $key }}={{ $value }}
+    {{- end }}
+
+  tools-log4j.properties: |
+    {{- range $key, $value := .Values.mirror.config.log4j }}
+      {{ $key }}={{ $value }}
+    {{- end }}
+
+{{- end -}}

--- a/incubator/kafka/templates/deployment-mirror.yaml
+++ b/incubator/kafka/templates/deployment-mirror.yaml
@@ -1,0 +1,55 @@
+---
+{{- if .Values.mirror.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "kafka.fullname" . }}-mirror
+  labels:
+    app: "{{ template "kafka.name" . }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.mirror.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "kafka.name" . }}-mirror
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "kafka.name" . }}-mirror
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: kafka-mirror
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          command:
+            - /usr/bin/kafka-run-class
+          args:
+            - kafka.tools.MirrorMaker
+            - --consumer.config
+            - /etc/kafka/consumer.properties
+            - --producer.config
+            - /etc/kafka/producer.properties
+            - --whitelist
+            - {{ .Values.mirror.whitelist | quote }}
+            - --num.streams
+            - {{ .Values.mirror.num.streams | quote }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/kafka/consumer.properties
+              subPath: consumer.properties
+            - name: config-volume
+              mountPath: /etc/kafka/producer.properties
+              subPath: producer.properties
+            - name: config-volume
+              mountPath: /etc/kafka/tools-log4j.properties
+              subPath: tools-log4j.properties
+          resources:
+{{ toYaml .Values.mirror.resources | indent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "kafka.fullname" . }}-mirror-config
+{{- end }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -467,6 +467,30 @@ topics: []
 ## test your own chart.
 testsEnabled: true
 
+## Enable/disable the chart's kafka mirror deployment
+mirror:
+  enabled: false
+  replicas: 1
+  resources: {}
+  num:
+    streams: 1
+  whitelist: ""
+  config:
+    consumer: {}
+#      bootstrap.servers:
+#      group.id:
+#      auto.offset.reset:
+    producer: {}
+#      bootstrap.servers:
+#      compression.type:
+#      batch.size:
+    log4j:
+      log4j.rootLogger: WARN, stderr
+      log4j.appender.stderr: org.apache.log4j.ConsoleAppender
+      log4j.appender.stderr.layout: org.apache.log4j.PatternLayout
+      log4j.appender.stderr.layout.ConversionPattern: "[%d] %p %m (%c)%n"
+      log4j.appender.stderr.Target: System.err
+
 # ------------------------------------------------------------------------------
 # Zookeeper:
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
#### What this PR does / why we need it:

Add support for mirror kafka clusters, update to latest zookeeper chart. Make sure we can configure log4j logging for kafka mirror.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
