### PR TITLE
[stable/prometheus] add alertmanger useExistingRole support

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.10.0
+version: 11.10.1
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.10.1
+version: 11.11.0
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -126,6 +126,8 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `alertmanager.enabled` | If true, create alertmanager | `true`
 `alertmanager.name` | alertmanager container name | `alertmanager`
+`alertmanager.useClusterRole` | Use a ClusterRole (and ClusterRoleBinding). If set to false - we define a Role and RoleBinding in the defined namespaces ONLY. This makes alertmanager work - for users who do not have ClusterAdmin privs, but wants alertmanager to operate on their own namespaces, instead of clusterwide. | `alertmanager`
+`alertmanager.useExistingRole` | Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here.  | `alertmanager`
 `alertmanager.image.repository` | alertmanager container image repository | `prom/alertmanager`
 `alertmanager.image.tag` | alertmanager container image tag | `v0.21.0`
 `alertmanager.image.pullPolicy` | alertmanager container image pull policy | `IfNotPresent`

--- a/stable/prometheus/templates/rbac/alertmanager-clusterrole.yaml
+++ b/stable/prometheus/templates/rbac/alertmanager-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole -}}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole (not .Values.alertmanager.useExistingRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/stable/prometheus/templates/rbac/alertmanager-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/rbac/alertmanager-clusterrolebinding.yaml
@@ -12,5 +12,9 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+{{- if (not .Values.alertmanager.useExistingRole) }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+{{- else }}
+  name: {{ .Values.alertmanager.useExistingRole }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/rbac/alertmanager-role.yaml
+++ b/stable/prometheus/templates/rbac/alertmanager-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.alertmanager.enabled .Values.rbac.create (eq .Values.alertmanager.useClusterRole false) -}}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create (eq .Values.alertmanager.useClusterRole false) (not .Values.alertmanager.useExistingRole) -}}
 {{- range $.Values.alertmanager.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/stable/prometheus/templates/rbac/alertmanager-rolebinding.yaml
+++ b/stable/prometheus/templates/rbac/alertmanager-rolebinding.yaml
@@ -14,6 +14,10 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+{{- if (not $.Values.alertmanager.useExistingRole) }}
   name: {{ template "prometheus.alertmanager.fullname" $ }}
+{{- else }}
+  name: {{ $.Values.alertmanager.useExistingRole }}
+{{- end }}
 {{- end }}
 {{ end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -37,7 +37,7 @@ alertmanager:
   ## This makes alertmanager work - for users who do not have ClusterAdmin privs, but wants alertmanager to operate on their own namespaces, instead of clusterwide.
   useClusterRole: true
 
-  # Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here.
+  ## Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here.
   useExistingRole: false
 
   ## alertmanager container name

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -33,9 +33,12 @@ alertmanager:
   enabled: true
 
   ## Use a ClusterRole (and ClusterRoleBinding)
-  ## - If set to false, we define a Role and RoleBinding in the defined namespaces ONLY
+  ## - If set to false - we define a Role and RoleBinding in the defined namespaces ONLY
   ## This makes alertmanager work - for users who do not have ClusterAdmin privs, but wants alertmanager to operate on their own namespaces, instead of clusterwide.
   useClusterRole: true
+
+  # Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here.
+  useExistingRole: false
 
   ## alertmanager container name
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds support for telling AlertManager that there already is a Role definition (in the relevant namespace), that it should bind to, instead of creating a new Role. 
On f.ex. OpenShift - its a somewhat common practice to NOT allow the user to create Role's - only to bind to existing ones.

This allows for having a Role fitting the needs of Alertmanager pre-created - and pointing this chart at that role instead.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the Values.yaml
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
