### PR TITLE
[incubator/druid] Add missing ingress.yaml to druid router

### DIFF
--- a/incubator/druid/templates/router/ingress.yaml
+++ b/incubator/druid/templates/router/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.router.ingress.enabled -}}
+{{- $fullName := include "druid.router.fullname" . -}}
+{{- $ingressPath := .Values.router.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ include "druid.name" . }}
+    chart: {{ include "druid.chart" . }}
+    component: {{ .Values.router.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.router.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.router.ingress.tls }}
+  tls:
+  {{- range .Values.router.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.router.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
### What this PR does / why we need it:
Adds the missing `ingress.yaml` to Druid's router template.

#### Which issue this PR fixes
  - fixes #23396

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
