### PR TITLE
[stable/rabbitmq-ha] Use new load definitions when using a version eq…

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.7
-version: 1.46.6
+version: 1.47.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -79,7 +79,11 @@ data:
     loopback_users.guest = false
     {{- end }}
 
+    {{- if semverCompare ">=3.8.2" .Chart.AppVersion }}
+    load_definitions = /etc/definitions/definitions.json
+    {{ else }}
     management.load_definitions = /etc/definitions/definitions.json
+    {{- end }}
 
     ## Memory-based Flow Control threshold
     vm_memory_high_watermark.{{ .Values.rabbitmqMemoryHighWatermarkType }} = {{ .Values.rabbitmqMemoryHighWatermark }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
A small check against the .Chart.AppVersion to switch from using management.load_definitions to load_definitions when using a version which supports it (3.8.2+).

Needed to support 3.8.2+ having federation parameters set in the definitions and the chicken and egg situation which arises.

#### Special notes for your reviewer:
@steven-sheehy I've checked the documentation and it seems that this behaviour replaces the old one, and runs after all plugins have been loaded to eliminate this scenario.

- https://www.rabbitmq.com/definitions.html
- https://github.com/rabbitmq/rabbitmq-federation/issues/111

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
