### PR TITLE
[stable/jenkins] deprecate chart

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,8 @@
+# This chart is deprecated and moved to https://github.com/jenkinsci/helm-charts
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 2.5.2
+version: 2.5.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
@@ -25,3 +26,4 @@ maintainers:
 - name: wmcdona89
   email: wmcdona89@gmail.com
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
+deprecated: true

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -12,18 +12,5 @@ sources:
 - https://github.com/jenkinsci/docker-jnlp-slave
 - https://github.com/maorfr/kube-tasks
 - https://github.com/jenkinsci/configuration-as-code-plugin
-maintainers:
-- name: lachie83
-  email: lachlan.evenson@microsoft.com
-- name: viglesiasce
-  email: viglesias@google.com
-- name: maorfr
-  email: maor.friedman@redhat.com
-- name: torstenwalter
-  email: mail@torstenwalter.de
-- name: mogaal
-  email: garridomota@gmail.com
-- name: wmcdona89
-  email: wmcdona89@gmail.com
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
 deprecated: true

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -1,6 +1,6 @@
 # ⚠️ DEPRECATED
 
-This chart was moced to https://github.com/jenkinsci/helm-charts
+This chart was moved to https://github.com/jenkinsci/helm-charts
 
 # Jenkins Helm Chart
 

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -1,3 +1,7 @@
+# ⚠️ DEPRECATED
+
+This chart was moced to https://github.com/jenkinsci/helm-charts
+
 # Jenkins Helm Chart
 
 Jenkins master and agent cluster utilizing the Jenkins Kubernetes plugin

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -1,3 +1,8 @@
+*******************
+****DEPRECATED*****
+*******************
+* The Jenkins chart is deprecated. Future development has been moved to https://github.com/jenkinsci/helm-charts
+
 1. Get your '{{ .Values.master.adminUser }}' user password by running:
   printf $(kubectl get secret --namespace {{ template "jenkins.namespace" . }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
 


### PR DESCRIPTION
This chart was moved to a new location: https://github.com/jenkinsci/helm-charts

Part-of: #21103
Part-of: #23562
Part-of: jenkinsci/helm-charts#4

Should be merged after https://github.com/jenkinsci/helm-charts/pull/1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
