### PR TITLE
[stable/prometheus] Added init containers for prometheus server stateful set.

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.11.0
+version: 11.11.1
 appVersion: 2.19.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/statefulsets/server.yaml
+++ b/stable/prometheus/templates/statefulsets/server.yaml
@@ -47,6 +47,10 @@ spec:
       {{- end }}
 {{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
+      {{- if .Values.server.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.server.extraInitContainers | indent 8 }}
+      {{- end }}
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}


### PR DESCRIPTION
In prometheus chart for server-service.yaml there is an init container but its missing for statefulset, with this change added init containers for prometheus server stateful set.