### PR TITLE
[stable/logstash] Added envFrom support to logstash container

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.4.0
+version: 2.4.1
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `podAnnotations`                | Pod annotations                                    | `{}`                                             |
 | `podLabels`                     | Pod labels                                         | `{}`                                             |
 | `extraEnv`                      | Extra pod environment variables                    | `[]`                                             |
+| `envFrom`                       | Environment variables from configMaps & secrets    | `[]`                                             |
 | `extraContainers`               | Add additional containers                          | `[]`                                             |
 | `extraInitContainers`           | Add additional initContainers                      | `[]`                                             |
 | `podManagementPolicy`           | podManagementPolicy of the StatefulSet             | `OrderedReady`                                   |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -94,6 +94,10 @@ spec:
           {{- if .Values.extraEnv }}
 {{ .Values.extraEnv | toYaml | indent 12 }}
           {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+{{ toYaml .Values.envFrom | indent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -119,6 +119,12 @@ podLabels: {}
 
 extraEnv: []
 
+envFrom: []
+  # - configMapRef:
+  #     name: configMap-name
+  # - secretRef:
+  #     name: secret-name
+
 extraInitContainers: []
   # - name: echo
   #   image: busybox


### PR DESCRIPTION
Signed-off-by: Vignesh Subramanian <vignesh.subramanian93@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR provides support to add environment variables to the logstash container from configMaps & secrets, using the `envFrom` keyword.

#### Special notes for your reviewer:
The new keyword `envFrom` is added to the `values.yaml` with a default empty list and an example configuration.
Documentation is provided in the README.md.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
