### PR TITLE
[stable/jenkins] Add support for initializing Jenkins master only once

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
-## 2.4.2
+## 2.5.0
 
 Add an option to specify that Jenkins master should be initialized only once, during first install.
 

--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 2.4.2
+
+Add an option to specify that Jenkins master should be initialized only once, during first install.
+
 ## 2.4.1
 
 Reorder README parameters into sections to facilitate chart usage and maintenance

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.4.1
+version: 2.4.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.4.2
+version: 2.5.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -68,7 +68,7 @@ master:
 #### Migration steps
 
 Migration instructions heavily depend on your current setup.
-So think of the list below more as a general guideline of what should be done. 
+So think of the list below more as a general guideline of what should be done.
 
 - Ensure that the Jenkins image you are using contains a user with id 1000 and a group with the same id.
   That's the case for `jenkins/jenkins:lts` image, which the chart uses by default
@@ -191,6 +191,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `master.installPlugins`           | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.18.2 workflow-aggregator:2.6 credentials-binding:1.19 git:3.11.0 workflow-job:2.33` |
 | `master.additionalPlugins`        | List of Jenkins plugins to install in addition to those listed in master.installPlugins | `[]` |
+| `master.initializeOnce`           | Initialize only on first install. Ensures plugins do not get updated inadvertently. | `false` |
 | `master.overwritePlugins`         | Overwrite installed plugins on start.| `false`                                   |
 | `master.overwritePluginsFromImage` | Keep plugins that are already installed in the master image.| `true`            |
 

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -191,7 +191,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `master.installPlugins`           | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.18.2 workflow-aggregator:2.6 credentials-binding:1.19 git:3.11.0 workflow-job:2.33` |
 | `master.additionalPlugins`        | List of Jenkins plugins to install in addition to those listed in master.installPlugins | `[]` |
-| `master.initializeOnce`           | Initialize only on first install. Ensures plugins do not get updated inadvertently. | `false` |
+| `master.initializeOnce`           | Initialize only on first install. Ensures plugins do not get updated inadvertently. Requires `persistence.enabled` to be set to `true`. | `false` |
 | `master.overwritePlugins`         | Overwrite installed plugins on start.| `false`                                   |
 | `master.overwritePluginsFromImage` | Keep plugins that are already installed in the master image.| `true`            |
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -159,6 +159,12 @@ data:
     </jenkins.CLI>
 {{- end }}
   apply_config.sh: |-
+{{- if .Values.master.initializeOnce }}
+    if [ -f {{ .Values.master.jenkinsHome }}/initialization-completed ]; then
+      echo "master was previously initialized, refusing to re-initialize"
+      exit 0
+    fi
+{{- end }}
     echo "applying Jenkins configuration"
     mkdir -p {{ .Values.master.jenkinsRef }}/secrets/;
 {{- if .Values.master.enableXmlConfig }}
@@ -253,6 +259,9 @@ data:
     yes n | cp -i /var/jenkins_secrets/* {{ .Values.master.jenkinsRef }}/secrets/;
 {{- end }}
     echo "finished initialization"
+{{- if .Values.master.initializeOnce }}
+    touch {{ .Values.master.jenkinsHome }}/initialization-completed
+{{- end }}
 {{- range $key, $val := .Values.master.initScripts }}
   init{{ $key }}.groovy: |-
 {{ $val | indent 4 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -235,6 +235,10 @@ master:
   # List of plugins to install in addition to those listed in master.installPlugins
   additionalPlugins: []
 
+  # Enable to initialize the Jenkins master only once on initial installation.
+  # Without this, whenever the master gets restarted (Evicted, etc.) it will fetch plugin updates which has the potential to cause breakage.
+  initializeOnce: false
+
   # Enable to always override the installed plugins with the values of 'master.installPlugins' on upgrade or redeployment.
   # overwritePlugins: true
 

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -237,6 +237,7 @@ master:
 
   # Enable to initialize the Jenkins master only once on initial installation.
   # Without this, whenever the master gets restarted (Evicted, etc.) it will fetch plugin updates which has the potential to cause breakage.
+  # Note that for this to work, `persistence.enabled` needs to be set to `true`
   initializeOnce: false
 
   # Enable to always override the installed plugins with the values of 'master.installPlugins' on upgrade or redeployment.


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a configuration option to configure Jenkins master initialization. Using `master.initializeOnce` it can be ensured that plugins do not get updated inadvertently when the `apply_config.sh` is executed as part of the initialization.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Prior to this, whenever the Jenkins master pod got rescheduled (Eviction, node rotated etc.) the `apply_config.sh` would be executed as part of the initialization process. This upgrades the plugins ( `rm -rf {{ .Values.master.jenkinsRef }}/plugins/*.lock` ) which in turn causes breakages if the Jenkins image version is pinned or if the plugin configuration format has changed. This PR introduces the configuration parameter `master.initializeOnce` so that the user can elect to initialize Jenkins only once during initial provisioning.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
