### PR TITLE
[incubator/fluentd-cloudwatch] Add value to allow moving ahead of extensions/v1beta1 API version without helm capabilities

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-cloudwatch
-version: 0.13.0
+version: 0.13.1
 appVersion: v1.7.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -46,38 +46,39 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd Cloudwatch chart and their default values.
 
-| Parameter                       | Description                                                                     | Default                               |
-| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------|
-| `image.repository`              | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
-| `image.tag`                     | Image tag                                                                       | `v1.3.3-debian-cloudwatch-1.0`        |
-| `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                        |
-| `resources.limits.cpu`          | CPU limit                                                                       | `100m`                                |
-| `resources.limits.memory`       | Memory limit                                                                    | `200Mi`                               |
-| `resources.requests.cpu`        | CPU request                                                                     | `100m`                                |
-| `resources.requests.memory`     | Memory request                                                                  | `200Mi`                               |
-| `hostNetwork`                   | Host network                                                                    | `false`                               |
-| `podAnnotations`                | Annotations                                                                     | `{}`                                  |
-| `podSecurityContext`            | Security Context                                                                | `{}`                                  |
-| `awsRegion`                     | AWS Cloudwatch region                                                           | `us-east-1`                           |
-| `awsRole`                       | AWS IAM Role To Use                                                             | `nil`                                 |
-| `awsAccessKeyId`                | AWS Access Key Id of a AWS user with a policy to access Cloudwatch              | `nil`                                 |
-| `awsSecretAccessKey`            | AWS Secret Access Key of a AWS user with a policy to access Cloudwatch          | `nil`                                 |
-| `data`                          | Fluentd ConfigMap values. The main configuration is defined under `fluent.conf` | `example configuration`               |
-| `logGroupName`                  | AWS Cloudwatch log group                                                        | `kubernetes`                          |
-| `rbac.create`                   | If true, create & use RBAC resources                                            | `false`                               |
-| `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true)                    | `default`                             |
-| `rbac.pspEnabled`               | PodSecuritypolicy                                                               | `false`                               |
-| `rbac.serviceAccountAnnotations`| Additional Service Account annotations                                          | `{}`                                  |
-| `volumeMounts`                  | Add volume mounts to daemon set                                                 | `[]`                                  |
-| `volumes`                       | Add volumes to daemon set                                                       | `[]`                                  |
-| `tolerations`                   | Add tolerations                                                                 | `[]`                                  |
-| `extraVars`                     | Add pod environment variables (must be specified as a single line object)       | `[]`                                  |
-| `updateStrategy`                | Define daemonset update strategy                                                | `OnDelete`                            |
-| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                  |
-| `affinity`                      | Node affinity for pod assignment                                                | `{}`                                  |
-| `priorityClassName`             | Set priority class for daemon set                                               | `nil`                                 |
-| `busybox.repository`            | Image repository of busybox                                                     | `busybox`                             |
-| `busybox.tag`                   | Image tag of busybox                                                            | `1.31.0`                              |
+| Parameter                          | Description                                                                     | Default                               |
+| ---------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------|
+| `image.repository`                 | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                        | Image tag                                                                       | `v1.3.3-debian-cloudwatch-1.0`        |
+| `image.pullPolicy`                 | Image pull policy                                                               | `IfNotPresent`                        |
+| `resources.limits.cpu`             | CPU limit                                                                       | `100m`                                |
+| `resources.limits.memory`          | Memory limit                                                                    | `200Mi`                               |
+| `resources.requests.cpu`           | CPU request                                                                     | `100m`                                |
+| `resources.requests.memory`        | Memory request                                                                  | `200Mi`                               |
+| `hostNetwork`                      | Host network                                                                    | `false`                               |
+| `podAnnotations`                   | Annotations                                                                     | `{}`                                  |
+| `podSecurityContext`               | Security Context                                                                | `{}`                                  |
+| `awsRegion`                        | AWS Cloudwatch region                                                           | `us-east-1`                           |
+| `awsRole`                          | AWS IAM Role To Use                                                             | `nil`                                 |
+| `awsAccessKeyId`                   | AWS Access Key Id of a AWS user with a policy to access Cloudwatch              | `nil`                                 |
+| `awsSecretAccessKey`               | AWS Secret Access Key of a AWS user with a policy to access Cloudwatch          | `nil`                                 |
+| `data`                             | Fluentd ConfigMap values. The main configuration is defined under `fluent.conf` | `example configuration`               |
+| `logGroupName`                     | AWS Cloudwatch log group                                                        | `kubernetes`                          |
+| `rbac.create`                      | If true, create & use RBAC resources                                            | `false`                               |
+| `rbac.serviceAccountName`          | existing ServiceAccount to use (ignored if rbac.create=true)                    | `default`                             |
+| `rbac.pspEnabled`                  | PodSecuritypolicy                                                               | `false`                               |
+| `rbac.serviceAccountAnnotations`   | Additional Service Account annotations                                          | `{}`                                  |
+| `volumeMounts`                     | Add volume mounts to daemon set                                                 | `[]`                                  |
+| `volumes`                          | Add volumes to daemon set                                                       | `[]`                                  |
+| `tolerations`                      | Add tolerations                                                                 | `[]`                                  |
+| `extraVars`                        | Add pod environment variables (must be specified as a single line object)       | `[]`                                  |
+| `updateStrategy`                   | Define daemonset update strategy                                                | `OnDelete`                            |
+| `nodeSelector`                     | Node labels for pod assignment                                                  | `{}`                                  |
+| `affinity`                         | Node affinity for pod assignment                                                | `{}`                                  |
+| `priorityClassName`                | Set priority class for daemon set                                               | `nil`                                 |
+| `busybox.repository`               | Image repository of busybox                                                     | `busybox`                             |
+| `busybox.tag`                      | Image tag of busybox                                                            | `1.31.0`                              |
+| `avoidExtensionsV1Beta1ApiVersion` | Use newer APIVersions than extensions/v1beta1, not required for helm install    | `false`                               |
 
 
 If using fluentd-kubernetes-daemonset v0.12.43-cloudwatch, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+{{- if or (.Capabilities.APIVersions.Has "apps/v1") (.Values.avoidExtensionsV1Beta1ApiVersion) }}
 apiVersion: apps/v1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/incubator/fluentd-cloudwatch/templates/psp.yaml
+++ b/incubator/fluentd-cloudwatch/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1beta1") (.Values.avoidExtensionsV1Beta1ApiVersion) }}
 apiVersion: policy/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -6,6 +6,9 @@ image:
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
   pullPolicy: IfNotPresent
 
+# Set this to true to drop the use of extensions/v1beta1
+avoidExtensionsV1Beta1ApiVersion: false
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
We are using `helm template` without `helm install` so none of the
Capabilities.APIVersions stuff works for us, but we do want to install this
chart on Kubernetes 1.16.

See also https://github.com/helm/charts/pull/21660

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
