### PR TITLE
[stable/prometheus-operator] fix additionalScrapeConfigsSecret

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.1.1
+version: 9.1.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -211,8 +211,8 @@ spec:
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalScrapeConfigsSecret.enabled }}
   additionalScrapeConfigs:
-    name: {{- .Values.prometheus.prometheusSpec.additionalScrapeConfigsSecret.name }}
-    key: {{- .Values.prometheus.prometheusSpec.additionalScrapeConfigsSecret.key }}
+    name: {{ .Values.prometheus.prometheusSpec.additionalScrapeConfigsSecret.name }}
+    key: {{ .Values.prometheus.prometheusSpec.additionalScrapeConfigsSecret.key }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalAlertManagerConfigs }}
   additionalAlertManagerConfigs:


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently the `additionalScrapeConfigsSecret` cannot be applied as it renders
```
  additionalScrapeConfigs:
    name:prom-op-prometheus-scrape-confg
    key:additional-scrape-configs.yaml
```
giving error:
>error validating data: ValidationError(Prometheus.spec.additionalScrapeConfigs): invalid type for com.coreos.monitoring.v1.Prometheus.spec.additionalScrapeConfigs: got "string", expected "map" 

temp workaround:
```
      additionalScrapeConfigsSecret:
        enabled: true
        name: " prom-op-prometheus-scrape-confg"
        key: " additional-scrape-configs.yaml"
```
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
