### PR TITLE
[stable/clamav] Add DaemonSet Capablities

### DIFF
--- a/stable/clamav/Chart.yaml
+++ b/stable/clamav/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6"
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 name: clamav
-version: 1.0.5
+version: 1.0.6
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 maintainers:

--- a/stable/clamav/templates/daemonset.yaml
+++ b/stable/clamav/templates/daemonset.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.daemonset.enabled }}
+apiVersion: {{ default "apps/v1beta2" .Values.kubeMeta.deploymentApiVersion }}
+kind: DaemonSet
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "clamav.name" . }}
+    helm.sh/chart: {{ include "clamav.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "clamav.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "clamav.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.freshclamConfig }}
+          volumeMounts:
+          - name: freshclam-config-volume
+            mountPath: /etc/clamav/freshclam.conf
+            subPath: freshclam.conf
+{{- end }}
+{{- if .Values.clamdConfig }}
+          volumeMounts:
+          - name: clamd-config-volume
+            mountPath: /etc/clamav/clamd.conf
+            subPath: clamd.conf
+{{- end }}
+{{- if .Values.daemonset.clamPathConfig }}
+          volumeMounts:
+          - name: host-fs
+            mountPath: /host-fs
+            readOnly: true
+{{- end }}
+          ports:
+            - name: clamavport
+              containerPort: 3310
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: clamavport
+            initialDelaySeconds: 300
+          readinessProbe:
+            tcpSocket:
+              port: clamavport
+            initialDelaySeconds: 300
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.freshclamConfig }}
+      volumes:
+        - name: freshclam-config-volume
+          configMap:
+            name: {{ include "clamav.fullname" . }}-freshclam
+{{- end }}
+{{- if .Values.clamdConfig }}
+      volumes:
+        - name: clamd-config-volume
+          configMap:
+            name: {{ include "clamav.fullname" . }}-clamd
+{{- end }}
+{{- if .Values.daemonset.clamPathConfig }}
+      volumes:
+        - name: data-vol
+          emptyDir: {}
+        - name: host-fs
+          hostPath:
+            path: /
+        - name: logs
+          hostPath:
+            path: /var/log/clamav
+{{ end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/stable/clamav/values.yaml
+++ b/stable/clamav/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 
 # Enable deamonset to scan the path / on every node
 daemonset:
-  enabled: true
+  enabled: false
   clamPathConfig:
     volumeMounts:
     - name: host-fs

--- a/stable/clamav/values.yaml
+++ b/stable/clamav/values.yaml
@@ -12,6 +12,15 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Enable deamonset to scan the path / on every node
+daemonset:
+  enabled: true
+  clamPathConfig:
+    volumeMounts:
+    - name: host-fs
+      mountPath: /host-fs
+      readOnly: true
+
 service:
   type: ClusterIP
   port: 3310


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds DaemonSet capabilities to ClamAV Chart

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
