### PR TITLE
[incubator/druid] include default values to use Google Cloud Storage as deep storage (#23488)

### DIFF
--- a/incubator/druid/Chart.yaml
+++ b/incubator/druid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.19.0
 description: Apache Druid is a high performance real-time analytics database.
 name: druid
-version: 0.2.10
+version: 0.2.11
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
 maintainers:

--- a/incubator/druid/README.md
+++ b/incubator/druid/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the Druid chart and the
 | `configVars`                              | druid configuration variables for all components         | ``                                         |
 | `gCloudStorage.enabled`                  | look for secret to set google cloud credentials         | `false`                                    |
 | `gCloudStorage.secretName`               | secretName to be mounted as google cloud credentials    | `false`                                    |
+| `google.gcsAPIKey`                       | base64 encoded credentials for google cloud             | ``                                         |
 | `broker.enabled`                         | enable broker                                           | `true`                                     |
 | `broker.name`                            | broker component name                                   | `broker`                                   |
 | `broker.replicaCount`                    | broker node replicas (deployment)                       | `1`                                        |

--- a/incubator/druid/values.yaml
+++ b/incubator/druid/values.yaml
@@ -19,7 +19,7 @@ configVars:
   DRUID_USE_CONTAINER_IP: "true"
 
   ## Druid Common Configurations. ref: https://druid.apache.org/docs/latest/configuration/index.html#common-configurations
-  druid_extensions_loadList: '["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage"]'
+  druid_extensions_loadList: '["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage", "druid-google-extensions"]'
   druid_metadata_storage_type: postgresql
   druid_metadata_storage_connector_connectURI: jdbc:postgresql://postgres:5432/druid
   druid_metadata_storage_connector_user: druid
@@ -33,9 +33,21 @@ configVars:
   druid_emitter_logging_logLevel: debug
   druid_emitter_http_recipientBaseUrl: http://druid_exporter_url:druid_exporter_port/druid
 
+  ## Configurations for Google Cloud Storage
+  # druid_storage_type=google
+  # druid_google_bucket=mybucket
+  # druid_google_prefix=druid
+  # druid_indexer_logs_type=google
+  # druid_indexer_logs_bucket=mybucket
+  # druid_indexer_logs_prefix=druid/indexing-logs
+
 gCloudStorage:
   enabled: false
   secretName: google-cloud-key
+
+# If gCloudStorage.enabled=true, it should contain the contents of the JSON file, encoded using base64.
+google:
+  gcsAPIKey: ""
 
 broker:
   ## If false, broker will not be installed


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Which issue this PR fixes
#23488 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
