### PR TITLE
[stable/kube-ops-view] add environment variables

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.2.0
+version: 1.2.1
 appVersion: 20.4.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters

--- a/stable/kube-ops-view/README.md
+++ b/stable/kube-ops-view/README.md
@@ -35,3 +35,8 @@ $ helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Variables
+| Parameter                              | Description                                                                      | Default                                           |
+| -------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `env`                                  | Pass environment variables to the pod ([more info](https://github.com/hjacobs/kube-ops-view#configuration)) | `{}` |

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -53,6 +53,11 @@ spec:
         args:
         - --redis-url=redis://{{ .Release.Name }}-redis-master:{{ .Values.redis.master.port }}
         {{- end }}
+        env:
+        {{- range $key, $value := index .Values "env" }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
         {{- with .Values.securityContext }}
         securityContext: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/stable/kube-ops-view/values.yaml
+++ b/stable/kube-ops-view/values.yaml
@@ -43,6 +43,9 @@ affinity: {}
 nodeSelector: {}
 tolerations: []
 
+# pass env vars like this: helm [...] --set env.ENV_NAME=env_value,env.ENV_NAME2=env_value2
+env: {}
+
 # Add securityContext
 securityContext: {}
 


### PR DESCRIPTION
Signed-off-by: Paul Rostorp <paul.rostorp@letsbuild.com>

@hjacobs 

#### What this PR does / why we need it:
Makes it possible to pass environment variables to kube ops view: https://github.com/hjacobs/kube-ops-view#configuration

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
