### PR TITLE
[stable/prometheus-mongodb-exporter] Add ServiceMonitor metricRelabeling

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.7.0
+version: 2.8.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -66,4 +66,5 @@ podAnnotations:
 | `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | `` |
 | `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}` |
 | `serviceMonitor.targetLabels` | Set of labels to transfer on the Kubernetes Service onto the target. | `[]`
+| `serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
 | `tolerations` | List of node taints to tolerate  | `[]` |

--- a/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
@@ -19,6 +19,9 @@ spec:
   - port: metrics
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -93,5 +93,6 @@ serviceMonitor:
   namespace:
   additionalLabels: {}
   targetLabels: []
+  metricRelabelings: []
 
 tolerations: []


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

Adds the ServiceMonitor metricRelabelings key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint).

Used for adding, dropping or renaming labels at ingestion time, or to drop entire metrics that are not useful.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
