### PR TITLE
[stable/prometheus-mysql-exporter] Add ServiceMonitor metricRelabeling

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.6.0
+version: 0.7.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -36,43 +36,44 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the mysql exporter chart and their default values.
 
-| Parameter                              | Description                                         | Default                            |
-| -------------------------------------- | --------------------------------------------------- | ---------------------------------- |
-| `replicaCount`                         | Amount of pods for the deployment                   | `1`                                |
-| `image.repository`                     | Image repository                                    | `prom/mysqld-exporter`             |
-| `image.tag`                            | Image tag                                           | `v0.11.0`                          |
-| `image.pullPolicy`                     | Image pull policy                                   | `IfNotPresent`                     |
-| `service.name`                         | Service name                                        | `mysql-exporter`                   |
-| `service.labels`                       | Additional labels for the service                   | `{}`                               |
-| `service.annotations`                  | Annotations to be added to the service              | `{}`                               |
-| `service.type`                         | Service type                                        | `ClusterIP`                        |
-| `service.externalport`                 | The service port                                    | `9104`                             |
-| `service.internalPort`                 | The target port of the container                    | `9104`                             |
-| `resources`                            | CPU/Memory resource requests/limits                 | `{}`                               |
-| `annotations`                          | pod annotations for easier discovery                | `see values.yaml`                  |
-| `collectors`                           | Collector configuration                             | `see values.yaml`                  |
-| `podLabels`                            | Additional labels to add to each pod                | `{}`                               |
-| `mysql.db`                             | MySQL connection db (optional)                      | `""`                               |
-| `mysql.host`                           | MySQL connection host                               | `localhost`                        |
-| `mysql.param`                          | MySQL connection parameters (optional)              | `"tcp"`                            |
-| `mysql.pass`                           | MySQL connection password                           | `password`                         |
-| `mysql.port`                           | MySQL connection port                               | `3306`                             |
-| `mysql.protocol`                       | MySQL connection protocol (optional)                | `""`                               |
-| `mysql.user`                           | MySQL connection username                           | `exporter`                         |
-| `mysql.existingSecret`                 | Use existing kubernetes secret for DATA_SOURCE_NAME | `false`                            |
-| `cloudsqlproxy.enabled`                | Flag to enable the connection using Cloud SQL Proxy | `false`                            |
-| `cloudsqlproxy.image.repo`             | Cloud SQL Proxy image repository                    | `gcr.io/cloudsql-docker/gce-proxy` |
-| `cloudsqlproxy.image.tag`              | Cloud SQL Proxy image tag                           | `1.14`                             |
-| `cloudsqlproxy.image.pullPolicy`       | Cloud SQL Proxy image pull policy                   | `IfNotPresent`                     |
-| `cloudsqlproxy.instanceConnectionName` | Google Cloud instance connection name               | `project:us-central1:dbname`       |
-| `cloudsqlproxy.port`                   | Cloud SQL Proxy listening port                      | `3306`                             |
-| `cloudsqlproxy.credentials`            | Cloud SQL Proxy service account credentials         | `bogus credential file`            |
-| `serviceMonitor.enabled`               | Integration with prometheus-operator                | `false`                            |
-| `serviceMonitor.interval`              | Interval for polling this exporter                  |                                    |
-| `serviceMonitor.scrapeTimeout`         | Timeout where exporter is considered faulty         |                                    |
-| `serviceMonitor.jobLabel`              | Label to use to retrieve the job name from          | `""`                               |
-| `serviceMonitor.targetLabels`          | Labels to transfer from service onto the target     | `[]`                               |
-| `serviceMonitor.podTargetLabels`       | Labels to transfor from pod onto the target         | `[]`                               |
+| Parameter                              | Description                                                | Default                            |
+| -------------------------------------- | -----------------------------------------------------------| ---------------------------------- |
+| `replicaCount`                         | Amount of pods for the deployment                          | `1`                                |
+| `image.repository`                     | Image repository                                           | `prom/mysqld-exporter`             |
+| `image.tag`                            | Image tag                                                  | `v0.11.0`                          |
+| `image.pullPolicy`                     | Image pull policy                                          | `IfNotPresent`                     |
+| `service.name`                         | Service name                                               | `mysql-exporter`                   |
+| `service.labels`                       | Additional labels for the service                          | `{}`                               |
+| `service.annotations`                  | Annotations to be added to the service                     | `{}`                               |
+| `service.type`                         | Service type                                               | `ClusterIP`                        |
+| `service.externalport`                 | The service port                                           | `9104`                             |
+| `service.internalPort`                 | The target port of the container                           | `9104`                             |
+| `resources`                            | CPU/Memory resource requests/limits                        | `{}`                               |
+| `annotations`                          | pod annotations for easier discovery                       | `see values.yaml`                  |
+| `collectors`                           | Collector configuration                                    | `see values.yaml`                  |
+| `podLabels`                            | Additional labels to add to each pod                       | `{}`                               |
+| `mysql.db`                             | MySQL connection db (optional)                             | `""`                               |
+| `mysql.host`                           | MySQL connection host                                      | `localhost`                        |
+| `mysql.param`                          | MySQL connection parameters (optional)                     | `"tcp"`                            |
+| `mysql.pass`                           | MySQL connection password                                  | `password`                         |
+| `mysql.port`                           | MySQL connection port                                      | `3306`                             |
+| `mysql.protocol`                       | MySQL connection protocol (optional)                       | `""`                               |
+| `mysql.user`                           | MySQL connection username                                  | `exporter`                         |
+| `mysql.existingSecret`                 | Use existing kubernetes secret for DATA_SOURCE_NAME        | `false`                            |
+| `cloudsqlproxy.enabled`                | Flag to enable the connection using Cloud SQL Proxy        | `false`                            |
+| `cloudsqlproxy.image.repo`             | Cloud SQL Proxy image repository                           | `gcr.io/cloudsql-docker/gce-proxy` |
+| `cloudsqlproxy.image.tag`              | Cloud SQL Proxy image tag                                  | `1.14`                             |
+| `cloudsqlproxy.image.pullPolicy`       | Cloud SQL Proxy image pull policy                          | `IfNotPresent`                     |
+| `cloudsqlproxy.instanceConnectionName` | Google Cloud instance connection name                      | `project:us-central1:dbname`       |
+| `cloudsqlproxy.port`                   | Cloud SQL Proxy listening port                             | `3306`                             |
+| `cloudsqlproxy.credentials`            | Cloud SQL Proxy service account credentials                | `bogus credential file`            |
+| `serviceMonitor.enabled`               | Integration with prometheus-operator                       | `false`                            |
+| `serviceMonitor.interval`              | Interval for polling this exporter                         |                                    |
+| `serviceMonitor.scrapeTimeout`         | Timeout where exporter is considered faulty                |                                    |
+| `serviceMonitor.jobLabel`              | Label to use to retrieve the job name from                 | `""`                               |
+| `serviceMonitor.targetLabels`          | Labels to transfer from service onto the target            | `[]`                               |
+| `serviceMonitor.podTargetLabels`       | Labels to transfor from pod onto the target                | `[]`                               |
+| `serviceMonitor.metricRelabelings`     | MetricRelabelConfigs to apply to samples before ingestion. | `[]`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-mysql-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-mysql-exporter/templates/servicemonitor.yaml
@@ -36,4 +36,7 @@ spec:
   {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   {{- end }}
+  {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
+  {{- end }}
 {{- end }}

--- a/stable/prometheus-mysql-exporter/values.yaml
+++ b/stable/prometheus-mysql-exporter/values.yaml
@@ -29,6 +29,7 @@ serviceMonitor:
   jobLabel: ""
   targetLabels: []
   podTargetLabels: []
+  metricRelabelings: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

Adds the ServiceMonitor metricRelabelings key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint).

Used for adding, dropping or renaming labels at ingestion time, or to drop entire metrics that are not useful.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
