### PR TITLE
[stable/prometheus-operator] Allow option to create additional Ingress for health endpoints

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -264,6 +264,10 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.additionalServiceMonitors` | List of `ServiceMonitor` objects to create. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec | `[]` |
 | `prometheus.enabled` | Deploy prometheus | `true` |
 | `prometheus.annotations` | Prometheus annotations | `{}` |
+| `prometheus.healthIngress.annotations` | Prometheus Health Ingress annotations | `{}` |
+| `prometheus.healthIngress.enabled` | If true, an additional Ingress for monitoring Prometheus health will be created | `false` |
+| `prometheus.healthIngress.labels` | Prometheus Health Ingress additional labels | `{}` |
+| `prometheus.ingressPerReplica.hostPrefix` |  | `""` |
 | `prometheus.ingress.annotations` | Prometheus Ingress annotations | `{}` |
 | `prometheus.ingress.enabled` | If true, Prometheus Ingress will be created | `false` |
 | `prometheus.ingress.hosts` | Prometheus Ingress hostnames | `[]` |
@@ -381,8 +385,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.thanosIngress.paths` |  Ingress paths for Thanos Sidecar | `[]` |
 | `prometheus.thanosIngress.annotations` |  Ingress annotations for Thanos Sidecar | `{}` |
 | `prometheus.thanosIngress.labels` |  Ingress labels for Thanos Sidecar | `{}` |
-| `prometheus.thanosIngress.hosts |  Ingress hosts for Thanos Sidecar | `[]` |
-| `prometheus.thanosIngress.tls |  Ingress tls for Thanos Sidecar | `[]` |
+| `prometheus.thanosIngress.hosts` |  Ingress hosts for Thanos Sidecar | `[]` |
+| `prometheus.thanosIngress.tls` |  Ingress tls for Thanos Sidecar | `[]` |
 
 ### Alertmanager
 | Parameter | Description | Default |
@@ -419,6 +423,9 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.apiVersion` | Api that prometheus will use to communicate with alertmanager. Possible values are v1, v2 | `v2` |
 | `alertmanager.config` | Provide YAML to configure Alertmanager. See https://prometheus.io/docs/alerting/configuration/#configuration-file. The default provided works to suppress the Watchdog alert from `defaultRules.create` | `{"global":{"resolve_timeout":"5m"},"route":{"group_by":["job"],"group_wait":"30s","group_interval":"5m","repeat_interval":"12h","receiver":"null","routes":[{"match":{"alertname":"Watchdog"},"receiver":"null"}]},"receivers":[{"name":"null"}]}` |
 | `alertmanager.enabled` | Deploy alertmanager | `true` |
+| `alertmanager.healthIngress.annotations` | Alertmanager Health Ingress annotations | `{}` |
+| `alertmanager.healthIngress.enabled` | If true, an additional Ingress for monitoring Alertmanager health will be created | `false` |
+| `alertmanager.healthIngress.labels` | Alertmanager Health Ingress additional labels | `{}` |
 | `alertmanager.ingress.annotations` | Alertmanager Ingress annotations | `{}` |
 | `alertmanager.ingress.enabled` | If true, Alertmanager Ingress will be created | `false` |
 | `alertmanager.ingress.hosts` | Alertmanager Ingress hostnames | `[]` |

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.8.14
+  version: 2.8.10
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.10.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.6
-digest: sha256:32724526e92c26d748eaab3ccb0b52909577ea1bd813513ff0e47990eff7b371
-generated: "2020-08-05T11:53:07.999905739+02:00"
+  version: 5.3.0
+digest: sha256:4cafebfa80daacbd651defea2a7cad3074e8022114d27d76a3baa1861998981b
+generated: "2020-06-22T12:36:10.4861206Z"

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.8.10
+  version: 2.8.14
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.10.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.0
-digest: sha256:4cafebfa80daacbd651defea2a7cad3074e8022114d27d76a3baa1861998981b
-generated: "2020-06-22T12:36:10.4861206Z"
+  version: 5.3.6
+digest: sha256:32724526e92c26d748eaab3ccb0b52909577ea1bd813513ff0e47990eff7b371
+generated: "2020-08-05T11:53:07.999905739+02:00"

--- a/stable/prometheus-operator/templates/alertmanager/ingressHealth.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingressHealth.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.healthIngress.enabled }}
+{{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager-health" }}
+{{- $servicePort := .Values.alertmanager.service.port -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+{{- if .Values.alertmanager.healthIngress.annotations }}
+  annotations:
+{{ toYaml .Values.alertmanager.healthIngress.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus-operator.name" . }}-alertmanager
+{{- if .Values.alertmanager.healthIngress.labels }}
+{{ toYaml .Values.alertmanager.healthIngress.labels | indent 4 }}
+{{- end }}
+{{ include "prometheus-operator.labels" . | indent 4 }}
+spec:
+  rules:
+  {{- if .Values.alertmanager.ingress.hosts }}
+  {{- range $host := .Values.alertmanager.ingress.hosts }}
+    - host: {{ tpl $host $ }}
+      http:
+        paths:
+          - path: /-/ready
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- else }}
+    - http:
+        paths:
+          - path: /-/ready
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- if .Values.alertmanager.ingress.tls }}
+  tls:
+{{ toYaml .Values.alertmanager.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/prometheus-operator/templates/alertmanager/ingressHealth.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingressHealth.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.healthIngress.enabled }}
-{{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager-health" }}
+{{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager" }}
 {{- $servicePort := .Values.alertmanager.service.port -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
@@ -8,7 +8,7 @@ apiVersion: extensions/v1beta1
 {{ end -}}
 kind: Ingress
 metadata:
-  name: {{ $serviceName }}
+  name: {{ $serviceName }}-health
   namespace: {{ template "prometheus-operator.namespace" . }}
 {{- if .Values.alertmanager.healthIngress.annotations }}
   annotations:

--- a/stable/prometheus-operator/templates/prometheus/ingressHealth.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingressHealth.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.healthIngress.enabled }}
+{{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus-health" }}
+{{- $servicePort := .Values.prometheus.service.port -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+{{- if .Values.prometheus.healthIngress.annotations }}
+  annotations:
+{{ toYaml .Values.prometheus.healthIngress.annotations | indent 4 }}
+{{- end }}
+  name: {{ $serviceName }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    app: {{ template "prometheus-operator.name" . }}-prometheus
+{{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.prometheus.healthIngress.labels }}
+{{ toYaml .Values.prometheus.healthIngress.labels | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- if .Values.prometheus.ingress.hosts }}
+  {{- range $host := .Values.prometheus.ingress.hosts }}
+    - host: {{ tpl $host $ }}
+      http:
+        paths:
+          - path: /-/ready
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- else }}
+    - http:
+        paths:
+          - path: /-/ready
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- if .Values.prometheus.ingress.tls }}
+  tls:
+{{ toYaml .Values.prometheus.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/prometheus-operator/templates/prometheus/ingressHealth.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingressHealth.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.healthIngress.enabled }}
-{{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus-health" }}
+{{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
 {{- $servicePort := .Values.prometheus.service.port -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
@@ -12,7 +12,7 @@ metadata:
   annotations:
 {{ toYaml .Values.prometheus.healthIngress.annotations | indent 4 }}
 {{- end }}
-  name: {{ $serviceName }}
+  name: {{ $serviceName }}-health
   namespace: {{ template "prometheus-operator.namespace" . }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -182,7 +182,7 @@ alertmanager:
 
   ## Configure an additional Ingress to expose health endpoint under a different Ingress.
   healthIngress:
-    enabled: false
+    enabled: true
     annotations: {}
     labels: {}
 
@@ -1464,7 +1464,7 @@ prometheus:
 
   ## Configure an additional Ingress to expose health endpoint under a different Ingress.
   healthIngress:
-    enabled: false
+    enabled: true
     annotations: {}
     labels: {}
 
@@ -1502,7 +1502,8 @@ prometheus:
     ##
     # hosts:
     #   - prometheus.domain.com
-    hosts: []
+    hosts:
+      - prometheus.mlsdevcloud.com
 
     ## Paths to use for ingress rules - one path should match the prometheusSpec.routePrefix
     ##
@@ -1512,7 +1513,10 @@ prometheus:
     ## TLS configuration for Prometheus Ingress
     ## Secret must be manually created in the namespace
     ##
-    tls: []
+    tls:
+      - secretName: prometheus.mlsdevcloud.com
+        hosts:
+          - prometheus.mlsdevcloud.com
       # - secretName: prometheus-general-tls
       #   hosts:
       #     - prometheus.example.com

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1456,7 +1456,13 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+  ## Configure an additional Ingress to expose health endpoint under a different Ingress.
+  healthIngress:
+    enabled: false
+    annotations: {}
+    labels: {}
+
+  ## Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -180,6 +180,12 @@ alertmanager:
   #       {{ end }}
   #       {{ end }}
 
+  ## Configure an additional Ingress to expose health endpoint under a different Ingress.
+  healthIngress:
+    enabled: false
+    annotations: {}
+    labels: {}
+
   ingress:
     enabled: false
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
It allows a user to expose the health endpoint using a different Ingress than the 'main' Ingress. This allows to protect the main endpoint using the [auth-directive](https://oauth2-proxy.github.io/oauth2-proxy/configuration#configuring-for-use-with-the-nginx-auth_request-directive), but leaving the `health` endpoint unprotected for status checks (Pingdom, StatusCake etc.).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
