### PR TITLE
[stable/coredns] Prevent port template failures if the optional use_tcp parameter is not set

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.13.2
+version: 1.13.3
 appVersion: 1.7.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/_helpers.tpl
+++ b/stable/coredns/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Generate the list of ports automatically from the server definitions
         {{- range .zones -}}
             {{- if has (default "" .scheme) (list "dns://") -}}
                 {{/* Optionally enable tcp for this service as well */}}
-                {{- if eq .use_tcp true }}
+                {{- if eq (default false .use_tcp) true }}
                     {{- $innerdict := set $innerdict "istcp" true -}}
                 {{- end }}
                 {{- $innerdict := set $innerdict "isudp" true -}}
@@ -105,7 +105,7 @@ Generate the list of ports automatically from the server definitions
         {{- range .zones -}}
             {{- if has (default "" .scheme) (list "dns://") -}}
                 {{/* Optionally enable tcp for this service as well */}}
-                {{- if eq .use_tcp true }}
+                {{- if eq (default false .use_tcp) true }}
                     {{- $innerdict := set $innerdict "istcp" true -}}
                 {{- end }}
                 {{- $innerdict := set $innerdict "isudp" true -}}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The parameter use_tcp is described as "Optionally enable tcp for this service as well" but omitting this value results in a template that fails to render.  This change just defaults that value to `false` if it is not set allowing the template to render successfully and making this "optional" parameter actually optional.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
