### PR TITLE
[stable/nginx-ingress] Pass correct headers to downstream applications when letting AWS terminate SSL.

### DIFF
--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -301,10 +301,13 @@ controller:
 
 ## AWS L7 ELB with SSL Termination
 
-Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/aws/l7/service-l7.yaml):
+Annotate the controller as shown in the [nginx-ingress AWS TLS deployment example](https://github.com/kubernetes/ingress-nginx/blob/beae32b6fe9e60a1e3d7976665112eb39fa86612/deploy/static/provider/aws/deploy-tls-termination.yaml):
 
 ```yaml
 controller:
+  config:
+    use-forwarded-headers: "true"
+    use-proxy-protocol: "false"
   service:
     targetPorts:
       http: http


### PR DESCRIPTION
#### What this PR does / why we need it:

The README offers a sample configuration for terminating SSL with an ELB on AWS's side. When this configuration is used, the header `X-Forwarded-Proto` is rewritten by nginx to always be `http` (what nginx sees), rather than `http` or `https` (what the ELB saw).


Some example behaviors I observed as a result:
1) Jenkins would redirect to the non-SSL endpoint when logging in, and also show the "It appears that your reverse proxy set up is broken." message in settings.
2) An internal application could not process POSTs unless they came in over plain HTTP (which caused other issues, as it wanted those POSTs to come in over HTTPS for security).

Setting `use-forwarded-headers` to true, and `use-proxy-protocol` to false in the ingress controller config corrects this, so that `X-Forwarded-Proto` reads `http` for a plain HTTP session, and `https` for an HTTPS session.

Since the behavior as-documented seemed broken, I chose to add these two parameters to the documentation.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

The link in the documentation was also broken, so I updated it.

I don't know if the broken config is correct in some other context, but I can't think of one, and it seems like it was just oversight.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
