### PR TITLE
[stable/datadog] Bump Agent version following 7.21 release

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.36
+
+* Bump default Agent version to `7.21.1`
+
 ## 2.3.35
 
 * Add support for configuring the Datadog Admission Controller

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.3.35
+version: 2.3.36
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -667,7 +667,7 @@ agents:
     ## Define the Agent version to use.
     ## Use 7-jmx to enable jmx fetch collection
     #
-    tag: 7.20.2
+    tag: 7.21.1
 
     ## @param doNotCheckTag - boolean - optional
     ## By default, the version passed in agents.image.tag is checked


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump Agent version

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
