### PR TITLE
[stable/fluent-bit] Make tests use fluent-bit image specified in values file

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.10.0
+version: 2.10.1
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/tests/test.yaml
+++ b/stable/fluent-bit/templates/tests/test.yaml
@@ -31,7 +31,7 @@ spec:
   containers:
     - name: {{ .Release.Name }}-test
       {{- if eq .Values.backend.type "forward"}}
-      image: "fluent/fluentd:v1.4-debian-1"
+      image: "{{ .Values.image.fluent_bit.repository }}:{{ .Values.image.fluent_bit.tag }}"
       {{- else }}
       image: "dwdraju/alpine-curl-jq"
       {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
Currently, when `.Values.backend.type` is set to `"forward"`, test pod uses hard-coded image `"fluent/fluentd:v1.4-debian-1"`. This makes test(s) inconsistent with the actual version of fluent-bit specified in `values.yaml` (e.g. I'm currently using `fluent/fluent-bit:1.5.2`). 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
