### PR TITLE
[incubator/rundeck] Add imagePullSecrets feature and update versions in Chart.yaml

### DIFF
--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 0.3.1
-appVersion: 3.2.8
+version: 0.3.2
+appVersion: 3.2.7
 keywords:
 - rundeck
 - jobs

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -20,6 +20,7 @@ deployment.strategy | Sets the K8s rollout strategy for the Rundeck deployment |
 image.repository | Name of the image to run, without the tag. | [rundeck/rundeck](https://github.com/rundeck/rundeck)
 image.tag | The image tag to use. | 3.2.7
 image.pullPolicy | The kubernetes image pull policy. | IfNotPresent
+image.pullSecrets | The kubernetes secret to pull the image from a private registry. | None
 service.type | The kubernetes service type to use. | ClusterIP
 service.port | The tcp port the service should listen on. | 80
 ingress | Any ingress rules to apply. | None

--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "rundeck.serviceAccountName" . }}
       securityContext:
         fsGroup: 1000
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
       containers:
         - name: nginx
           image: nginx:stable

--- a/incubator/rundeck/templates/volume.yaml
+++ b/incubator/rundeck/templates/volume.yaml
@@ -1,4 +1,3 @@
-  
 {{- if and .Values.persistence.enabled .Values.persistence.claim.create }}
 kind: PersistentVolumeClaim
 apiVersion: v1


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It adds imagePullSecrets field that allows you to pull the image from a private registry.

#### Special notes for your reviewer:
The appVersion field was 3.2.8 even though nobody tested and bumped the default image version. 3.3.2 is the latest now.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)