### PR TITLE
[incubator/etcd] Migrate to statefulstate apiversion to apps/v1

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.7.4
+version: 0.8.0
 appVersion: 3.2.26
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.

--- a/incubator/etcd/README.md
+++ b/incubator/etcd/README.md
@@ -5,7 +5,7 @@ Credit to https://github.com/ingvagabund. This is an implementation of that work
 * https://github.com/kubernetes/contrib/pull/1295
 
 ## Prerequisites Details
-* Kubernetes 1.5 (for `StatefulSets` support)
+* Kubernetes 1.9 (for `StatefulSets` support)
 * PV support on the underlying infrastructure
 * ETCD version >= 3.0.0
 

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
 {{- $etcdAuthOptions := include "etcd.authOptions" . }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "etcd.fullname" . }}


### PR DESCRIPTION
StatefulSet in the apps/v1beta1 and apps/v1beta2 API versions is no longer served.
Migrate to use the apps/v1 API version, available since v1.9.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### What this PR does / why we need it:
Statefulset is no longer served in app/v1beta2, which cause the error when `helm install`
```
  Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: unable to recognize
 "": no matches for kind "StatefulSet" in version "apps/v1beta2"
```