### PR TITLE
[stable/nginx-ingress] Add configurable serviceMonitor metricRelabelling and targetLabels

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.41.2
+version: 1.41.3
 appVersion: v0.34.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -153,6 +153,8 @@ Parameter | Description | Default
 `controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
 `controller.metrics.serviceMonitor.namespaceSelector` | [namespaceSelector](https://github.com/coreos/prometheus-operator/blob/v0.34.0/Documentation/api.md#namespaceselector) to configure what namespaces to scrape | `will scrape the helm release namespace only`
 `controller.metrics.serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s`
+`controller.metrics.serviceMonitor.targetLabels` | Set of labels to transfer on the Kubernetes Service onto the target. | `[]`
+`controller.metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]`
 `controller.metrics.prometheusRule.enabled` | Set this to `true` to create prometheusRules for Prometheus operator | `false`
 `controller.metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus | `{}`
 `controller.metrics.prometheusRule.namespace` | namespace where prometheusRules resource should be created | `the same namespace as nginx ingress`

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
       {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
       {{- end }}
+      {{- if .Values.controller.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.controller.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
   {{- if .Values.controller.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector:
 {{ toYaml .Values.controller.metrics.serviceMonitor.namespaceSelector | indent 4 -}}
@@ -29,6 +32,12 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- range .Values.controller.metrics.serviceMonitor.targetLabels }}
+    - {{ . }}
+    {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -417,6 +417,8 @@ controller:
       #   any: true
       scrapeInterval: 30s
       # honorLabels: true
+      targetLabels: []
+      metricRelabelings: []
 
     prometheusRule:
       enabled: false


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

#### What this PR does / why we need it:

**Target Labels**:  Adds the serviceMonitor `targetLabels` key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec)

**Metric Relabelings**: Adds the ServiceMonitor metricRelabelings key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint). Used for adding, dropping or renaming labels at ingestion time, or to drop entire metrics that are not useful.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
