### PR TITLE
[stable/prometheus-operator] Allow autoTagVersion for hyperkube image

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.4.1
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -214,6 +214,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.enabled` | Deploy Prometheus Operator. Only one of these should be deployed into the cluster | `true` |
 | `prometheusOperator.hyperkubeImage.pullPolicy` | Image pull policy for hyperkube image used to perform maintenance tasks | `IfNotPresent` |
 | `prometheusOperator.hyperkubeImage.repository` | Repository for hyperkube image used to perform maintenance tasks | `k8s.gcr.io/hyperkube` |
+| `prometheusOperator.hyperkubeImage.autoTagVersion` | Automatically set hyperkube image tag equal to the cluster's Kubernetes version | `false` |
 | `prometheusOperator.hyperkubeImage.tag` | Tag for hyperkube image used to perform maintenance tasks | `v1.16.12` |
 | `prometheusOperator.hyperkubeImage.sha` | Sha for hyperkube image used to perform maintenance tasks | `` |
 | `prometheusOperator.image.pullPolicy` | Pull policy for prometheus operator image | `IfNotPresent` |

--- a/stable/prometheus-operator/templates/prometheus-operator/cleanup-crds.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/cleanup-crds.yaml
@@ -24,7 +24,9 @@ spec:
     {{- end }}
       containers:
         - name: kubectl
-          {{- if .Values.prometheusOperator.hyperkubeImage.sha }}
+          {{- if .Values.prometheusOperator.hyperkubeImage.autoTagVersion}}
+          image: "{{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Capabilities.KubeVersion.GitVersion }}"
+          {{- else if .Values.prometheusOperator.hyperkubeImage.sha }}
           image: {{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}@sha256:{{ .Values.prometheusOperator.hyperkubeImage.sha }}
           {{- else }}
           image: "{{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}"

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1366,6 +1366,9 @@ prometheusOperator:
   ##
   hyperkubeImage:
     repository: k8s.gcr.io/hyperkube
+    ## When autoTagVersion is enabled, tag will default to the deployed Kubernetes version
+    ##
+    autoTagVersion: false
     tag: v1.16.12
     sha: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR will allow to conditionally set image tag for `hyperkube` depending on installed Kubernetes version using Helm's built-in `Capabilities`.

https://v2.helm.sh/docs/chart_template_guide/#built-in-objects
> `Capabilities.KubeVersion` provides a way to look up the Kubernetes version. It has the following values: `Major`, `Minor`, `GitVersion`, `GitCommit`, `GitTreeState`, `BuildDate`, `GoVersion`, `Compiler`, and `Platform`.

It will be really useful to avoid manual reconfiguration across clusters with different versions.
It won't affect existing installation until `autoTagVersion` will be set to `true`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
