### PR TITLE
[stable/prometheus] Disable "enableServiceLinks" on Kubernetes prior 1.13

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.9.1
+version: 11.10.0
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/statefulsets/server.yaml
+++ b/stable/prometheus/templates/statefulsets/server.yaml
@@ -39,11 +39,13 @@ spec:
 {{- if .Values.server.schedulerName }}
       schedulerName: "{{ .Values.server.schedulerName }}"
 {{- end }}
+{{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
       {{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") }}
       enableServiceLinks: true
       {{- else }}
       enableServiceLinks: false
       {{- end }}
+{{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}


### PR DESCRIPTION
#### What this PR does / why we need it:
I use K8s prior 1.13 when I've applied the Prometheus statefulset this error occurred:
`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec): unknown field "enableServiceLinks" in io.k8s.api.core.v1.PodSpec`
because the field doesn't available for prior version 1.13

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
