### PR TITLE
[stable/stolon] fix privileges to improve openshift deployments #23360

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.16.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -77,6 +77,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `keeper.replicaCount`                   | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | `{}`                                                         |
 | `keeper.priorityClassName`              | Keeper priorityClassName                       | `nil`                                                        |
+| `keeper.runAsUser`                      | Keeper securityContext runAsUser               | `stolon`                                                     |
 | `keeper.fsGroup`                        | Keeper securityContext fsGroup, do not set if pg9 or 10 | ``                                                  |
 | `keeper.nodeSelector`                   | Node labels for keeper pod assignment          | `{}`                                                         |
 | `keeper.affinity`                       | Affinity settings for keeper pod assignment    | `{}`                                                         |
@@ -91,6 +92,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `proxy.replicaCount`                    | Number of proxy nodes                          | `2`                                                          |
 | `proxy.resources`                       | Proxy resource requests/limit                  | `{}`                                                         |
 | `proxy.priorityClassName`               | Proxy priorityClassName                        | `nil`                                                        |
+| `proxy.runAsUser`                       | Proxy securityContext runAsUser                | `stolon`                                                     |
 | `proxy.nodeSelector`                    | Node labels for proxy pod assignment           | `{}`                                                         |
 | `proxy.affinity`                        | Affinity settings for proxy pod assignment     | `{}`                                                         |
 | `proxy.tolerations`                     | Toleration labels for proxy pod assignment     | `[]`                                                         |
@@ -101,6 +103,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `sentinel.replicaCount`                 | Number of sentinel nodes                       | `2`                                                          |
 | `sentinel.resources`                    | Sentinel resource requests/limit               | `{}`                                                         |
 | `sentinel.priorityClassName`            | Sentinel priorityClassName                     | `nil`                                                        |
+| `sentinel.runAsUser`                    | Sentinel securityContext runAsUser             | `stolon`                                                     |
 | `sentinel.nodeSelector`                 | Node labels for sentinel pod assignment        | `{}`                                                         |
 | `sentinel.affinity`                     | Affinity settings for sentinel pod assignment  | `{}`                                                         |
 | `sentinel.tolerations`                  | Toleration labels for sentinel pod assignment  | `[]`                                                         |

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -32,9 +32,14 @@ spec:
 {{- end }}
       serviceAccountName: {{ template "stolon.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
-{{- if .Values.keeper.fsGroup }}
+{{- if or .Values.keeper.fsGroup .Values.keeper.runAsUser }}
       securityContext:
+{{- if .Values.keeper.runAsUser }}
+        runAsUser: {{ .Values.keeper.runAsUser }}
+{{- end}}
+{{- if .Values.keeper.fsGroup }}
         fsGroup: {{ .Values.keeper.fsGroup }}
+{{- end}}
 {{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -54,11 +59,10 @@ spec:
               export POD_IP=$(hostname -i)
               export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
               export STOLON_DATA=/stolon-data
-              chown stolon:stolon $STOLON_DATA
               {{- if .Values.shmVolume.enabled }}
               chmod -R 777 /dev/shm
               {{- end }}
-              exec gosu stolon stolon-keeper --data-dir $STOLON_DATA
+              exec stolon-keeper --data-dir $STOLON_DATA
           env:
             - name: POD_NAME
               valueFrom:

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -30,6 +30,10 @@ spec:
       priorityClassName: "{{ .Values.proxy.priorityClassName }}"
 {{- end }}
       serviceAccountName: {{ template "stolon.serviceAccountName" . }}
+{{- if .Values.proxy.runAsUser }}
+      securityContext:
+        runAsUser: {{ .Values.proxy.runAsUser }}
+{{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
@@ -39,10 +43,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - "/bin/bash"
-            - "-ec"
-            - |
-              exec gosu stolon stolon-proxy
+            - stolon-proxy
           env:
             - name: POD_NAME
               valueFrom:

--- a/stable/stolon/templates/role.yaml
+++ b/stable/stolon/templates/role.yaml
@@ -14,8 +14,29 @@ rules:
   resources:
     - pods
     - endpoints
-    - configmaps
+  verbs:
+    - "watch"
+    - "get"
+    - "list"
+    - "update"
+    - "patch"
+- apiGroups:
+    - ""
+  resources:
     - events
   verbs:
-    - "*"
+    - "watch"
+    - "get"
+    - "list"
+- apiGroups:
+  - ""
+  resources:
+    - configmaps
+  verbs:
+    - "watch"
+    - "get"
+    - "list"
+    - "create"
+    - "update"
+    - "patch"
 {{- end -}}

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -31,6 +31,10 @@ spec:
       priorityClassName: "{{ .Values.sentinel.priorityClassName }}"
 {{- end }}
       serviceAccountName: {{ template "stolon.serviceAccountName" . }}
+{{- if .Values.sentinel.runAsUser }}
+      securityContext:
+        runAsUser: {{ .Values.sentinel.runAsUser }}
+{{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
@@ -40,10 +44,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - "/bin/bash"
-            - "-ec"
-            - |
-              exec gosu stolon stolon-sentinel
+            - stolon-sentinel
           env:
             - name: POD_NAME
               valueFrom:

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -115,6 +115,7 @@ keeper:
   annotations: {}
   resources: {}
   priorityClassName: ""
+  runAsUser: "stolon"
   fsGroup: ""
   service:
     type: ClusterIP
@@ -144,6 +145,7 @@ proxy:
   annotations: {}
   resources: {}
   priorityClassName: ""
+  runAsUser: "stolon"
   service:
     type: ClusterIP
 #    loadBalancerIP: ""
@@ -174,6 +176,7 @@ sentinel:
   annotations: {}
   resources: {}
   priorityClassName: ""
+  runAsUser: "stolon"
   nodeSelector: {}
   affinity: {}
   tolerations: []


### PR DESCRIPTION
Signed-off-by: Rafael Rivero <myspambox.rafael@gmail.com>

#### Is this a new chart

No, it's a fix to improve [stable/stolon] support of Openshift clusters.

#### What this PR does / why we need it:

This PR reduces the privileges that the chart requests, hopefully keeping backwards compatibility with the previous version of the chart:

- The role permissions are lower than requested previously, but still enough for stolon.
- `gosu stolon` calls at runtime are replaced by "securityPolicy.runAsUser: stolon" in specs, which should avoid booting the pods as root in the first place.

#### Which issue this PR fixes

I opened issue #23360 to describe my problems running the previous version of the chart in a managed openshift cluster, with an account that has limited privileges.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
