### PR TITLE
[stable/opa] add extraArgs to opa container

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.14.1
+version: 1.14.2
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -95,6 +95,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `timeoutSeconds` | Timeout for a webhook call in seconds. | `` |
 | `securityContext` | Security context for the containers | `{enabled: false, runAsNonRoot: true, runAsUser: 1}` |
 | `deploymentStrategy` | Specify deployment spec rollout strategy | `{}` |
+| `extraArgs` | Additional arguments to be added to the opa container | `[]` |
 | `extraContainers` | Additional containers to be added to the deployment | `[]` |
 | `extraVolumes` | Additional volumes to be added to the deployment | `[]` |
 | `extraPorts` | Additional ports to OPA service. Useful to expose `extraContainer` ports. | `[]` |

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
 {{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
             - "/bootstrap"
 {{- end }}
+{{- range .Values.extraArgs }}
+            - {{ . }}
+{{- end }}
           volumeMounts:
             - name: certs
               readOnly: true

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -114,6 +114,8 @@ imagePullPolicy: IfNotPresent
 # and livenessProbe
 port: 443
 
+extraArgs: []
+
 mgmt:
   enabled: true
   image: openpolicyagent/kube-mgmt


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR enables passing some extra arguments to the main opa container, like:
```- "--set=decision_logs.console=true"```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
