### PR TITLE
stable/chartmuseum: Fix condition for setting schedulerName

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.13.1
+version: 2.13.2
 appVersion: 0.12.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -160,7 +160,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
+    {{- if .Values.deployment.schedulerName }}
       schedulerName: {{ .Values.deployment.schedulerName }}
     {{- end -}}
     {{- if .Values.serviceAccount.create }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes configuring schedulerName for chartmuseum

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)