### PR TITLE
[prometheus-operator] fixed hardcoded label for grafana servicemonitor

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana
+      app.kubernetes.io/name: {{ template "prometheus-operator.name" . }}-grafana
       app.kubernetes.io/instance: {{ $.Release.Name | quote }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Now each grafana instance can have it's own servicemonitor. Fixes #23513

- [x] DCO signed
- [x] Chart Version bumped