### PR TITLE
[stable/envoy] Added loadBalancerSourceRanges for Service objects

### DIFF
--- a/stable/envoy/Chart.yaml
+++ b/stable/envoy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Envoy is an open source edge and service proxy, designed for cloud-native applications.
 name: envoy
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.11.2
 keywords:
 - envoy

--- a/stable/envoy/README.md
+++ b/stable/envoy/README.md
@@ -44,6 +44,7 @@ Parameter | Description | Default
 `volumeMounts` | Additional volume mounts to be added to Envoy containers(Primary containers of Envoy pods) | ``
 `initContainerTemplate` | Golang template of the init container added to Envoy pods| ``
 `sidecarContainersTemplate` | Golang template of additional containers added after the primary container of Envoy pods | ``
+`service.loadBalancerSourceRanges` | An optional list of CIDR-formatted IP ranges for limiting access to the proxy to these source addresses | ``
 
 All other user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).
 

--- a/stable/envoy/templates/service.yaml
+++ b/stable/envoy/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-  {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 6 }}
+  {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 6 }}
   {{- end }}
   selector:
     app: {{ template "envoy.name" . }}

--- a/stable/envoy/templates/service.yaml
+++ b/stable/envoy/templates/service.yaml
@@ -22,6 +22,10 @@ spec:
     - name: {{ $key }}
 {{ toYaml $value | indent 6 }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 6 }}
+  {{- end }}
   selector:
     app: {{ template "envoy.name" . }}
     release: {{ .Release.Name }}

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -48,7 +48,7 @@ service:
       port: 10000
       targetPort: n0
       protocol: TCP
-  ## Used to whitelist certain source CIDRs 
+  ## Used to whitelist certain source CIDRs
   # loadBalancerSourceRanges:
   # - 0.0.0.0/0
 
@@ -100,9 +100,9 @@ podAnnotations: {}
   # prometheus.io/path: "/stats/prometheus"
   # prometheus.io/port: "9901"
 
-podLabels: {}
-  # team: "developers"
-  # service: "envoy"
+podLabels:
+  app: envoy-whitelisted
+  env: prod
 
 livenessProbe:
   tcpSocket:

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -100,9 +100,9 @@ podAnnotations: {}
   # prometheus.io/path: "/stats/prometheus"
   # prometheus.io/port: "9901"
 
-podLabels:
-  app: envoy-whitelisted
-  env: prod
+podLabels: {}
+  # team: "developers"
+  # service: "envoy"
 
 livenessProbe:
   tcpSocket:

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -48,6 +48,9 @@ service:
       port: 10000
       targetPort: n0
       protocol: TCP
+  ## Used to whitelist certain source CIDRs 
+  # loadBalancerSourceRanges:
+  # - 0.0.0.0/0
 
 ports:
   admin:


### PR DESCRIPTION
#### Is this a new chart
It is an addition to an existing chart

#### What this PR does / why we need it:
This PR adds the ability to specify the `loadBalancerSourceRanges` attribute on the Service object of Envoy. It is used by AWS (and hopefully in the future by additional public cloud providers) to allow whitelisting the load balancer's inbound traffic to a set of CIDR-formatted IP ranges.

For example, to allow inbound traffic to the proxy from two specific IP ranges, write:
```yaml
service:
  loadBalancerSourceRanges:
  - 192.88.99.0/24
  - 192.0.2.0/24
```

#### Special comments for the reviewer:
Tested on a EKS v1.17 cluster with a Network Load Balancer


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
