### PR TITLE
[stable/prometheus-adapter] Create resources when providing existing rules

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.5.0
+version: 2.5.1
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-auth-reader-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-auth-reader-role-binding.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "k8s-prometheus-adapter.name" . }}-auth-reader
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/prometheus-adapter/templates/custom-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiservice.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rules.default .Values.rules.custom }}
+{{- if or .Values.rules.default .Values.rules.custom .Values.rules.existing }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:

--- a/stable/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (or .Values.rules.default .Values.rules.custom) -}}
+{{- if and .Values.rbac.create (or .Values.rules.default .Values.rules.custom .Values.rules.existing) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/stable/prometheus-adapter/templates/external-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-apiservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rules.external }}
+{{- if or .Values.rules.external .Values.rules.existing }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:

--- a/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rules.external -}}
+{{- if and .Values.rbac.create (or .Values.rules.external .Values.rules.existing) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rules.external -}}
+{{- if and .Values.rbac.create (or .Values.rules.external .Values.rules.existing) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/prometheus-adapter/templates/resource-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/resource-metrics-apiservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rules.resource}}
+{{- if or .Values.rules.resource .Values.rules.existing }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:

--- a/stable/prometheus-adapter/templates/resource-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/resource-metrics-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rules.resource -}}
+{{- if and .Values.rbac.create (or .Values.rules.resource .Values.rules.existing) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/prometheus-adapter/templates/resource-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/resource-metrics-cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rules.resource -}}
+{{- if and .Values.rbac.create (or .Values.rules.resource .Values.rules.existing) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

The chart gives the ability to use a manually created config map containing rules, but it doesn't create all necessary resources (like `APIService`s, `ClusterRole`s, and `ClusterRoleBinding`s). This PR adds check if the `rules.existing` value was set to all conditions responsible for creating these resources.

It also adds missing `namespace` to the `auth-reader` role binding. The `extension-apiserver-authentication-reader` exists in `kube-system` namespace, so the role binding should be created there.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
