### PR TITLE
[incubator/kube-downscaler] Bump to 20.5.0 and update default values to match

### DIFF
--- a/incubator/kube-downscaler/Chart.yaml
+++ b/incubator/kube-downscaler/Chart.yaml
@@ -1,7 +1,7 @@
 name: kube-downscaler
 apiVersion: v1
 version: 0.4.2
-appVersion: 19.10.1
+appVersion: 20.5.0
 description: A Helm chart for kube-downscaler
 home: https://github.com/hjacobs/kube-downscaler
 sources:

--- a/incubator/kube-downscaler/Chart.yaml
+++ b/incubator/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: 0.4.2
+version: 0.5.0
 appVersion: 20.5.0
 description: A Helm chart for kube-downscaler
 home: https://github.com/hjacobs/kube-downscaler

--- a/incubator/kube-downscaler/README.md
+++ b/incubator/kube-downscaler/README.md
@@ -42,29 +42,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the kube-downscaler chart and their default values.
 
-| Parameter               | Description                                                                                          | Default                                 |
-| ----------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `replicaCount`            | Number of replicas to run                                                                            | `1`                                       |
-| `name`                    | How to name resources created by this chart                                                          | `kube-downscaler`                         |
-| `debug.enable`            | Do you want to start the downscaler in debug mode                                                    | `false`                                   |
-| `namespace.active_in`     | Which namespace does the downscaler scans for deployment/statefulsets to downscale (`''` equals all)   | `''`                                      |
-| `interval`                | Interval between scans, in seconds                                                                   | `60`                                      |
-| `image.repository`        | Downscaler container image repository                                                                | `hjacobs/kube-downscaler`                 |
-| `image.tag`               | Downscaler container image tag                                                                       | `19.10.1`                                 |
-| `image.pullPolicy`        | Downscaler container image pull policy                                                               | `IfNotPresent`                            |
-| `nodeSelector`            | Node labels for downscaler pod assignment                                                            | `{}`                                      |
-| `tolerations`             | Downscaler pod toleration for taints                                                                 | `[]`                                      |
-| `affinity`                | Downscaler pod affinity                                                                              | `{}`                                      |
-| `podAnnotations`          | Annotations to be added to downscaler pod                                                            | `{}`                                      |
-| `podLabels`               | Labels to be added to downscaler pod                                                                 | `{}`                                      |
-| `resources`               | Downscaler pod resource requests & limits                                                            | `{}`                                      |
-| `securityContext`         | SecurityContext to apply to the downscaler pod                                                       | `{}`                                      |
-| `rbac.create`             | If true, create & use RBAC resources                                                                 | `true`                                    |
-| `rbac.serviceAccountName` | ServiceAccount downscaler will use (ignored if rbac.create=true)                                     | `default`                                 |
-| `downscaleResources`      | Resources the downscaler is allowed to manage                                                        | `[deployments, statefulsets]`             |
-| `excludedDeployments`     | Deployments to exclude from the downscaler                                                           | `[]`                                      |
-| `excludedNamespaces`      | Namespaces to exclude from the downscaler                                                            | `[]`                                      |
-| `extraArgs`               | Add extra args to docker command                                                                     | `[]`                                      |
+| Parameter                 | Description                                                                                          | Default                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `replicaCount`            | Number of replicas to run                                                                            | `1`                                                               |
+| `name`                    | How to name resources created by this chart                                                          | `kube-downscaler`                                                 |
+| `debug.enable`            | Do you want to start the downscaler in debug mode                                                    | `false`                                                           |
+| `namespace.active_in`     | Which namespace does the downscaler scans for deployment/statefulsets to downscale (`''` equals all) | `''`                                                              |
+| `interval`                | Interval between scans, in seconds                                                                   | `60`                                                              |
+| `image.repository`        | Downscaler container image repository                                                                | `hjacobs/kube-downscaler`                                         |
+| `image.tag`               | Downscaler container image tag                                                                       | `20.5.0`                                                          |
+| `image.pullPolicy`        | Downscaler container image pull policy                                                               | `IfNotPresent`                                                    |
+| `nodeSelector`            | Node labels for downscaler pod assignment                                                            | `{}`                                                              |
+| `tolerations`             | Downscaler pod toleration for taints                                                                 | `[]`                                                              |
+| `affinity`                | Downscaler pod affinity                                                                              | `{}`                                                              |
+| `podAnnotations`          | Annotations to be added to downscaler pod                                                            | `{}`                                                              |
+| `podLabels`               | Labels to be added to downscaler pod                                                                 | `{}`                                                              |
+| `resources`               | Downscaler pod resource requests & limits                                                            | `{}`                                                              |
+| `securityContext`         | SecurityContext to apply to the downscaler pod                                                       | `{}`                                                              |
+| `rbac.create`             | If true, create & use RBAC resources                                                                 | `true`                                                            |
+| `rbac.serviceAccountName` | ServiceAccount downscaler will use (ignored if rbac.create=true)                                     | `default`                                                         |
+| `downscaleResources`      | Resources the downscaler is allowed to manage                                                        | `[deployments, statefulsets, horizontalpodautoscalers, cronjobs]` |
+| `excludedDeployments`     | Deployments to exclude from the downscaler                                                           | `[]`                                                              |
+| `excludedNamespaces`      | Namespaces to exclude from the downscaler                                                            | `[]`                                                              |
+| `extraArgs`               | Add extra args to docker command                                                                     | `[]`                                                              |
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 

--- a/incubator/kube-downscaler/values.yaml
+++ b/incubator/kube-downscaler/values.yaml
@@ -16,6 +16,8 @@ namespace:
 downscaleResources:
   - deployments
   - statefulsets
+  - horizontalpodautoscalers
+  - cronjobs
 
 # List of namespaces to be excluded from the downscaler
 excludedNamespaces: []

--- a/incubator/kube-downscaler/values.yaml
+++ b/incubator/kube-downscaler/values.yaml
@@ -34,7 +34,7 @@ rbac:
 
 image:
   repository: hjacobs/kube-downscaler
-  tag: 19.10.1
+  tag: 20.5.0
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
* Update the `incubator/kube-downscaler` chart to match the latest version available from [hjacobs/kube-downscaler](https://github.com/hjacobs/kube-downscaler).
* Adjust `downscaleResources` with the newly supported api types in the latest release

#### Special notes for your reviewer:

@Rowern I can remove the `downscaleResources` change if you would prefer to keep the previous defaults. 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
