### PR TITLE
stable/jenkins - Changes as per JENKINS-47112

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 2.5.2
+
+Fix as per JENKINS-47112
+
+## 2.5.1
+
+Support Jenkins Resource Root URL
+
 ## 2.5.0
 
 Add an option to specify that Jenkins master should be initialized only once, during first install.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.5.1
+version: 2.5.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -175,13 +175,13 @@ Returns kubernetes pod template configuration as code
     command: {{ .Values.agent.command }}
     {{- end }}
     envVars:
-    - containerEnvVar:
-        key: "JENKINS_URL"
-    {{- if .Values.master.slaveJenkinsUrl }}
-        value: {{ tpl .Values.master.slaveJenkinsUrl . }}
-    {{- else }}
-        value: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}"
-    {{- end }}
+      - envVar:
+          key: "JENKINS_URL"
+          {{- if .Values.master.slaveJenkinsUrl }}
+          value: {{ tpl .Values.master.slaveJenkinsUrl . }}
+          {{- else }}
+          value: "http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}"
+          {{- end }}
     {{- if .Values.agent.imageTag }}
     image: "{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}"
     {{- else }}


### PR DESCRIPTION
Fixes the UI showing usage of deprecated field `containerEnvVar`.

Also fixed the indentation.

Ref: https://github.com/jenkinsci/kubernetes-plugin/pull/273

Before: 

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/18496730/89196127-64870580-d5c7-11ea-8f33-0f1010a23b89.png">


After:

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/18496730/89196189-7cf72000-d5c7-11ea-96bf-f3da112dc003.png">



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
