### PR TITLE
[stable/prometheus-operator] add udp protocol support for alertmanager NodePort service

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.0
+version: 9.4.0
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -33,13 +33,23 @@ spec:
   {{- end }}
 {{- end }}
   ports:
-    - name: {{ .Values.alertmanager.alertmanagerSpec.portName }}
     {{- if eq .Values.alertmanager.service.type "NodePort" }}
+    - name: {{ .Values.alertmanager.alertmanagerSpec.portName }}
       nodePort: {{ .Values.alertmanager.service.nodePort }}
-    {{- end }}
       port: {{ .Values.alertmanager.service.port }}
       targetPort: {{ .Values.alertmanager.service.targetPort }}
       protocol: TCP
+    - name: {{ printf "%s-udp" .Values.alertmanager.alertmanagerSpec.portName }}
+      nodePort: {{ .Values.alertmanager.service.nodePort }}
+      port: {{ .Values.alertmanager.service.port }}
+      targetPort: {{ .Values.alertmanager.service.targetPort }}
+      protocol: UDP
+    {{- else }}
+    - name: {{ .Values.alertmanager.alertmanagerSpec.portName }}
+      port: {{ .Values.alertmanager.service.port }}
+      targetPort: {{ .Values.alertmanager.service.targetPort }}
+      protocol: TCP
+    {{- end }}
   selector:
     app: alertmanager
     alertmanager: {{ template "prometheus-operator.fullname" . }}-alertmanager


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:

When joining alertmanager to external cluster it is required to have both UDP and TCP enabled for gossip to function properly.
See - https://github.com/prometheus/alertmanager#high-availability
> Important: Both UDP and TCP are needed in alertmanager 0.15 and higher for the cluster to work.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
