### PR TITLE
[stable/prometheus-operator] - Updating README.md to fix table entry formatting

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -381,8 +381,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.thanosIngress.paths` |  Ingress paths for Thanos Sidecar | `[]` |
 | `prometheus.thanosIngress.annotations` |  Ingress annotations for Thanos Sidecar | `{}` |
 | `prometheus.thanosIngress.labels` |  Ingress labels for Thanos Sidecar | `{}` |
-| `prometheus.thanosIngress.hosts |  Ingress hosts for Thanos Sidecar | `[]` |
-| `prometheus.thanosIngress.tls |  Ingress tls for Thanos Sidecar | `[]` |
+| `prometheus.thanosIngress.hosts` |  Ingress hosts for Thanos Sidecar | `[]` |
+| `prometheus.thanosIngress.tls` |  Ingress tls for Thanos Sidecar | `[]` |
 
 ### Alertmanager
 | Parameter | Description | Default |


### PR DESCRIPTION
#### What this PR does / why we need it:
The formatting on 2 of the prometheus values table is missing the trailing `

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
