### PR TITLE
[stable/prometheus-operator] bump requirements

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.0
+version: 9.3.1
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.8.10
+  version: 2.8.13
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.10.0
+  version: 1.11.1
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.0
-digest: sha256:4cafebfa80daacbd651defea2a7cad3074e8022114d27d76a3baa1861998981b
-generated: "2020-06-22T12:36:10.4861206Z"
+  version: 5.4.1
+digest: sha256:05235704d7443807582abb5a22ae3e49b944c3716e5ba9906419be01582ce3a5
+generated: "2020-07-26T19:46:46.295417091+02:00"

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.11.1
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.4.1
-digest: sha256:05235704d7443807582abb5a22ae3e49b944c3716e5ba9906419be01582ce3a5
-generated: "2020-07-26T19:46:46.295417091+02:00"
+  version: 5.5.1
+digest: sha256:d849500e09413f98944d128bfb7f70fdf6462f1702258fb4f913b29c233e7ba8
+generated: "2020-07-30T01:24:21.855046946+02:00"

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: "5.4.*"
+    version: "5.5.*"
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: grafana.enabled

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -6,11 +6,11 @@ dependencies:
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
-    version: "1.10.*"
+    version: "1.11.*"
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: "5.3.*"
+    version: "5.4.*"
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: grafana.enabled


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This is a simple version bump on chart dependencies. I am interested in particular with the grafana chart 5.3.1 which fixes a bug for ldap configuration. 

#### Special notes for your reviewer:
I can only bump the grafana version, if multiple bumps in one PR is too much.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
