### PR TITLE
[stable/grafana] Avoid creating a secret with empty LDAP config

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.5.2
+version: 5.5.3
 appVersion: 7.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/secret.yaml
+++ b/stable/grafana/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD)) (not .Values.ldap.existingSecret) }}
+{{- if or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

https://github.com/helm/charts/pull/23006 ensures that the secret is created when not using an existing secret for LDAP config. However, when LDAP isn't enabled, there's no need to do this, and the result is a secret containing only

```yaml
data:
  ldap-toml: ""
```

This PR addresses the issue so that the secret won't be created unnecessarily.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
