### PR TITLE
Rundeck Update deployment.yaml in order to make k8s probes on GKE work.

### DIFF
--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -101,14 +101,14 @@ spec:
               containerPort: 4440
           livenessProbe:
             httpGet:  
-              path: /
+              path: /user/login
               port: 4440
               scheme: HTTP
             initialDelaySeconds: 120
             periodSeconds: 120
           readinessProbe:
             httpGet:
-              path: /
+              path: /user/login
               port: 4440
               scheme: HTTP
             initialDelaySeconds: 60


### PR DESCRIPTION
On GKE on Google with GCE load Balancers rundeck container liveliness and readiness probes does not work. Load balòancer expectys an http 2xx response in order to consider the container successfully responding but rundeck on path / returns a 302 (redirect to /user/login). Changing the path would fix the issue on GKE not introducing regressions on other platforms

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #


