### PR TITLE
[stable/hlf-ord] Configure metrics

### DIFF
--- a/stable/hlf-ord/Chart.yaml
+++ b/stable/hlf-ord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ord
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.4.3
 keywords:
   - blockchain

--- a/stable/hlf-ord/README.md
+++ b/stable/hlf-ord/README.md
@@ -81,40 +81,46 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Hyperledger Fabric Orderer chart and default values.
 
-| Parameter                          | Description                                     | Default                                                    |
-| ---------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| `image.repository`                 | `hlf-ord` image repository                       | `hyperledger/fabric-orderer`                                    |
-| `image.tag`                        | `hlf-ord` image tag                              | `x86_64-1.1.0`                                             |
-| `image.pullPolicy`                 | Image pull policy                                | `IfNotPresent`                                             |
-| `service.port`                     | TCP port                                         | `7050`                                                     |
-| `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`| `ClusterIP`                                                |
-| `ingress.enabled`                  | If true, Ingress will be created                 | `false`                                                    |
-| `ingress.annotations`              | Ingress annotations                              | `{}`                                                       |
-| `ingress.path`                     | Ingress path                                     | `/`                                                        |
-| `ingress.hosts`                    | Ingress hostnames                                | `[]`                                                       |
-| `ingress.tls`                      | Ingress TLS configuration                        | `[]`                                                       |
-| `persistence.accessMode`           | Use volume as ReadOnly or ReadWrite              | `ReadWriteOnce`                                            |
-| `persistence.annotations`          | Persistent Volume annotations                    | `{}`                                                       |
-| `persistence.size`                 | Size of data volume (adjust for production!)     | `1Gi`                                                      |
-| `persistence.storageClass`         | Storage class of backing PVC                     | `default`                                                  |
-| `ord.type`                         | Type of Orderer (`solo` or `kafka`)              | `solo`                                                     |
-| `ord.mspID`                        | ID of MSP the Orderer belongs to                 | `OrdererMSP`                                               |
-| `ord.tls.server.enabled`           | Do we enable server-side TLS?                    | `false`                                                    |
-| `ord.tls.client.enabled`           | Do we enable client-side TLS?                    | `false`                                                    |
-| `secrets.ord.cred`                 | Credentials: 'CA_USERNAME' and 'CA_PASSWORD'     | ``                                                         |
-| `secrets.ord.cert`                 | Certificate: as 'cert.pem'                       | ``                                                         |
-| `secrets.ord.key`                  | Private key: as 'key.pem'                        | ``                                                         |
-| `secrets.ord.caCert`               | CA Cert: as 'cacert.pem'                         | ``                                                         |
-| `secrets.ord.intCaCert`            | Int. CA Cert: as 'intermediatecacert.pem'        | ``                                                         |
-| `secrets.ord.tls`                  | TLS secret: as 'tls.crt' and 'tls.key'           | ``                                                         |
-| `secrets.ord.tlsRootCert`          | TLS root CA certificate: as 'cert.pem'           | ``                                                         |
-| `secrets.ord.tlsClientRootCert`    | TLS client root CA certificate: as 'cert.pem'    | ``                                                         |
-| `secrets.genesis`                  | Secret containing Genesis Block for orderer      | ``                                                         |
-| `secrets.adminCert`                | Secret containing Orderer Org admin certificate  | ``                                                         |
-| `resources`                        | CPU/Memory resource requests/limits              | `{}`                                                       |
-| `nodeSelector`                     | Node labels for pod assignment                   | `{}`                                                       |
-| `tolerations`                      | Toleration labels for pod assignment             | `[]`                                                       |
-| `affinity`                         | Affinity settings for pod assignment             | `{}`                                                       |
+| Parameter                          | Description                                                   | Default                                                    |
+| ---------------------------------- | ------------------------------------------------              | ---------------------------------------------------------- |
+| `image.repository`                 | `hlf-ord` image repository                                    | `hyperledger/fabric-orderer`                               |
+| `image.tag`                        | `hlf-ord` image tag                                           | `x86_64-1.1.0`                                             |
+| `image.pullPolicy`                 | Image pull policy                                             | `IfNotPresent`                                             |
+| `service.port`                     | TCP port                                                      | `7050`                                                     |
+| `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`             | `ClusterIP`                                                |
+| `ingress.enabled`                  | If true, Ingress will be created                              | `false`                                                    |
+| `ingress.annotations`              | Ingress annotations                                           | `{}`                                                       |
+| `ingress.path`                     | Ingress path                                                  | `/`                                                        |
+| `ingress.hosts`                    | Ingress hostnames                                             | `[]`                                                       |
+| `ingress.tls`                      | Ingress TLS configuration                                     | `[]`                                                       |
+| `persistence.accessMode`           | Use volume as ReadOnly or ReadWrite                           | `ReadWriteOnce`                                            |
+| `persistence.annotations`          | Persistent Volume annotations                                 | `{}`                                                       |
+| `persistence.size`                 | Size of data volume (adjust for production!)                  | `1Gi`                                                      |
+| `persistence.storageClass`         | Storage class of backing PVC                                  | `default`                                                  |
+| `ord.type`                         | Type of Orderer (`solo` or `kafka`)                           | `solo`                                                     |
+| `ord.mspID`                        | ID of MSP the Orderer belongs to                              | `OrdererMSP`                                               |
+| `ord.tls.server.enabled`           | Do we enable server-side TLS?                                 | `false`                                                    |
+| `ord.tls.client.enabled`           | Do we enable client-side TLS?                                 | `false`                                                    |
+| `ord.operations.listenAddress`     | Host and port for the operations server                       | ``                                                         |
+| `ord.metrics.provider`             | Metrics provider, can be `statsd`, `prometheus` or `disabled` | `disabled`                                                 |
+| `ord.metrics.statsd.network`       | Network type, can be `udp` or `tcp`                           | `udp`                                                      |
+| `ord.metrics.statsd.address`       | Address of the StatsD server                                  | `127.0.0.1:8125`                                           |
+| `ord.metrics.statsd.writeInterval` | Intervall at whitch counters and gauges are pushed            | `30s`                                                      |
+| `ord.metrics.statsd.prefix`        | Prefix prepended to all the exported metrics                  | ``                                                         |
+| `secrets.ord.cred`                 | Credentials: 'CA_USERNAME' and 'CA_PASSWORD'                  | ``                                                         |
+| `secrets.ord.cert`                 | Certificate: as 'cert.pem'                                    | ``                                                         |
+| `secrets.ord.key`                  | Private key: as 'key.pem'                                     | ``                                                         |
+| `secrets.ord.caCert`               | CA Cert: as 'cacert.pem'                                      | ``                                                         |
+| `secrets.ord.intCaCert`            | Int. CA Cert: as 'intermediatecacert.pem'                     | ``                                                         |
+| `secrets.ord.tls`                  | TLS secret: as 'tls.crt' and 'tls.key'                        | ``                                                         |
+| `secrets.ord.tlsRootCert`          | TLS root CA certificate: as 'cert.pem'                        | ``                                                         |
+| `secrets.ord.tlsClientRootCert`    | TLS client root CA certificate: as 'cert.pem'                 | ``                                                         |
+| `secrets.genesis`                  | Secret containing Genesis Block for orderer                   | ``                                                         |
+| `secrets.adminCert`                | Secret containing Orderer Org admin certificate               | ``                                                         |
+| `resources`                        | CPU/Memory resource requests/limits                           | `{}`                                                       |
+| `nodeSelector`                     | Node labels for pod assignment                                | `{}`                                                       |
+| `tolerations`                      | Toleration labels for pod assignment                          | `[]`                                                       |
+| `affinity`                         | Affinity settings for pod assignment                          | `{}`                                                       |
 
 ## Persistence
 

--- a/stable/hlf-ord/templates/configmap--ord.yaml
+++ b/stable/hlf-ord/templates/configmap--ord.yaml
@@ -32,3 +32,19 @@ data:
   ORDERER_GENERAL_TLS_CLIENTROOTCAS: "/var/hyperledger/tls/client/cert/*"
   GODEBUG: "netdns=go"
   ADMIN_MSP_PATH: /var/hyperledger/admin_msp
+  ##############
+  # Operations #
+  ##############
+  {{- if .Values.ord.operations.listenAddress }}
+  ORDERER_OPERATIONS_LISTENADDRESS: {{ .Values.ord.operations.listenAddress | quote }}
+  {{- end }}
+  ###########
+  # Metrics #
+  ###########
+  ORDERER_METRICS_PROVIDER: {{ .Values.ord.metrics.provider | quote }}
+  {{- if eq .Values.ord.metrics.provider "statsd" }}
+  ORDERER_METRICS_STATSD_NETWORK: {{ .Values.ord.metrics.statsd.network | quote }}
+  ORDERER_METRICS_STATSD_ADDRESS: {{ .Values.ord.metrics.statsd.address | quote }}
+  ORDERER_METRICS_STATSD_WRITEINTERVAL: {{ .Values.ord.metrics.statsd.WriteInterval | quote }}
+  ORDERER_METRICS_STATSD_PREFIX: {{ .Values.ord.metrics.statsd.prefix | quote }}
+  {{- end }}

--- a/stable/hlf-ord/values.yaml
+++ b/stable/hlf-ord/values.yaml
@@ -55,7 +55,15 @@ ord:
       enabled: "false"
     client:
       enabled: "false"
-
+  operations:
+    listenAddress: ""
+  metrics:
+    provider: "disabled"
+    statsd:
+      network: "udp"
+      address: "127.0.0.1:8125"
+      writeInterval: "30s"
+      prefix: ""
 
 secrets:
   ## These secrets should contain the Orderer crypto materials and credentials


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR enable the setup of a metrics server to get more insight of what is happening from an operational point of view.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

For the values names I replicated the structure and default values from the [orderer.yaml](https://github.com/hyperledger/fabric/blob/master/sampleconfig/orderer.yaml) file.

In the `readme.md` it was required to resize the columns generating a big diff, the relevant added lines are from L104 to L109.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
