### PR TITLE
[stable/atlantis] Allow for multiple-hostnames in ingress

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.14.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.12.2
+version: 3.13.0
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/README.md
+++ b/stable/atlantis/README.md
@@ -20,7 +20,7 @@ In order for Atlantis to start and run successfully:
 
 1. Supply a value for `orgWhitelist`, e.g. `github.org/myorg/*`.
 
-## Additional manifests 
+## Additional manifests
 
 It is possible to add additional manifests into a deployment, to extend the chart. One of the reason is to deploy a manifest specific to a cloud provider ( BackendConfig on GKE for example ).
 
@@ -93,6 +93,7 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `ingress.labels`                            | Additional labels to use for the Ingress. | `{}` |
 | `ingress.path`                              | Path to use in the `Ingress`. Should be set to `/*` if using gce-ingress in Google Cloud.                                                                                                                                                                                                                 | `/`     |
 | `ingress.host`                              | Domain name Kubernetes Ingress rule looks for. Set it to the domain Atlantis will be hosted on.                                                                                                                                                                                                           | `chart-example.local`     |
+| `ingress.hosts`                             | Domain name Kubernetes Ingress rule looks for. Supports multiple values in array notation. Set it to the domains Atlantis will be hosted on.                                                                                                                                                                                                           | `[]`     |
 | `ingress.tls`                               | Kubernetes tls block. See [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) for details.                                                                                                                                                                            | `[]`     |
 | `test.enabled`                              | Whether to enable the test. | `true` |
 | `extraManifests`                         | add additional manifests to deploy                      | `[]`                      |

--- a/stable/atlantis/templates/ingress.yaml
+++ b/stable/atlantis/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "atlantis.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -30,10 +32,10 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.port }}
+              servicePort: {{ $servicePort }}
     {{- end }}
     {{- if .Values.ingress.host }}
     - host: {{ .Values.ingress.host }}

--- a/stable/atlantis/templates/ingress.yaml
+++ b/stable/atlantis/templates/ingress.yaml
@@ -26,6 +26,16 @@ spec:
 {{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end }}
   rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .Values.service.port }}
+    {{- end }}
+    {{- if .Values.ingress.host }}
     - host: {{ .Values.ingress.host }}
       http:
         paths:
@@ -33,4 +43,5 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ .Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -158,6 +158,12 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   path: /
   host: chart-example.local
+  # When a single host isn't enough. Preferrably change the
+  # host variable above to an empty string, and populate the
+  # array below.
+  hosts: []
+  # - atlantis-example.local
+  # - atlantis.production.tld.remote
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -158,9 +158,9 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   path: /
   host: chart-example.local
-  # When a single host isn't enough. Preferrably change the
-  # host variable above to an empty string, and populate the
-  # array below.
+  # When a single host isn't enough. The above
+  # host will still act as the primary endpoint in the chart, however this
+  # value will let you extend to multiple domains/endpoints.
   hosts: []
   # - atlantis-example.local
   # - atlantis.production.tld.remote


### PR DESCRIPTION

#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

Allows an operator to specify multiple-hostnames for the ingress that ships with the chart. TLS allows for multiple hostnames, the ingress object should follow the same pattern. Due care was taken to ensure the chart continues to behave as expected with both values declared, or a mix/match of the two. (note: no additonal logic was added to the tls block, and the operator is still expected to list all hostnames that require TLS in the TLS configuration block)

- Its often that we deploy a service under a serialized "cluster dns" tier, and then CNAME a short-hand TLD to the serialized "cluster dns". The current chart only accepts a single hostname and that breaks the assumption of how we have our ingress tree is structured.

#### Special notes for your reviewer:

This was an attempt to not fully deprecate an existing config option, and retain compatibility until a 4.0.0 release target was reached to deprecate the single-hostname ingress. Please advise if there is a better pattern you'd like me to implement.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
