### PR TITLE
[stable/prometheus-blackbox-exporter] fix(helm#23318): PodSecurityPolicy NET_RAW capability

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.2.1
+version: 4.2.2
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -36,4 +36,8 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
+  {{- if .Values.allowIcmp }}
+  allowedCapabilities: 
+  - NET_RAW
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
To fix [stable/prometheus-blackbox-exporter] PodSecurityPolicy in the scope of NET_RAW capability

#### Which issue this PR fixes
  - fixes #23318

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
