### PR TITLE
[stable/envoy] Added support for creating an ingress object alongside Envoy

### DIFF
--- a/stable/envoy/Chart.yaml
+++ b/stable/envoy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Envoy is an open source edge and service proxy, designed for cloud-native applications.
 name: envoy
-version: 1.9.2
+version: 1.9.3
 appVersion: 1.11.2
 keywords:
 - envoy

--- a/stable/envoy/README.md
+++ b/stable/envoy/README.md
@@ -45,6 +45,9 @@ Parameter | Description | Default
 `initContainerTemplate` | Golang template of the init container added to Envoy pods| ``
 `sidecarContainersTemplate` | Golang template of additional containers added after the primary container of Envoy pods | ``
 `service.loadBalancerSourceRanges` | An optional list of CIDR-formatted IP ranges for limiting access to the proxy to these source addresses | ``
+`ingress.enabled` | Whether to create an `Ingress` object alongside Envoy | `false`
+`ingress.annotations` | Annotations for the ingress | `{}`
+`ingress.rules` | Non-default rules to be added to the ingress | See [values.yaml](values.yaml)
 
 All other user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).
 

--- a/stable/envoy/templates/ingress.yaml
+++ b/stable/envoy/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{ $ingress := default dict .Values.ingress }}
+{{ if and $ingress $ingress.enabled }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "envoy.fullname" . }}
+  labels:
+    app: {{ template "envoy.name" . }}
+    chart: {{ template "envoy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- if $ingress.annotations }}
+    {{- toYaml $ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    {{- if $ingress.rules }}
+    {{- toYaml $ingress.rules | nindent 6}}
+    {{- else }}
+    - http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: {{ .Values.service.name }}
+              servicePort: n0
+    {{- end }}
+{{ end }}

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -52,6 +52,22 @@ service:
   # loadBalancerSourceRanges:
   # - 0.0.0.0/0
 
+# Optional ingress object to be created with the proxy
+ingress:
+  enabled: false
+  annotations: {}
+  ## Annotations to be added to the Ingress object
+  rules: {}
+  ## Overrides the ingress rules. If not set, creates a rule that proxies all requests to
+  ## Envoy's n0 traffic port
+  ## Example:
+  #  - http:
+  #      paths:
+  #        - path: "/*"
+  #          backend:
+  #            serviceName: envoy-service
+  #            servicePort: n0
+
 ports:
   admin:
     containerPort: 9901


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This change adds the ability to create an `Ingress` object alongside the deployment of Envoy, sparing the admin the need to create a different, unmanaged ingress, which is a common use case. This is useful when deploying Envoy as a front/edge proxy.

The chart does not create the ingress object by default, so this does not impact any existing behavior. The object is only created if the required values are explicitly defined under `values.yaml`.

#### Special notes for your reviewer:
Change was tested on a Kubernetes v1.17 cluster

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
