### PR TITLE
[stable/grafana] Updated documentation for importing dashboards

### DIFF
--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -211,6 +211,19 @@ ingress:
 There are a few methods to import dashboards to Grafana. Below are some examples and explanations as to how to use each method:
 
 ```yaml
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+      - name: 'default' # Should match a key under dashboards
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/default # dashboards under the dashboards object are downloaded to /var/lib/grafana/dashboards/{name}/
+
 dashboards:
   default:
     some-dashboard:


### PR DESCRIPTION
Signed-off-by: Thomas O'Neill <toneill818@gmail.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Includes the dashboardProvider in the example to import dashboards. This is needed to access the dashboards that are imported. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
