### PR TITLE
[stable/satisfy] upgrade to use apps/v1

### DIFF
--- a/stable/satisfy/Chart.yaml
+++ b/stable/satisfy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: satisfy
-version: 1.0.0
+version: 1.1.0
 appVersion: "3.0.4"
 description: Composer repo hosting with Satisfy
 home: https://github.com/anapsix/docker-satisfy

--- a/stable/satisfy/templates/_helpers.tpl
+++ b/stable/satisfy/templates/_helpers.tpl
@@ -38,3 +38,14 @@ Create chart name and version as used by the chart label.
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Use apps/v1 when supported, fallback to apps/v1beta2 if it's not.
+*/}}
+{{- define "satisfy.deployAPIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+{{- printf "apps/v1" -}}
+{{- else -}}
+{{- printf "apps/v1beta2" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/satisfy/templates/deployment.yaml
+++ b/stable/satisfy/templates/deployment.yaml
@@ -1,4 +1,5 @@
-apiVersion: apps/v1beta2
+{{- $apiVersion := include "satisfy.deployAPIVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: Deployment
 metadata:
   name: {{ include "satisfy.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the `Deployment` to use `apps/v1` api version.
This is required to deploy on k8s above 1.15 (`apps/v1beta2` support was removed in 1.16).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
