### PR TITLE
[stable/prometheus-redis-exporter] Add ServiceMonitor metricRelabelings

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.4.1
+version: 3.5.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters and their default values.
 | `serviceMonitor.labels`        | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`            |
 | `serviceMonitor.timeout`       | Timeout after which the scrape is ended                |                            |
 | `serviceMonitor.targetLabels`  | Set of labels to transfer on the Kubernetes Service onto the target.  |             |
+| `serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion.  |             |
 | `prometheusRule.enabled`           | Set this to true to create prometheusRules for Prometheus operator | `false`     |
 | `prometheusRule.additionalLabels`  | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`  |
 | `prometheusRule.namespace`         | namespace where prometheusRules resource should be created |      |

--- a/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-redis-exporter/templates/servicemonitor.yaml
@@ -23,6 +23,10 @@ spec:
 {{- if .Values.serviceMonitor.timeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
   jobLabel: {{ template "prometheus-redis-exporter.fullname" . }}
   namespaceSelector:
     matchNames:

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -60,6 +60,7 @@ serviceMonitor:
   # timeout: 10s
   # Set of labels to transfer on the Kubernetes Service onto the target.
   # targetLabels: []
+  # metricRelabelings: []
 
 ## Custom PrometheusRules to be defined
 ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

Adds the ServiceMonitor metricRelabelings key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint).

Used for adding, dropping or renaming labels at ingestion time, or to drop entire metrics that are not useful.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
