### PR TITLE
stable/Spinnaker Add config/checksum annotation to Halyard StatefulSet

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.1
+version: 2.2.2
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -13,8 +13,9 @@ spec:
       component: halyard
   template:
     metadata:
-      {{- if .Values.halyard.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap/halyard-init-script.yaml") . | sha256sum }}
+      {{- if .Values.halyard.annotations }}
 {{ toYaml .Values.halyard.annotations | indent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This is a simple PR to annotate the Halyard StatefulSet in the Spinnaker chart with the checksum of the init script ConfigMap. Without this, any change to the init script would not automatically restart the StatefulSet, and any additional configuration scripts relying on the changes in the init script would fail.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
