### PR TITLE
[stable/prometheus-operator] fixed hardcoded label for grafana servicemonitor

### DIFF
--- a/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana
+      app.kubernetes.io/name: {{ template "prometheus-operator.name" . }}-grafana
       app.kubernetes.io/instance: {{ $.Release.Name | quote }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Now each grafana instance can have it's own servicemonitor. Fixes #23513

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
