### PR TITLE
[stable/grafana] Adding hostAliases

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.5.0
+version: 5.5.1
 appVersion: 7.0.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -68,6 +68,7 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `service.loadBalancerSourceRanges`        | list of IP CIDRs allowed access to lb (if supported) | `[]`                                             |
 | `service.externalIPs`                     | service external IP addresses                 | `[]`                                                    |
 | `extraExposePorts`                        | Additional service ports for sidecar containers| `[]`                                                   |
+| `hostAliases`                             | adds rules to the pod's /etc/hosts            | `[]`                                                    |
 | `ingress.enabled`                         | Enables Ingress                               | `false`                                                 |
 | `ingress.annotations`                     | Ingress annotations (values are templated)    | `{}`                                                    |
 | `ingress.labels`                          | Custom labels                                 | `{}`                                                    |

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -1,3 +1,4 @@
+
 {{- define "grafana.pod" -}}
 {{- if .Values.schedulerName }}
 schedulerName: "{{ .Values.schedulerName }}"
@@ -6,6 +7,10 @@ serviceAccountName: {{ template "grafana.serviceAccountName" . }}
 {{- if .Values.securityContext }}
 securityContext:
 {{ toYaml .Values.securityContext | indent 2 }}
+{{- end }}
+{{- if .Values.hostAliases }}
+hostAliases:
+{{ toYaml .Values.hostAliases | indent 2 }}
 {{- end }}
 {{- if .Values.priorityClassName }}
 priorityClassName: {{ .Values.priorityClassName }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -130,6 +130,12 @@ extraExposePorts: []
  #   targetPort: 8080
  #   type: ClusterIP
 
+# overrides pod.spec.hostAliases in the grafana deployment's pods
+hostAliases: []
+  # - ip: "1.2.3.4"
+  #   hostnames:
+  #     - "my.host.com"
+
 ingress:
   enabled: false
   # Values can be templated


### PR DESCRIPTION
@zanhsieh 
@rtluckie 
@maorfr 

#### What this PR does / why we need it:

This PR adds the hostAliases parameter allowing users to edit `/etc/hosts` in their pods so grafana can access other kubernetes services that don't resolve over a the cluster's DNS but have that have ingress rules.

#### Which issue this PR fixes
  - fixes #23301 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
