### PR TITLE
[stable/prometheus-blackbox-exporter] add optional extraRelablings for targets

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.3.0
+version: 4.4.0
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -41,63 +41,65 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Blackbox-Exporter chart and their default values.
 
-| Parameter                                 | Description                                                                      | Default                                                                      |
-| ----------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `kind`                                    | You can choose between `Deployment` or `DaemonSet`                               | `Deployment`                                                                 |
-| `config`                                  | Prometheus blackbox configuration                                                | {}                                                                           |
-| `secretConfig`                            | Whether to treat blackbox configuration as secret                                | `false`                                                                      |
-| `extraArgs`                               | Optional flags for blackbox                                                      | `[]`                                                                         |
-| `image.repository`                        | container image repository                                                       | `prom/blackbox-exporter`                                                     |
-| `image.tag`                               | container image tag                                                              | `v0.15.1`                                                                    |
-| `image.pullPolicy`                        | container image pull policy                                                      | `IfNotPresent`                                                               |
-| `image.pullSecrets`                       | container image pull secrets                                                     | `[]`                                                                         |
-| `ingress.annotations`                     | Ingress annotations                                                              | None                                                                         |
-| `ingress.enabled`                         | Enables Ingress                                                                  | `false`                                                                      |
-| `ingress.hosts`                           | Ingress accepted hostnames                                                       | None                                                                         |
-| `ingress.path`                            | Ingress accepted path                                                            | `/`                                                                         |
-| `ingress.tls`                             | Ingress TLS configuration                                                        | None                                                                         |
-| `nodeSelector`                            | node labels for pod assignment                                                   | `{}`                                                                         |
-| `runAsUser`                               | User to run blackbox-exporter container as                                       | `1000`                                                                       |
-| `readOnlyRootFilesystem`                  | Set blackbox-exporter file-system to read-only                                   | `true`                                                                       |
-| `runAsNonRoot`                            | Run blackbox-exporter as non-root                                                | `true`                                                                       |
-| `tolerations`                             | node tolerations for pod assignment                                              | `[]`                                                                         |
-| `affinity`                                | node affinity for pod assignment                                                 | `{}`                                                                         |
-| `podAnnotations`                          | annotations to add to each pod                                                   | `{}`                                                                         |
-| `podDisruptionBudget`                     | pod disruption budget                                                            | `{}`                                                                         |
-| `pspEnabled`                              | create pod security policy resources                                             | `true`                                                                       |
-| `priorityClassName`                       | priority class name                                                              | None                                                                         |
-| `allowIcmp`                               | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
-| `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
-| `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
-| `livenessProbe`                           | Container liveness probe                                                         | See values.yaml                                                              |
-| `readinessProbe`                          | Container readiness probe                                                        | See values.yaml                                                              |
-| `networkPolicy.enabled`                   | Enable network policy and allow access from anywhere                             | `false`                                                                      |
-| `networkPolicy.allowMonitoringNamespace`  | Limit access only from monitoring namespace                                      | `false`                                                                      |
-| `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
-| `service.labels`                          | additional labels for the service                                                | None                                                                         |
-| `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |
-| `service.port`                            | port for the blackbox http service                                               | `9115`                                                                       |
-| `service.externalIPs`                     | list of external ips                                                             | []                                                                           |
-| `serviceAccount.create`                   | Specifies whether a service account should be created.                           | `true`                                                                       |
-| `serviceAccount.name`                     | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
-| `serviceAccount.annotations`              | ServiceAccount annotations                                                       |                                                                              |
-| `serviceMonitor.enabled`                  | If true, a ServiceMonitor CRD is created for a prometheus operator               | `false`                                                                      |
-| `serviceMonitor.defaults.labels`          | Labels for prometheus operator                                                   | `{}`                                                                         |
-| `serviceMonitor.defaults.interval`        | Interval for prometheus operator endpoint                                        | `30s`                                                                        |
-| `serviceMonitor.defaults.scrapeTimeout`   | Scrape timeout for prometheus operator endpoint                                  | `30s`                                                                        |
-| `serviceMonitor.defaults.module`          | The module that blackbox will use if serviceMonitor is enabled                   | `http_2xx`                                                                   |
-| `serviceMonitor.targets.[]`               | List of targets to scrape                                                        | `[]`                                                                         |
-| `serviceMonitor.targets.[].name`          | Human readable name for the job. It will also appear in job labels in Prometheus | `example`                                                                    |
-| `serviceMonitor.targets.[].url`           | The URL that blackbox will scrape if serviceMonitor is enabled                   | `http://example.com/healthz`                                                 |
-| `serviceMonitor.targets.[].labels`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.labels }`                                        |
-| `serviceMonitor.targets.[].interval`      | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.interval }}`                                     |
-| `serviceMonitor.targets.[].scrapeTimeout` | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.scrateTimeout }}`                                |
-| `serviceMonitor.targets.[].module`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.module }}`                                       |
-| `prometheusRule.enabled`                  | Set this to true to create PrometheusRule for Prometheus operator | `false`     |
-| `prometheusRule.additionalLabels`         | Additional labels that can be passed to PrometheusRule | `{}`  |
-| `prometheusRule.namespace`                | Namespace where PrometheusRule resource should be created |      |
-| `prometheusRule.rules`                    | [PrometheusRule](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created                      | `[]`                                                    |
-| `strategy`                                | strategy used to replace old Pods with new ones                                  | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` |
+| Parameter                                   | Description                                                                      | Default                                                                      |
+| -----------------------------------------   | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `kind`                                      | You can choose between `Deployment` or `DaemonSet`                               | `Deployment`                                                                 |
+| `config`                                    | Prometheus blackbox configuration                                                | {}                                                                           |
+| `secretConfig`                              | Whether to treat blackbox configuration as secret                                | `false`                                                                      |
+| `extraArgs`                                 | Optional flags for blackbox                                                      | `[]`                                                                         |
+| `image.repository`                          | container image repository                                                       | `prom/blackbox-exporter`                                                     |
+| `image.tag`                                 | container image tag                                                              | `v0.15.1`                                                                    |
+| `image.pullPolicy`                          | container image pull policy                                                      | `IfNotPresent`                                                               |
+| `image.pullSecrets`                         | container image pull secrets                                                     | `[]`                                                                         |
+| `ingress.annotations`                       | Ingress annotations                                                              | None                                                                         |
+| `ingress.enabled`                           | Enables Ingress                                                                  | `false`                                                                      |
+| `ingress.hosts`                             | Ingress accepted hostnames                                                       | None                                                                         |
+| `ingress.path`                              | Ingress accepted path                                                            | `/`                                                                         |
+| `ingress.tls`                               | Ingress TLS configuration                                                        | None                                                                         |
+| `nodeSelector`                              | node labels for pod assignment                                                   | `{}`                                                                         |
+| `runAsUser`                                 | User to run blackbox-exporter container as                                       | `1000`                                                                       |
+| `readOnlyRootFilesystem`                    | Set blackbox-exporter file-system to read-only                                   | `true`                                                                       |
+| `runAsNonRoot`                              | Run blackbox-exporter as non-root                                                | `true`                                                                       |
+| `tolerations`                               | node tolerations for pod assignment                                              | `[]`                                                                         |
+| `affinity`                                  | node affinity for pod assignment                                                 | `{}`                                                                         |
+| `podAnnotations`                            | annotations to add to each pod                                                   | `{}`                                                                         |
+| `podDisruptionBudget`                       | pod disruption budget                                                            | `{}`                                                                         |
+| `pspEnabled`                                | create pod security policy resources                                             | `true`                                                                       |
+| `priorityClassName`                         | priority class name                                                              | None                                                                         |
+| `allowIcmp`                                 | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
+| `resources`                                 | pod resource requests & limits                                                   | `{}`                                                                         |
+| `restartPolicy`                             | container restart policy                                                         | `Always`                                                                     |
+| `livenessProbe`                             | Container liveness probe                                                         | See values.yaml                                                              |
+| `readinessProbe`                            | Container readiness probe                                                        | See values.yaml                                                              |
+| `networkPolicy.enabled`                     | Enable network policy and allow access from anywhere                             | `false`                                                                      |
+| `networkPolicy.allowMonitoringNamespace`    | Limit access only from monitoring namespace                                      | `false`                                                                      |
+| `service.annotations`                       | annotations for the service                                                      | `{}`                                                                         |
+| `service.labels`                            | additional labels for the service                                                | None                                                                         |
+| `service.type`                              | type of service to create                                                        | `ClusterIP`                                                                  |
+| `service.port`                              | port for the blackbox http service                                               | `9115`                                                                       |
+| `service.externalIPs`                       | list of external ips                                                             | []                                                                           |
+| `serviceAccount.create`                     | Specifies whether a service account should be created.                           | `true`                                                                       |
+| `serviceAccount.name`                       | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
+| `serviceAccount.annotations`                | ServiceAccount annotations                                                       |                                                                              |
+| `serviceMonitor.enabled`                    | If true, a ServiceMonitor CRD is created for a prometheus operator               | `false`                                                                      |
+| `serviceMonitor.defaults.labels`            | Labels for prometheus operator                                                   | `{}`                                                                         |
+| `serviceMonitor.defaults.interval`          | Interval for prometheus operator endpoint                                        | `30s`                                                                        |
+| `serviceMonitor.defaults.scrapeTimeout`     | Scrape timeout for prometheus operator endpoint                                  | `30s`                                                                        |
+| `serviceMonitor.defaults.module`            | The module that blackbox will use if serviceMonitor is enabled                   | `http_2xx`                                                                   |
+| `serviceMonitor.defaults.extraRelablings`   | Extra metric relabel configs to add to the serviceMonitor                        | `[]`                                                                         |
+| `serviceMonitor.targets.[]`                 | List of targets to scrape                                                        | `[]`                                                                         |
+| `serviceMonitor.targets.[].name`            | Human readable name for the job. It will also appear in job labels in Prometheus | `example`                                                                    |
+| `serviceMonitor.targets.[].url`             | The URL that blackbox will scrape if serviceMonitor is enabled                   | `http://example.com/healthz`                                                 |
+| `serviceMonitor.targets.[].labels`          | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.labels }`                                        |
+| `serviceMonitor.targets.[].interval`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.interval }}`                                     |
+| `serviceMonitor.targets.[].scrapeTimeout`   | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.scrateTimeout }}`                                |
+| `serviceMonitor.targets.[].module`          | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.module }}`                                       |
+| `serviceMonitor.targets.[].extraRelabelings`| See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.extraRelabelings }}`                             |
+| `prometheusRule.enabled`                    | Set this to true to create PrometheusRule for Prometheus operator | `false`     |
+| `prometheusRule.additionalLabels`           | Additional labels that can be passed to PrometheusRule | `{}`  |
+| `prometheusRule.namespace`                  | Namespace where PrometheusRule resource should be created |      |
+| `prometheusRule.rules`                      | [PrometheusRule](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created                      | `[]`                                                    |
+| `strategy`                                  | strategy used to replace old Pods with new ones                                  | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -30,6 +30,9 @@ spec:
         replacement: {{ .url }}
       - targetLabel: target
         replacement: {{ .name }}
+      {{- if or $.Values.serviceMonitor.defaults.extraRelabelings .extraRelabelings }}
+      {{- toYaml (.extraRelabelings | default $.Values.serviceMonitor.defaults.extraRelabelings) | nindent 6 }}
+      {{- end }}
   jobLabel: "{{ $.Release.Name }}"
   selector:
     matchLabels:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -141,6 +141,9 @@ serviceMonitor:
 #      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
 #      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
 #      module: http_2xx                 # Module used for scraping. Overrides value set in `defaults`
+#      extraRelabelings:
+#        - targetLabel: app
+#          replacement: web
 
 ## Custom PrometheusRules to be defined
 ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In some cases the existing metric labels provided by the servicemonitors aren't enough to effectively group metrics in services like grafana. This change allows us to submit arbitrary metric labels like:

```yaml
      extraRelabelings:
        - targetLabel: app
          replacement: web
```

so that we end up with metrics like:
`probe_duration_seconds{endpoint="http",instance="xxx",job="prometheus-blackbox-exporter",namespace="monitoring",pod="prometheus-blackbox-exporter-595cc7987c-77zkw",app="web",target="us-west-2"}`

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
