### PR TITLE
[stable/clamav] added extra Volume ability

### DIFF
--- a/stable/clamav/Chart.yaml
+++ b/stable/clamav/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: "1.6"
+apiVersion: v1.0.1
+appVersion: "1.7"
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 name: clamav
 version: 1.0.5

--- a/stable/clamav/templates/deployment.yaml
+++ b/stable/clamav/templates/deployment.yaml
@@ -26,17 +26,21 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.freshclamConfig }}
+{{- if or .Values.freshclamConfig .Values.clamdConfig .Values.extraVolumeMounts }}
           volumeMounts:
+{{- end }}
+{{- if .Values.freshclamConfig }}
           - name: freshclam-config-volume
             mountPath: /etc/clamav/freshclam.conf
             subPath: freshclam.conf
 {{- end }}
 {{- if .Values.clamdConfig }}
-          volumeMounts:
           - name: clamd-config-volume
             mountPath: /etc/clamav/clamd.conf
             subPath: clamd.conf
+{{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
 {{- end }}
           ports:
             - name: clamavport
@@ -52,17 +56,21 @@ spec:
             initialDelaySeconds: 300
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.freshclamConfig }}
+{{- if or .Values.freshclamConfig .Values.clamdConfig .Values.extraVolumes }}
       volumes:
+{{- end }}
+{{- if .Values.freshclamConfig }}
         - name: freshclam-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-freshclam
 {{- end }}
 {{- if .Values.clamdConfig }}
-      volumes:
         - name: clamd-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-clamd
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/clamav/values.yaml
+++ b/stable/clamav/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: mailu/clamav
-  tag: "1.6"
+  tag: "1.7"
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/clamav/values.yaml
+++ b/stable/clamav/values.yaml
@@ -12,6 +12,15 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}
+
+extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
 service:
   type: ClusterIP
   port: 3310


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR enables you to define extra volumes and extra volume mounts. For example you can add a volume to `/data` so persist the virus definitions.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
