### PR TITLE
[stable/minio] Don't display the ACCESS_KEY and SECRET_KEY to console...

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.32
+version: 5.0.33
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/templates/NOTES.txt
+++ b/stable/minio/templates/NOTES.txt
@@ -30,7 +30,9 @@ You can now access Minio server on http://<External-IP>:9000. Follow the below s
 
   1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
 
-  2. mc config host add {{ template "minio.fullname" . }}-local http://<External-IP>:{{ .Values.service.port }} {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+	2. Get the ACCESS_KEY=$(kubectl get secret minio -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret minio -o jsonpath="{.data.secretkey}" | base64 --decode)
+
+  2. mc config host add {{ template "minio.fullname" . }}-local http://<External-IP>:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
 
   3. mc ls {{ template "minio.fullname" . }}-local
 


### PR DESCRIPTION
- This puts some logic in for the NOTES.txt so you don't display the
  access_key and secret_key to the console
- Fix a missing `--api` for the command

Co-authored-by: Paul Czarkowski <username.taken@gmail.com>
Signed-off-by: JJ Asghar <jjasghar@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
