### PR TITLE
[stable/prometheus] Document in README and Values "enableServiceLinks"

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.10.0
+version: 11.10.1
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -312,6 +312,7 @@ Parameter | Description | Default
 `server.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
 `server.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `server.priorityClassName` | Prometheus server priorityClassName | `nil`
+`server.enableServiceLinks` | Prometheus server ServiceLinks feature | `true`
 `server.schedulerName` | Prometheus server alternate scheduler name | `nil`
 `server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim | `true`
 `server.persistentVolume.accessModes` | Prometheus server data Persistent Volume access modes | `[ReadWriteOnce]`

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -312,7 +312,7 @@ Parameter | Description | Default
 `server.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
 `server.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `server.priorityClassName` | Prometheus server priorityClassName | `nil`
-`server.enableServiceLinks` | Prometheus server ServiceLinks feature | `true`
+`server.enableServiceLinks` | Set service environment variables in Prometheus server pods | `true`
 `server.schedulerName` | Prometheus server alternate scheduler name | `nil`
 `server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim | `true`
 `server.persistentVolume.accessModes` | Prometheus server data Persistent Volume access modes | `[ReadWriteOnce]`

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -572,7 +572,10 @@ server:
   ##
   priorityClassName: ""
 
-  ## WARNING: Not supported in K8s prior to v1.13.0 - therefore, the field will be skipped by the chart.
+  ## EnableServiceLinks indicates whether information about services should be injected
+  ## into pod's environment variables, matching the syntax of Docker links.
+  ## WARNING: Not supported in K8s prior v1.13.0 - therefore, the field will be skipped by the chart.
+  ##
   enableServiceLinks: true
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -574,7 +574,7 @@ server:
 
   ## EnableServiceLinks indicates whether information about services should be injected
   ## into pod's environment variables, matching the syntax of Docker links.
-  ## WARNING: Not supported in K8s prior to v1.13.0 - therefore, the field will be skipped by the chart.
+  ## WARNING: the field is unsupported and will be skipped in K8s prior to v1.13.0.
   ##
   enableServiceLinks: true
 

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -572,7 +572,7 @@ server:
   ##
   priorityClassName: ""
 
-  # EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links.
+  ## WARNING: Not supported in K8s prior to v1.13.0 - therefore, the field will be skipped by the chart.
   enableServiceLinks: true
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -574,7 +574,7 @@ server:
 
   ## EnableServiceLinks indicates whether information about services should be injected
   ## into pod's environment variables, matching the syntax of Docker links.
-  ## WARNING: Not supported in K8s prior v1.13.0 - therefore, the field will be skipped by the chart.
+  ## WARNING: Not supported in K8s prior to v1.13.0 - therefore, the field will be skipped by the chart.
   ##
   enableServiceLinks: true
 


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

- Document in `README.md` and `values.yaml` `enableServiceLinks` for Prometheus server pods.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
