### PR TITLE
stable/nextcloud: ensure cron recovers from failures

### DIFF
--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   schedule: "{{ .Values.cronjob.schedule }}"
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
   {{- with .Values.cronjob.failedJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ . }}
   {{- end }}
@@ -48,6 +49,7 @@ spec:
                 - "-k"
               {{- end }}
                 - "--fail"
+                - "-m 300"
                 - "-L"
               {{- if .Values.ingress.tls }}
                 - "https://{{ .Values.nextcloud.host }}/cron.php"


### PR DESCRIPTION
#### What this PR does / why we need it:

Without this change, CronJobs will never recover automatically after they reached 100 failures (could happen e.g. during DB outage) and might hang indefinitely when there are network issues as curl has no default timeout.

#### Special notes for your reviewer:

I didn't feel there is a need for this to be configurable, but can be done of course.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

cc Chart maintainers @chrisingenhaag @billimek