### PR TITLE
[stable/graylog] Added helm hooks to trigger provisioner job on upgrades

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.6.9
+version: 1.6.10
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/job.yaml
+++ b/stable/graylog/templates/job.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "graylog.fullname" . }}-provisioner-job
   labels:
 {{ include "graylog.metadataLabels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
     metadata:

--- a/stable/graylog/templates/job.yaml
+++ b/stable/graylog/templates/job.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "graylog.fullname" . }}-provisioner-job
   labels:
 {{ include "graylog.metadataLabels" . | indent 4 }}
+  {{ if .Values.graylog.provisioner.runOnUpdates }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+  {{ end }}
 spec:
   template:
     metadata:

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -368,6 +368,7 @@ graylog:
   ##
   provisioner:
     enabled: false
+    runOnUpdates: false
     useGraylogServiceAccount: false
     # script: |
     #  json='{


### PR DESCRIPTION
Signed-off-by: Volodymyr Linevych <linevych.v@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR optionally installs the annotation that triggers the job on chart release upgrades.

Triggering the provisioner job after release upgrade might be useful, depending on a logic of your provisioner script.
In my case, I install content packs and propagate saved searches. 


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
