### PR TITLE
[stable/reloader] deprecate chart

### DIFF
--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 name: reloader
-description: Reloader chart that runs on kubernetes
-version: 1.2.0
+description: DEPRECATED - Reloader chart that runs on kubernetes
+version: 1.3.0
 appVersion: "v0.0.41"
+deprecated: true
 keywords:
   - Reloader
   - kubernetes

--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -3,6 +3,7 @@ name: reloader
 description: DEPRECATED - Reloader chart that runs on kubernetes
 version: 1.3.0
 appVersion: "v0.0.41"
+# deprecated in favor of stakater chart repo. see README.md
 deprecated: true
 keywords:
   - Reloader
@@ -11,16 +12,4 @@ home: https://github.com/stakater/Reloader
 sources:
 - https://github.com/stakater/Reloader
 icon: https://raw.githubusercontent.com/stakater/Reloader/master/assets/web/reloader-round-100px.png
-maintainers:
-- name: rasheedamir
-  email: rasheed@aurorasolutions.io
-- name: waseem-h
-  email: waseemhassan@stakater.com
-- name: faizanahmad055
-  email: faizan.ahmad55@outlook.com
-- name: kahootali
-  email: ali.kahoot@aurorasolutions.io
-- name: ahmadiq
-  email: ahmad@aurorasolutions.io
-- name: ahsan-storm
-  email: ahsanmuhammad1@outlook.com
+maintainers: []

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -1,5 +1,7 @@
 # ![](https://raw.githubusercontent.com/stakater/Reloader/master/assets/web/reloader-round-100px.png) RELOADER
 
+> This chart has been **DEPRECATED**.  Please use the Chart found [here](https://github.com/stakater/Reloader#helm-charts) instead.
+
 A Kubernetes controller to watch changes in ConfigMap and Secrets and then restart pods for Deployment, StatefulSet and DaemonSet
 
 [![Get started with Stakater](https://stakater.github.io/README/stakater-github-banner.png)](http://stakater.com/?utm_source=Reloader&utm_medium=github)

--- a/stable/reloader/templates/NOTES.txt
+++ b/stable/reloader/templates/NOTES.txt
@@ -1,3 +1,5 @@
+> This chart has been **DEPRECATED**.  Please use the Chart found at https://github.com/stakater/Reloader#helm-charts instead.
+
 - For a `Deployment` called `foo` have a `ConfigMap` called `foo-configmap`. Then add this annotation to main metadata of your `Deployment`
   configmap.reloader.stakater.com/reload: "foo-configmap"
 


### PR DESCRIPTION
Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

This deprecates the reloader chart in favor of the official chart.

* see https://github.com/stakater/Reloader/issues/159 for deprecation plan in Reloader git org
* see https://github.com/stakater/Reloader/issues/132 for Reloader folks talking about awareness of deprecation.
* see https://github.com/helm/charts/issues/21103 for general chart deprecation plan

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
