### PR TITLE
[stable/opa] allow hostNetwork setting on OPA pod

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.14.0
+version: 1.14.1
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -69,6 +69,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for OPA. | `false` |
 | `podDisruptionBudget.minAvailable` | Sets the minimum number of pods to be available. Cannot be set at the same time as maxUnavailable. | `1` |
 | `podDisruptionBudget.maxUnavailable` | Sets the maximum number of pods to be unavailable. Cannot be set at the same time as minAvailable. | Unset |
+| `hostNetwork.enabled` | Use hostNetwork setting on OPA pod | `false` |
 | `image` | OPA image to deploy. | `openpolicyagent/opa` |
 | `imageTag` | OPA image tag to deploy. | See [values.yaml](values.yaml) |
 | `port` | Port in the pod to which OPA will bind itself. | `443` |

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -72,7 +72,9 @@ spec:
             - name: bootstrap
               mountPath: /bootstrap
 {{- end }}
-
+{{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+{{- end }}
       containers:
         - name: opa
           image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -100,6 +100,10 @@ authz:
   # Mostly useful for debugging.
   enabled: true
 
+# Use hostNetwork setting on OPA pod
+hostNetwork:
+  enabled: false
+
 # Docker image and tag to deploy.
 image: openpolicyagent/opa
 imageTag: 0.15.1


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
We need to allow the open-policy-agent pod to use the hostNetwork in managed cloud environments like EKS.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
