### PR TITLE
[incubator/druid] overlord is broken when gCloudStorage.enabled is true (#23484)

### DIFF
--- a/incubator/druid/Chart.yaml
+++ b/incubator/druid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.19.0
 description: Apache Druid is a high performance real-time analytics database.
 name: druid
-version: 0.2.10
+version: 0.2.11
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
 maintainers:

--- a/incubator/druid/templates/overlord/deployment.yaml
+++ b/incubator/druid/templates/overlord/deployment.yaml
@@ -56,6 +56,17 @@ spec:
               port: {{ .Values.overlord.port }}
           resources:
 {{ toYaml .Values.overlord.resources | indent 12 }}
+          volumeMounts:
+  {{- if .Values.gCloudStorage.enabled }}
+            - name: google-cloud-key
+              mountPath: /var/secrets/google
+  {{- end }}
+      volumes:
+  {{- if .Values.gCloudStorage.enabled }}
+      - name: google-cloud-key
+        secret:
+          secretName: {{ .Values.gCloudStorage.secretName }}
+  {{- end }}
     {{- with .Values.overlord.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Which issue this PR fixes
#23484

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
