### PR TITLE
[stable/openldap] Support assigning node ports

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 1.2.4
+version: 1.2.5
 appVersion: 2.4.48
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -36,9 +36,11 @@ The following table lists the configurable parameters of the openldap chart and 
 | `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
 | `service.clusterIP`                | IP address to assign to the service                                                                                                       | `nil`                |
 | `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
+| `service.ldapNodePort`             | External service node port for LDAP. Only used if `service.type` is set to `NodePort`.                                                    | `nil`               |
 | `service.ldapPort`                 | External service port for LDAP                                                                                                            | `389`               |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
+| `service.sslLdapNodePort`          | External service node port for SSL+LDAP. Only used if `service.type` is set to `NodePort`.                                                | `nil`               |
 | `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
 | `service.type`                     | Service type                                                                                                                              | `ClusterIP`         |
 | `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |

--- a/stable/openldap/templates/service.yaml
+++ b/stable/openldap/templates/service.yaml
@@ -32,10 +32,16 @@ spec:
   ports:
     - name: ldap-port
       protocol: TCP
+{{- if and (eq .Values.service.type "NodePort") .Values.service.ldapNodePort }}
+      nodePort: {{ .Values.service.ldapNodePort }}
+{{- end }}
       port: {{ .Values.service.ldapPort }}
       targetPort: ldap-port
     - name: ssl-ldap-port
       protocol: TCP
+{{- if and (eq .Values.service.type "NodePort") .Values.service.sslLdapNodePort }}
+      nodePort: {{ .Values.service.sslLdapNodePort }}
+{{- end }}
       port: {{ .Values.service.sslLdapPort }}
       targetPort: ssl-ldap-port
   selector:

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -46,6 +46,10 @@ service:
   ##
   externalIPs: []
 
+  # Node port specifications. Only used if service.type is set to NodePort.
+  # ldapNodePort: 30389
+  # sslLdapNodePort: 30636
+
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   type: ClusterIP


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This change allows users to specify `nodePort` properties for the LDAP and LDAPS ports when running the Service as a NodePort (`service.type` equals `NodePort`).

#### Which issue this PR fixes
N/A, general improvement

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
