### PR TITLE
stable/kafka-manager

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-manager
-version: 2.3.1
+version: 2.3.2
 appVersion: 1.3.3.22
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/stable/kafka-manager/requirements.lock
+++ b/stable/kafka-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 1.2.0
-digest: sha256:48de211cbffc0b7df9995edc4fd5d693e8bbc94e684aa83c11e6f94803f0e8b9
-generated: 2018-10-24T11:47:00.371605298-07:00
+  version: 2.1.4
+digest: sha256:cae2ac48619e7b5726962d7356adb009a4b67cb6b7f90fc1d7878425c90a401c
+generated: "2020-08-19T20:24:49.871418+02:00"

--- a/stable/kafka-manager/requirements.yaml
+++ b/stable/kafka-manager/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: zookeeper
-  version: 1.2.0
+  version: 2.1.4
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: zookeeper.enabled


### PR DESCRIPTION
I was not able to deploy `stable/kafka-manager` to Kuberenetes v1.16 and v1.17 due to the deprecated API Versions, which was caused by the Zookeeper dependency not being updated.

This PR updates Zookeeper dependency for `stable/kafka-manager` to resolve the above deployment issue.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- ~Variables are documented in the README.md~ __note applicable__
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
