### PR TITLE
[stable/prometheus-postgres-exporter] Add feature to set constantLabels

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/README.md
+++ b/stable/prometheus-postgres-exporter/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the postgres Exporter c
 | `config.disableDefaultMetrics`  | Specifies whether to use only metrics from `queries.yaml`| `false` |
 | `config.autoDiscoverDatabases`  | Specifies whether to autodiscover all databases | `false` |
 | `config.excludeDatabases`  | When autodiscover is enabled, list databases to exclude| `[]` |
+| `config.constantLabels`         | Specifies labels to set in all metrics. | `{}` |
 | `rbac.create`                   | Specifies whether RBAC resources should be created.| `true` |
 | `rbac.pspEnabled`               | Specifies whether a PodSecurityPolicy should be created.| `true` |
 | `serviceAccount.create`         | Specifies whether a service account should be created.| `true` |

--- a/stable/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/stable/prometheus-postgres-exporter/templates/deployment.yaml
@@ -48,6 +48,14 @@ spec:
           - {{ .Values.config.excludeDatabases | join "," }}
           {{- end }}
           {{- end }}
+          {{- if .Values.config.constantLabels }}
+          {{- $labels := list -}}
+          {{- range $key, $value := .Values.config.constantLabels }}
+          {{- $labels = printf "%s=%s" $key $value | append $labels }}
+          {{- end }}
+          - "--constantLabels"
+          - {{ $labels | join "," | quote }}
+          {{- end }}
           env:
           {{- if .Values.config.datasourceSecret }}
           - name: DATA_SOURCE_NAME

--- a/stable/prometheus-postgres-exporter/values.yaml
+++ b/stable/prometheus-postgres-exporter/values.yaml
@@ -86,6 +86,7 @@ config:
   disableSettingsMetrics: false
   autoDiscoverDatabases: false
   excludeDatabases: []
+  constantLabels: {}
   # this are the defaults queries that the exporter will run, extracted from: https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml
   queries: |-
     pg_replication:


### PR DESCRIPTION
Hi @gianrubio, @maorfr,

can you please review my changes.

#### Is this a new chart
NO

#### What this PR does / why we need it:
This PR will add feature to set constant labels on [prometheus postgres exporter](https://github.com/wrouesnel/postgres_exporter#flags). Under the hood it's a comma-separated list of label=value pairs, but as discussed in #[20818](https://github.com/helm/charts/pull/20181) it may be a good idea to have this as map. So if someone wants to overwrite a single label it's not required to pass in all labels again. 

#### Which issue this PR fixes
- #[20818](https://github.com/helm/charts/pull/20181)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
