### PR TITLE
[stable/elasticsearch-exporter] Add ServiceMonitor metricRelabeling

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 3.5.0
+version: 3.6.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -102,6 +102,7 @@ Parameter | Description | Default
 `serviceMonitor.scheme` | Scheme to use for scraping | `http`
 `serviceMonitor.relabelings` | Relabel configuration for the metrics | `[]`
 `serviceMonitor.targetLabels` | Set of labels to transfer on the Kubernetes Service onto the target. | `[]`
+`serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]`
 `prometheusRule.enabled` | If true, a PrometheusRule CRD is created for a prometheus operator | `false`
 `prometheusRule.namespace` | If set, the PrometheusRule will be installed in a different namespace  | `""`
 `prometheusRule.labels` | Labels for prometheus operator | `{}`

--- a/stable/elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/stable/elasticsearch-exporter/templates/servicemonitor.yaml
@@ -29,6 +29,10 @@ spec:
     relabelings:
     {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
     {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -172,6 +172,7 @@ serviceMonitor:
   scheme: http
   relabelings: []
   targetLabels: []
+  metricRelabelings: []
 
 prometheusRule:
   ## If true, a PrometheusRule CRD is created for a prometheus operator


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

Adds the ServiceMonitor metricRelabelings key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint).

Used for adding, dropping or renaming labels at ingestion time, or to drop entire metrics that are not useful.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
