### PR TITLE
stable/jenkins - Feature: Support Resource Root URL in Ingress

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.5.0
+version: 2.5.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -270,6 +270,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.ingress.enabled`          | Enables ingress                      | `false`                                   |
 | `master.ingress.apiVersion`       | Ingress API version                  | `extensions/v1beta1`                      |
 | `master.ingress.hostName`         | Ingress host name                    | Not set                                   |
+| `master.ingress.resourceRootUrl`  | Hostname to serve assets from        | Not set                                   |
 | `master.ingress.annotations`      | Ingress annotations                  | `{}`                                      |
 | `master.ingress.labels`           | Ingress labels                       | `{}`                                      |
 | `master.ingress.path`             | Ingress path                         | Not set                                   |

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -38,6 +38,14 @@ spec:
 {{- if .Values.master.ingress.hostName }}
     host: {{ .Values.master.ingress.hostName | quote }}
 {{- end }}
+{{- if .Values.master.ingress.resourceRootUrl }}
+  - http:
+      paths:
+      - backend:
+        serviceName: {{ template "jenkins.fullname" . }}
+        servicePort: {{ .Values.master.servicePort }}
+    host: {{ .Values.master.ingress.resourceRootUrl | quote }}
+{{- end }}
 {{- if .Values.master.ingress.tls }}
   tls:
 {{ toYaml .Values.master.ingress.tls | indent 4 }}

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -42,8 +42,8 @@ spec:
   - http:
       paths:
       - backend:
-        serviceName: {{ template "jenkins.fullname" . }}
-        servicePort: {{ .Values.master.servicePort }}
+          serviceName: {{ template "jenkins.fullname" . }}
+          servicePort: {{ .Values.master.servicePort }}
     host: {{ .Values.master.ingress.resourceRootUrl | quote }}
 {{- end }}
 {{- if .Values.master.ingress.tls }}


### PR DESCRIPTION
Feature: Support Resource Root URL in Ingress

Ref: https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy

Signed-off-by: Noel Georgi <git@frezbo.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
