### PR TITLE
[stable/spinnaker] Annotate Halyard StatefulSet with ConfigMap hashes

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.4
+version: 2.2.5
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -14,7 +14,19 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap/halyard-init-script.yaml") . | sha256sum }}
+        {{ if .Values.halyard.additionalConfigMaps.create -}}
+        checksum/config/additional-configmaps: {{ include (print $.Template.BasePath "/configmap/additional-configmaps.yaml") . | sha256sum }}
+        {{- end}}
+        checksum/config/additional-profile-configmaps: {{ include (print $.Template.BasePath "/configmap/additional-profile-configmaps.yaml") . | sha256sum }}
+        {{ if .Values.halyard.additionalScripts.create -}}
+        checksum/config/additional-scripts: {{ include (print $.Template.BasePath "/configmap/additional-scripts.yaml") . | sha256sum }}
+        {{- end}}
+        checksum/config/halyard-config: {{ include (print $.Template.BasePath "/configmap/halyard-config.yaml") . | sha256sum }}
+        checksum/config/halyard-init-script: {{ include (print $.Template.BasePath "/configmap/halyard-init-script.yaml") . | sha256sum }}
+        {{ if .Values.halyard.serviceConfigs -}}
+        checksum/config/service-configs: {{ include (print $.Template.BasePath "/configmap/service-configs.yaml") . | sha256sum }}
+        {{- end}}
+        checksum/config/service-settings: {{ include (print $.Template.BasePath "/configmap/service-settings.yaml") . | sha256sum }}
       {{- if .Values.halyard.annotations }}
 {{ toYaml .Values.halyard.annotations | indent 8 }}
       {{- end }}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This is a simple PR to annotate the Halyard StatefulSet in the Spinnaker chart with the checksum of ConfigMaps. Without this, any changes in the mounted ConfigMaps would not automatically restart the StatefulSet, and any additional configuration scripts relying on the changes in the init script would fail.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
