### PR TITLE
fix: Updated the airflow version to fix argcomplete not found error

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.4.1
-appVersion: 1.10.10
+version: 7.4.2
+appVersion: 1.10.11
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/
 maintainers:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -6,7 +6,7 @@ airflow:
   ##
   image:
     repository: apache/airflow
-    tag: 1.10.10-python3.6
+    tag: 1.10.11-python3.6
     ## values: Always or IfNotPresent
     pullPolicy: IfNotPresent
     pullSecret: ""


### PR DESCRIPTION
While running airflow with Kubernetes Executor. I was facing argcomplete package not found error. This issue was fixed on 1.10.11 version. For the same. I raised the PR
```
Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 23, in <module>
    import argcomplete
ModuleNotFoundError: No module named 'argcomplete'
```
https://github.com/apache/airflow/issues/8564
https://github.com/apache/airflow/pull/8312/files