### PR TITLE
[stable/prometheus-adapter] Add psp for prometheus adapter

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.5.0
+version: 2.5.1
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -144,6 +144,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `extraVolumeMounts`             | Any extra volumes mounts                                                        | `[]`                                        |
 | `extraVolumes`                  | Any extra volumes                                                               | `[]`                                        |
 | `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
+| `psp.create`                    | If true, create & use PSP resources                                             | `true`                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-psp.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-psp.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.psp.create -}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.hostNetwork.enabled }}
+  hostNetwork: true
+  {{- end }}
+  fsGroup:
+    rule: RunAsAny
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+    - max: 0
+      min: 0
+  runAsUser:
+    rule: MustRunAs
+    ranges:
+    - max: 10001
+      min: 10001
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - emptyDir
+  - configMap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-psp
+rules:
+- apiGroups: 
+  - 'policy'
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "k8s-prometheus-adapter.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-psp
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/stable/prometheus-adapter/templates/hpa-custom-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/hpa-custom-metrics-cluster-role-binding.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.rbac.create -}}
+{{- /*
+This if must be aligned with custom-metrics-cluster-role.yaml
+as otherwise this binding will point to not existing role.
+*/ -}}
+{{- if and .Values.rbac.create (or .Values.rules.default .Values.rules.custom) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -27,6 +27,9 @@ replicas: 1
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+psp:
+  # Specifies whether PSP resources should be created
+  create: false
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
- adds pod security policy for prometheus adapter
- fix the condition in custom metrics cluster role binding to match with the role creation as otherwise it will point to non-existent role. 

Thanks to @robq99 for his contrib in fine tuning and the fix

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Reviewers
/cc @mattiasgees @steven-sheehy @hectorj2f 
