### PR TITLE
[incubator/zookeeper] Add SSL support

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.4
+version: 2.1.5
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/config-script.yaml
+++ b/incubator/zookeeper/templates/config-script.yaml
@@ -12,11 +12,19 @@ metadata:
 data:
     ok: |
       #!/bin/sh
-      zkServer.sh status
+      if [ -f /tls/client/ca.crt ]; then
+        echo "srvr" | openssl s_client -CAfile /tls/client/ca.crt -cert /tls/client/tls.crt -key /tls/client/tls.key -connect 127.0.0.1:${1:-2281} -quiet -ign_eof 2>/dev/null | grep Mode
+      else
+        zkServer.sh status
+      fi
 
     ready: |
       #!/bin/sh
-      echo ruok | nc 127.0.0.1 ${1:-2181}
+      if [ -f /tls/client/ca.crt ]; then
+        echo "ruok" | openssl s_client -CAfile /tls/client/ca.crt -cert /tls/client/tls.crt -key /tls/client/tls.key -connect 127.0.0.1:${1:-2281} -quiet -ign_eof 2>/dev/null
+      else
+        echo ruok | nc 127.0.0.1 ${1:-2181}
+      fi
 
     run: |
       #!/bin/bash
@@ -30,6 +38,7 @@ data:
       ZK_DATA_LOG_DIR=${ZK_DATA_LOG_DIR:-"/data/log"}
       ZK_CONF_DIR=${ZK_CONF_DIR:-"/conf"}
       ZK_CLIENT_PORT=${ZK_CLIENT_PORT:-2181}
+      ZK_SSL_CLIENT_PORT=${ZK_SSL_CLIENT_PORT:-2281}
       ZK_SERVER_PORT=${ZK_SERVER_PORT:-2888}
       ZK_ELECTION_PORT=${ZK_ELECTION_PORT:-3888}
       ZK_TICK_TIME=${ZK_TICK_TIME:-2000}
@@ -64,7 +73,15 @@ data:
       mkdir -p $ZK_DATA_LOG_DIR
       echo $MY_ID >> $ID_FILE
 
-      echo "clientPort=$ZK_CLIENT_PORT" >> $ZK_CONFIG_FILE
+      if [[ -f /tls/server/ca.crt ]]; then
+        cp /tls/server/ca.crt /data/server-ca.pem
+        cat /tls/server/tls.crt /tls/server/tls.key > /data/server.pem
+      fi
+      if [[ -f /tls/client/ca.crt ]]; then
+        cp /tls/client/ca.crt /data/client-ca.pem
+        cat /tls/client/tls.crt /tls/client/tls.key > /data/client.pem
+      fi
+
       echo "dataDir=$ZK_DATA_DIR" >> $ZK_CONFIG_FILE
       echo "dataLogDir=$ZK_DATA_LOG_DIR" >> $ZK_CONFIG_FILE
       echo "tickTime=$ZK_TICK_TIME" >> $ZK_CONFIG_FILE
@@ -76,6 +93,23 @@ data:
       echo "autopurge.snapRetainCount=$ZK_SNAP_RETAIN_COUNT" >> $ZK_CONFIG_FILE
       echo "autopurge.purgeInterval=$ZK_PURGE_INTERVAL" >> $ZK_CONFIG_FILE
       echo "4lw.commands.whitelist=*" >> $ZK_CONFIG_FILE
+
+      # Client TLS configuration
+      if [[ -f /tls/client/ca.crt ]]; then
+        echo "secureClientPort=$ZK_SSL_CLIENT_PORT" >> $ZK_CONFIG_FILE
+        echo "ssl.keyStore.location=/data/client.pem" >> $ZK_CONFIG_FILE
+        echo "ssl.trustStore.location=/data/client-ca.pem" >> $ZK_CONFIG_FILE
+      else
+        echo "clientPort=$ZK_CLIENT_PORT" >> $ZK_CONFIG_FILE
+      fi
+
+      # Server TLS configuration
+      if [[ -f /tls/server/ca.crt ]]; then
+        echo "serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory" >> $ZK_CONFIG_FILE
+        echo "sslQuorum=true" >> $ZK_CONFIG_FILE
+        echo "ssl.quorum.keyStore.location=/data/server.pem" >> $ZK_CONFIG_FILE
+        echo "ssl.quorum.trustStore.location=/data/server-ca.pem" >> $ZK_CONFIG_FILE
+      fi
 
       for (( i=1; i<=$ZK_REPLICAS; i++ ))
       do

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -113,6 +113,16 @@ spec:
                 {{- end }}
               {{- end }}
             {{- end }}
+            {{- if .Values.serverTlsSecret }}
+            - name: {{ $.Release.Name }}-server-tls
+              mountPath: /tls/server
+              readOnly: true
+            {{- end }}
+            {{- if .Values.clientTlsSecret }}
+            - name: {{ $.Release.Name }}-client-tls
+              mountPath: /tls/client
+              readOnly: true
+            {{- end }}
             - name: config
               mountPath: /config-scripts
 
@@ -196,6 +206,16 @@ spec:
         - name: {{ $.Release.Name }}-{{ .name }}
           secret:
             secretName: {{ .name }}
+        {{- end }}
+        {{- if .Values.serverTlsSecret }}
+        - name: {{ $.Release.Name }}-server-tls
+          secret:
+            secretName: {{ .Values.serverTlsSecret }}
+        {{- end }}
+        {{- if .Values.clientTlsSecret }}
+        - name: {{ $.Release.Name }}-client-tls
+          secret:
+            secretName: {{ .Values.clientTlsSecret }}
         {{- end }}
         {{- if .Values.exporters.jmx.enabled }}
         - name: config-jmx-exporter

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -99,6 +99,19 @@ command:
   - -xec
   - /config-scripts/run
 
+## If you want the quorum to use SSL internally, create a
+## kubernetes.io/tls object (cert-manager produces these), and ensure
+## that it has a SAN entry for each of the server hostnames (e.g.:
+## zookeeper-0.zookeeper-headless.namespace.svc.cluster.local).
+## Supply the name of the object here:
+# serverTlsSecret: "zookeeper-server-tls"
+
+## To use client SSL, create a kubernetes.io/tls object (cert-manager
+## produces these), and supply the name here.  If this is provided,
+## then plain-text client connections are disabled.  The same secret
+## may be used for both client and server connections.
+# clientTlsSecret: "zookeeper-server-tls"
+
 ## Useful if using any custom authorizer.
 ## Pass any secrets to the kafka pods. Each secret will be passed as an
 ## environment variable by default. The secret can also be mounted to a


### PR DESCRIPTION
This adds both quorum and client SSL support.  It accepts certificate
material in kubernetes.io/tls format (i.e., compatible with cert-
manager).  Client or server support can be configured separately,
and if client SSL support is enabled, plain-text client connections
are disabled.

Signed-off-by: James E. Blair <jeblair@redhat.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds SSL support for Zookeeper

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
