### PR TITLE
[stable/prometheus-adapter] Add custom annotations for serviceAccount

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.5.0
+version: 2.5.1
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -137,6 +137,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |
 | `serviceAccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
 | `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
+| `serviceAccount.annotations`    | Annotations to add to the serviceAccount                                        | `{}`                                        |
 | `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs    | `false`                                     |
 | `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)         | ``                                          |
 | `tls.key`                       | Private key of the APIService (ignored if tls.enable=false)                     | ``                                          |

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-service-account.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-service-account.yaml
@@ -8,4 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 {{- end -}}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -34,6 +34,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # ServiceAccount annotations.
+  annotations: {}
 
 resources: {}
   # requests:


### PR DESCRIPTION
Signed-off-by: Juan Pablo Jaramillo Pineda <juan@pablox.io>

cc @mattiasgees @steven-sheehy @hectorj2f

#### What this PR does / why we need it:

Add support for custom annotations for `serviceAccount`

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
