### PR TITLE
[stable/prometheus-operator] prevent nodePort from constantly changing

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.2.1
+version: 9.2.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -34,7 +34,7 @@ spec:
 {{- end }}
   ports:
     - name: {{ .Values.alertmanager.alertmanagerSpec.portName }}
-    {{- if eq .Values.alertmanager.service.type "NodePort" }}
+    {{- if eq .Values.alertmanager.service.type "NodePort" | and .Values.alertmanager.service.nodePort }}
       nodePort: {{ .Values.alertmanager.service.nodePort }}
     {{- end }}
       port: {{ .Values.alertmanager.service.port }}

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -34,7 +34,7 @@ spec:
 {{- end }}
   ports:
   - name: {{ .Values.prometheus.prometheusSpec.portName }}
-    {{- if eq .Values.prometheus.service.type "NodePort" }}
+    {{- if eq .Values.prometheus.service.type "NodePort" | and .Values.prometheus.service.nodePort }}
     nodePort: {{ .Values.prometheus.service.nodePort }}
     {{- end }}
     port: {{ .Values.prometheus.service.port }}


### PR DESCRIPTION
Prevent nodePort from constantly changing when using a nodePort service on AlertManager and Prometheus and not specifying a fixed port number.

Signed-off-by: Mickaël Le Baillif <mickael.le.baillif@gmail.com>

Chart maintainers:
@vsliouniaev
@bismarck
@gianrubio

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No.

#### What this PR does / why we need it:

Avoid assigning a new nodePort number when applying the "Service" manifests for prometheus and alertmanager. This is especially noticeable when these manifests are handled with a GitOps method, such as with FluxCD, because manifests are applied on a regular basis.

Why is the nodePort number modified when applying the generated manifest ? Because when `prometheus.service.type` is `NodePort`, or the same with `alertmanager.service.type`, and `prometheus.service.nodePort` (respectively `alertmanager.service.nodePort` is unassigned, the generated service manifest contains a key `service.spec.ports.nodePort` and with an empty value.

This PR remove this key from the manifest if the port number is unassigned.

#### Which issue this PR fixes

No related issue found.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
