### PR TITLE
[stable/prometheus-operator] add instance-namespace paramters to scope api interaction for CRs

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.0
+version: 9.4.0
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -209,6 +209,9 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.namespaces` |  Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with `denyNamespaces`. Setting this to an empty object will disable the configuration | `{}` |
 | `prometheusOperator.namespaces.releaseNamespace` | Include the release namespace | `false` |
 | `prometheusOperator.namespaces.additional` | Include additional namespaces besides the release namespace | `[]` |
+| `prometheusOperator.alertmanagerInstanceNamespaces` | Namespaces to scope the interaction of the Prometheus Operator for Alertmanager CRs. Overrides the global namespace configuration for Alertmanager CRs. Setting to an empty list will disable the configuration | `[]` |
+| `prometheusOperator.thanosRulerInstanceNamespaces` | Namespaces to scope the interaction of the Prometheus Operator for Thanos Ruler CRs. Overrides the global namespace configuration for Thanos Ruler CRs. Setting to an empty list will disable the configuration | `[]` |
+| `prometheusOperator.prometheusInstanceNamespaces` | Namespaces to scope the interaction of the Prometheus Operator for Prometheus CRs. Overrides the global namespace configuration for Prometheus CRs. Setting to an empty list will disable the configuration | `[]` |
 | `prometheusOperator.manageCrds` |If true prometheus operator will create and update its CRDs on startup (for operator `<v0.39.0`)) | `true` |
 | `prometheusOperator.denyNamespaces` | Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with `namespaces` | `[]` |
 | `prometheusOperator.enabled` | Deploy Prometheus Operator. Only one of these should be deployed into the cluster | `true` |

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -61,6 +61,15 @@ spec:
           {{- end }}
             - --namespaces={{ $ns | join "," }}
           {{- end }}
+          {{- if .Values.prometheusOperator.alertmanagerInstanceNamespaces }}
+            - --alertmanager-instance-namespaces={{ .Values.prometheusOperator.alertmanagerInstanceNamespaces | join "," }}
+          {{- end }}
+          {{- if .Values.prometheusOperator.prometheusInstanceNamespaces }}
+            - --prometheus-instance-namespaces={{ .Values.prometheusOperator.prometheusInstanceNamespaces | join "," }}
+          {{- end }}
+          {{- if .Values.prometheusOperator.thanosRulerInstanceNamespaces }}
+            - --thanos-ruler-instance-namespaces={{ .Values.prometheusOperator.thanosRulerInstanceNamespaces | join "," }}
+          {{- end }}
             - --logtostderr=true
             - --localhost=127.0.0.1
             {{- if .Values.prometheusOperator.prometheusConfigReloaderImage.sha }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1181,6 +1181,21 @@ prometheusOperator:
   ##
   denyNamespaces: []
 
+  ## Namespaces to scope the interaction of the Prometheus Operator for Alertmanager CRs.
+  ## Overrides the global namespace configuration for Alertmanager CRs. Setting to an empty list will disable the configuration
+  ##
+  alertmanagerInstanceNamespaces: []
+
+  ## Namespaces to scope the interaction of the Prometheus Operator for Prometheus CRs.
+  ## Overrides the global namespace configuration for Prometheus CRs. Setting to an empty list will disable the configuration
+  ##
+  prometheusInstanceNamespaces: []
+
+  ## Namespaces to scope the interaction of the Prometheus Operator for Thanos Ruler CRs.
+  ## Overrides the global namespace configuration for Thanos Ruler CRs. Setting to an empty list will disable the configuration
+  ##
+  thanosRulerInstanceNamespaces: []
+
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
Implement command line arguments of prometheus operator to scope api interactions for Alertmanager, Prometheus and ThanosRuler CRs. These arguments take precedence over the normal namespace scope parameters.

These flags are not yet fully documented in Prometheus Operator but can be found [here](https://github.com/coreos/prometheus-operator/blob/ad3571f1e23c51277f6522dee93919ce153d1f46/cmd/operator/main.go#L177) in the source code.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
