### PR TITLE
[stable/sematext-agent] Deprecate Sematext Agent Helm chart

### DIFF
--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.29
+version: 1.0.30
 description: Helm chart for deploying Sematext Agent and Logagent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/README.md
+++ b/stable/sematext-agent/README.md
@@ -1,3 +1,14 @@
+## This Helm chart is deprecated
+
+Given the [deprecation of `stable`](https://github.com/helm/charts#deprecation-timeline), future Sematext Agent charts will be located at [sematext/helm-charts](https://github.com/sematext/helm-charts/).
+
+To update an existing _stable_ deployment with the chart hosted in the Sematext Agent repository, you should run:
+
+```bash
+$ helm repo add sematext https://cdn.sematext.com/helm-charts/
+$ helm upgrade st-agent sematext/sematext-agent
+```
+
 # Sematext Agent
 
 Sematext Agent collects logs, metrics, events and more info for hosts (CPU, memory, disk, network, processes, ...), containers and orchestrator platforms and ships that to [Sematext Cloud](https://sematext.com/cloud). Sematext Cloud is available in the US and EU regions.


### PR DESCRIPTION
#### What this PR does / why we need it:
Deprecates this chart in favour of https://github.com/sematext/helm-charts

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
