### PR TITLE
[incubator/schema-registry] Update jmx exporter and remove invalid Java flags

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,7 +1,7 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
 version: 1.2.0
-appVersion: 5.0.1
+appVersion: 5.0.2
 keywords:
   - confluent
   - kafka

--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,7 +1,7 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.2.0
-appVersion: 5.0.2
+version: 1.2.1
+appVersion: 5.0.1
 keywords:
   - confluent
   - kafka

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           command:
           - java
+          - -XX:+UseContainerSupport
+          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -77,8 +77,6 @@ spec:
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           command:
           - java
-          - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -78,7 +78,6 @@ spec:
           command:
           - java
           - -XX:+UseContainerSupport
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -158,7 +158,7 @@ prometheus:
   jmx:
     enabled: false
     image: solsson/kafka-prometheus-jmx-exporter@sha256
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 70852d19ab9182c191684a8b08ac831230006d82e65d1db617479ea27884e4e8
     port: 5556
     resources: {}
       # limits:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
This updates the `jmx_exporter` image to the latest version, using Java 11 base image.

As a result, some of the Java flags have been updated in order to not cause an error upon startup.

#### Which issue this PR fixes
No issue.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
