### PR TITLE
[stable/jenkins] Add Values.master.prometheus.serviceMonitorName

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -299,6 +299,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `master.prometheus.enabled`       | Enables prometheus service monitor | `false`                                     |
 | `master.prometheus.serviceMonitorAdditionalLabels` | Additional labels to add to the service monitor object | `{}`                       |
+| `master.prometheus.serviceMonitorName` | Custom name for serviceMonitor | Not set (Helm release name) |
 | `master.prometheus.serviceMonitorNamespace` | Custom namespace for serviceMonitor | Not set (same ns where is Jenkins being deployed) |
 | `master.prometheus.scrapeInterval` | How often prometheus should scrape metrics | `60s`                              |
 | `master.prometheus.scrapeEndpoint` | The endpoint prometheus should get metrics from | `/prometheus`                 |

--- a/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
+++ b/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 
 metadata:
+{{- if .Values.master.prometheus.serviceMonitorName }}
+  name: {{ .Values.master.prometheus.serviceMonitorName }}
+{{- else }}
   name: {{ template "jenkins.fullname" . }}
+{{- end }}
 {{- if .Values.master.prometheus.serviceMonitorNamespace }}
   namespace: {{ .Values.master.prometheus.serviceMonitorNamespace }}
 {{- else }}


### PR DESCRIPTION
Signed-off-by: Aleksandr Malkov <truealex@mail.ru>

#### What this PR does / why we need it:
Add Values.master.prometheus.serviceMonitorName

#### Which issue this PR fixes
  - fixes #23494

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
