### PR TITLE
[stable/datadog] Deprecate stable/datadog

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.3.42
+
+* Deprecate current repository, replaced by `helm.datadoghq.com`
+
 ## 2.3.41
 
 * Fix issue with Kubernetes <= 1.14 and Cluster Agent's External Metrics Provider (must be 443)

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 name: datadog
-version: 2.3.41
+deprecated: true
+version: 2.3.42
 appVersion: "7"
-description: Datadog Agent
+description: DEPRECATED Datadog Agent
 keywords:
 - monitoring
 - alerting
@@ -12,20 +13,3 @@ icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 sources:
 - https://app.datadoghq.com/account/settings#agent/kubernetes
 - https://github.com/DataDog/datadog-agent
-maintainers:
-- name: ahmed-mez
-  email: ahmed.mezghani@datadoghq.com
-- name: celenechang
-  email: celene@datadoghq.com
-- name: charlyf
-  email: charly@datadoghq.com
-- name: clamoriniere
-  email: cedric.lamoriniere@datadoghq.com
-- name: irabinovitch
-  email: ilan@datadoghq.com
-- name: L3n41c
-  email: lenaic.huard@datadoghq.com
-- name: vboulineau
-  email: vincent.boulineau@datadoghq.com
-- name: xornivore
-  email: ivan.ilichev@datadoghq.com

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -1,3 +1,23 @@
+# **DEPRECATED** This repository has moved
+
+With upcoming deprecation of `helm/charts` repository, the Datadog Helm Charts repository has moved to: https://github.com/DataDog/helm-charts
+
+You can use this new repository by doing:
+
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+```
+
+You can now use `datadog/datadog` instead of `stable/datadog` in all your Helm commands, e.g.:
+
+```bash
+# New installation
+helm install --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> datadog/datadog
+# Upgrade existing installation
+helm upgrade --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> datadog/datadog
+```
+
 # Datadog
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -1,3 +1,16 @@
+#################################################################
+####          WARNING: This repository is deprecated         ####
+#################################################################
+
+Following upcoming deprecation of https://github.com/helm/charts repository
+The stable/datadog Helm chart has been moved to helm.datadoghq.com (source: https://github.com/DataDog/helm-charts)
+
+You can add new repository by running:
+  helm repo add datadog https://helm.datadoghq.com
+  helm repo update
+
+You can now replace stable/datadog by datadog/datadog in all your Helm commands
+
 {{- if (or (.Values.datadog.apiKeyExistingSecret) (not (eq .Values.datadog.apiKey "<DATADOG_API_KEY>"))) }}
 Datadog agents are spinning up on each node in your cluster. After a few
 minutes, you should see your agents starting in your event stream:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add deprecation notice for this repository, has been replaced by https://github.com/DataDog/helm-charts accessible at `helm.datadoghq.com`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
