### PR TITLE
[stable/prometheus-operator] Added windows dashboards and rules

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-windows-cluster.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-windows-cluster.yaml
@@ -1,0 +1,1196 @@
+# Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "k8s-resources-windows-cluster" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
+    app: {{ template "prometheus-operator.name" $ }}-grafana
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+data:
+  k8s-resources-windows-cluster.json: |-
+    {
+        "__inputs": [ ],
+        "__requires": [ ],
+        "annotations": {
+            "list": [ ]
+        },
+        "editable": false,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "hideControls": false,
+        "id": null,
+        "links": [ ],
+        "refresh": "10s",
+        "rows": [
+            {
+                "collapse": false,
+                "height": "100px",
+                "panels": [
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "format": "percentunit",
+                    "id": 2,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "1 - avg(rate(wmi_cpu_time_total{mode=\"idle\"}[1m]))",
+                            "format": "time_series",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "70,80",
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "CPU Utilisation",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "singlestat",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    },
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "format": "percentunit",
+                    "id": 3,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_cpu_cores_request) / sum(node:windows_node_num_cpu:sum)",
+                            "format": "time_series",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "70,80",
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "CPU Requests Commitment",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "singlestat",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    },
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "format": "percentunit",
+                    "id": 4,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_cpu_cores_limit) / sum(node:windows_node_num_cpu:sum)",
+                            "format": "time_series",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "70,80",
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "CPU Limits Commitment",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "singlestat",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    },
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "format": "percentunit",
+                    "id": 5,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "1 - sum(:windows_node_memory_MemFreeCached_bytes:sum) / sum(:windows_node_memory_MemTotal_bytes:sum)",
+                            "format": "time_series",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "70,80",
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Memory Utilisation",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "singlestat",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    },
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "format": "percentunit",
+                    "id": 6,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_memory_request) / sum(:windows_node_memory_MemTotal_bytes:sum)",
+                            "format": "time_series",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "70,80",
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Memory Requests Commitment",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "singlestat",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    },
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "format": "percentunit",
+                    "id": 7,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 2,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_memory_limit) / sum(:windows_node_memory_MemTotal_bytes:sum)",
+                            "format": "time_series",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": "70,80",
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Memory Limits Commitment",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "singlestat",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": false,
+                "title": "Headlines",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 10,
+                    "id": 8,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 0,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate) by (namespace)",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{`{{namespace}}`}}",
+                            "legendLink": null,
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [ ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "CPU Usage",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "CPU",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "id": 9,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": false,
+                    "steppedLine": false,
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "hidden"
+                        },
+                        {
+                            "alias": "CPU Usage",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #A",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "short"
+                        },
+                        {
+                            "alias": "CPU Requests",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #B",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "short"
+                        },
+                        {
+                            "alias": "CPU Requests %",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #C",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "percentunit"
+                        },
+                        {
+                            "alias": "CPU Limits",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #D",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "short"
+                        },
+                        {
+                            "alias": "CPU Limits %",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #E",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "percentunit"
+                        },
+                        {
+                            "alias": "Namespace",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": true,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "./d/490b402361724ab1d4c45666c1fa9b6f/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell",
+                            "pattern": "namespace",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "short"
+                        },
+                        {
+                            "alias": "",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "pattern": "/.*/",
+                            "thresholds": [ ],
+                            "type": "string",
+                            "unit": "short"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_cpu_cores_request) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_windows_container_resource_cpu_cores_request) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "C",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_cpu_cores_limit) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "D",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_windows_container_resource_cpu_cores_limit) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "E",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [ ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "CPU Quota",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "transform": "table",
+                    "type": "table",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "CPU Quota",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 10,
+                    "id": 10,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 0,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "expr": "sum(windows_container_private_working_set_usage{}) by (namespace)",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{`{{namespace}}`}}",
+                            "legendLink": null,
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [ ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Memory Usage (Private Working Set)",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "decbytes",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Memory",
+                "titleSize": "h6"
+            },
+            {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                    {
+                    "aliasColors": { },
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": "$datasource",
+                    "fill": 1,
+                    "id": 11,
+                    "legend": {
+                        "avg": false,
+                        "current": false,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [ ],
+                    "nullPointMode": "null as zero",
+                    "percentage": false,
+                    "pointradius": 5,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [ ],
+                    "spaceLength": 10,
+                    "span": 12,
+                    "stack": false,
+                    "steppedLine": false,
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "hidden"
+                        },
+                        {
+                            "alias": "Memory Usage",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #A",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "decbytes"
+                        },
+                        {
+                            "alias": "Memory Requests",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #B",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "decbytes"
+                        },
+                        {
+                            "alias": "Memory Requests %",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #C",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "percentunit"
+                        },
+                        {
+                            "alias": "Memory Limits",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #D",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "decbytes"
+                        },
+                        {
+                            "alias": "Memory Limits %",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": false,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "",
+                            "pattern": "Value #E",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "percentunit"
+                        },
+                        {
+                            "alias": "Namespace",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "link": true,
+                            "linkTooltip": "Drill down",
+                            "linkUrl": "./d/490b402361724ab1d4c45666c1fa9b6f/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell",
+                            "pattern": "namespace",
+                            "thresholds": [ ],
+                            "type": "number",
+                            "unit": "short"
+                        },
+                        {
+                            "alias": "",
+                            "colorMode": null,
+                            "colors": [ ],
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "decimals": 2,
+                            "pattern": "/.*/",
+                            "thresholds": [ ],
+                            "type": "string",
+                            "unit": "short"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "expr": "sum(windows_container_private_working_set_usage{}) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "A",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_memory_request) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "B",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(windows_container_private_working_set_usage{}) by (namespace) / sum(kube_pod_windows_container_resource_memory_request) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "C",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(kube_pod_windows_container_resource_memory_limit) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "D",
+                            "step": 10
+                        },
+                        {
+                            "expr": "sum(windows_container_private_working_set_usage{}) by (namespace) / sum(kube_pod_windows_container_resource_memory_limit) by (namespace)",
+                            "format": "table",
+                            "instant": true,
+                            "intervalFactor": 2,
+                            "legendFormat": "",
+                            "refId": "E",
+                            "step": 10
+                        }
+                    ],
+                    "thresholds": [ ],
+                    "timeFrom": null,
+                    "timeShift": null,
+                    "title": "Requests by Namespace",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "transform": "table",
+                    "type": "table",
+                    "xaxis": {
+                        "buckets": null,
+                        "mode": "time",
+                        "name": null,
+                        "show": true,
+                        "values": [ ]
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                        }
+                    ]
+                    }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Memory Requests",
+                "titleSize": "h6"
+            }
+        ],
+        "schemaVersion": 14,
+        "style": "dark",
+        "tags": [
+            "kubernetes-mixin"
+        ],
+        "templating": {
+            "list": [
+                {
+                    "current": {
+                    "text": "default",
+                    "value": "default"
+                    },
+                    "hide": 0,
+                    "label": null,
+                    "name": "datasource",
+                    "options": [ ],
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "datasource"
+                }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "browser",
+        "title": "Kubernetes / Compute Resources / Cluster (Windows)",
+        "uid": "4d08557fd9391b100730f2494bccac68",
+        "version": 0
+    }
+
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-windows-namespace.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-windows-namespace.yaml
@@ -1,0 +1,748 @@
+# Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "k8s-resources-windows-namespace" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
+    app: {{ template "prometheus-operator.name" $ }}-grafana
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+data:
+  k8s-resources-windows-namespace.json: |-
+    {
+    "__inputs": [ ],
+    "__requires": [ ],
+    "annotations": {
+        "list": [ ]
+    },
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [ ],
+    "refresh": "10s",
+    "rows": [
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 2,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod)",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{pod}}`}}",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Usage",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU Usage",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 3,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                    {
+                        "alias": "Time",
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "pattern": "Time",
+                        "type": "hidden"
+                    },
+                    {
+                        "alias": "CPU Usage",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #A",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "CPU Requests",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #B",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "CPU Requests %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #C",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "CPU Limits",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #D",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "CPU Limits %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #E",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "Pod",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": true,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "./d/40597a704a610e936dc6ed374a7ce023/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell",
+                        "pattern": "pod",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "pattern": "/.*/",
+                        "thresholds": [ ],
+                        "type": "string",
+                        "unit": "short"
+                    }
+                ],
+                "targets": [
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_cpu_cores_request{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "B",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod) / sum(kube_pod_windows_container_resource_cpu_cores_request{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "C",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_cpu_cores_limit{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "D",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod) / sum(kube_pod_windows_container_resource_cpu_cores_limit{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "E",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Quota",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "transform": "table",
+                "type": "table",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU Quota",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 4,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\"}) by (pod)",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{pod}}`}}",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Usage",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "decbytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory Usage",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 5,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                    {
+                        "alias": "Time",
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "pattern": "Time",
+                        "type": "hidden"
+                    },
+                    {
+                        "alias": "Memory Usage",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #A",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "decbytes"
+                    },
+                    {
+                        "alias": "Memory Requests",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #B",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "decbytes"
+                    },
+                    {
+                        "alias": "Memory Requests %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #C",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "Memory Limits",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #D",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "decbytes"
+                    },
+                    {
+                        "alias": "Memory Limits %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #E",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "Pod",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": true,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "./d/40597a704a610e936dc6ed374a7ce023/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell",
+                        "pattern": "pod",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "pattern": "/.*/",
+                        "thresholds": [ ],
+                        "type": "string",
+                        "unit": "short"
+                    }
+                ],
+                "targets": [
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_memory_request{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "B",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\"}) by (pod) / sum(kube_pod_windows_container_resource_memory_request{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "C",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_memory_limit{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "D",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\"}) by (pod) / sum(kube_pod_windows_container_resource_memory_limit{namespace=\"$namespace\"}) by (pod)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "E",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Quota",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "transform": "table",
+                "type": "table",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory Quota",
+            "titleSize": "h6"
+        }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+        "kubernetes-mixin"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                "text": "default",
+                "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(windows_container_available, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Kubernetes / Compute Resources / Namespace (Windows Pods)",
+    "uid": "490b402361724ab1d4c45666c1fa9b6f",
+    "version": 0
+    }
+
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-windows-pod.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-windows-pod.yaml
@@ -1,0 +1,866 @@
+# Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "k8s-resources-windows-pod" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
+    app: {{ template "prometheus-operator.name" $ }}-grafana
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+data:
+  k8s-resources-windows-pod.json: |-
+    {
+    "__inputs": [ ],
+    "__requires": [ ],
+    "annotations": {
+        "list": [ ]
+    },
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [ ],
+    "refresh": "10s",
+    "rows": [
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 2,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{container}}`}}",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Usage",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU Usage",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 3,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                    {
+                        "alias": "Time",
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "pattern": "Time",
+                        "type": "hidden"
+                    },
+                    {
+                        "alias": "CPU Usage",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #A",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "CPU Requests",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #B",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "CPU Requests %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #C",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "CPU Limits",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #D",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "CPU Limits %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #E",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "Container",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "container",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "pattern": "/.*/",
+                        "thresholds": [ ],
+                        "type": "string",
+                        "unit": "short"
+                    }
+                ],
+                "targets": [
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_cpu_cores_request{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "B",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_windows_container_resource_cpu_cores_request{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "C",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_cpu_cores_limit{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "D",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_windows_container_resource_cpu_cores_limit{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "E",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Quota",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "transform": "table",
+                "type": "table",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU Quota",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 4,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{container}}`}}",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Usage",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory Usage",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 5,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                    {
+                        "alias": "Time",
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "pattern": "Time",
+                        "type": "hidden"
+                    },
+                    {
+                        "alias": "Memory Usage",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #A",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "decbytes"
+                    },
+                    {
+                        "alias": "Memory Requests",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #B",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "decbytes"
+                    },
+                    {
+                        "alias": "Memory Requests %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #C",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "Memory Limits",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #D",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "decbytes"
+                    },
+                    {
+                        "alias": "Memory Limits %",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "Value #E",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "percentunit"
+                    },
+                    {
+                        "alias": "Container",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "link": false,
+                        "linkTooltip": "Drill down",
+                        "linkUrl": "",
+                        "pattern": "container",
+                        "thresholds": [ ],
+                        "type": "number",
+                        "unit": "short"
+                    },
+                    {
+                        "alias": "",
+                        "colorMode": null,
+                        "colors": [ ],
+                        "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                        "decimals": 2,
+                        "pattern": "/.*/",
+                        "thresholds": [ ],
+                        "type": "string",
+                        "unit": "short"
+                    }
+                ],
+                "targets": [
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "A",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_memory_request{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "B",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_windows_container_resource_memory_request{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "C",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(kube_pod_windows_container_resource_memory_limit{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "D",
+                        "step": 10
+                    },
+                    {
+                        "expr": "sum(windows_container_private_working_set_usage{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_windows_container_resource_memory_limit{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                        "format": "table",
+                        "instant": true,
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "E",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Quota",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "transform": "table",
+                "type": "table",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory Quota",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 6,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": true,
+                    "current": true,
+                    "max": false,
+                    "min": false,
+                    "rightSide": true,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sort_desc(sum by (container) (rate(windows_container_network_receive_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[1m])))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Received : {{`{{container}}`}}",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "sort_desc(sum by (container) (rate(windows_container_network_transmit_bytes_total{namespace=\"$namespace\", pod=\"$pod\"}[1m])))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Transmitted : {{`{{container}}`}}",
+                        "refId": "B"
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Network I/O",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Network I/O",
+            "titleSize": "h6"
+        }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+        "kubernetes-mixin"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                "text": "default",
+                "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(windows_container_available, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Pod",
+                "multi": false,
+                "name": "pod",
+                "options": [ ],
+                "query": "label_values(windows_container_available{namespace=\"$namespace\"}, pod)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Kubernetes / Compute Resources / Pod (Windows)",
+    "uid": "40597a704a610e936dc6ed374a7ce023",
+    "version": 0
+    }
+  
+
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-windows-cluster-rsrc-use.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-windows-cluster-rsrc-use.yaml
@@ -1,0 +1,686 @@
+# Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "k8s-windows-cluster-rsrc-use" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
+    app: {{ template "prometheus-operator.name" $ }}-grafana
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+data:
+  k8s-windows-cluster-rsrc-use.json: |-
+    {
+    "__inputs": [ ],
+    "__requires": [ ],
+    "annotations": {
+        "list": [ ]
+    },
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [ ],
+    "refresh": "10s",
+    "rows": [
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 2,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_cpu_utilisation:avg1m * node:windows_node_num_cpu:sum / scalar(sum(node:windows_node_num_cpu:sum))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Utilisation",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": 1,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 3,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_memory_utilisation:ratio",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Utilisation",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": 1,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 4,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_memory_swap_io_pages:irate",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Saturation (Swap I/O Pages)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 5,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_disk_utilisation:avg_irate / scalar(node:windows_node:sum)",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Disk IO Utilisation",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": 1,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Disk",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 6,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_net_utilisation:sum_irate",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Net Utilisation (Transmitted)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "Bps",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 7,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_net_saturation:sum_irate",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Net Saturation (Dropped)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "Bps",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Network",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 10,
+                "id": 8,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sum by (instance)(node:windows_node_filesystem_usage:)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{instance}}`}}'",
+                        "legendLink": "./d/96e7484b0bb53b74fbc2bcb7723cd40b/k8s-windows-node-rsrc-use",
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Disk Capacity",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": 1,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Storage",
+            "titleSize": "h6"
+        }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+        "kubernetes-mixin"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                "text": "default",
+                "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Kubernetes / USE Method / Cluster (Windows)",
+    "uid": "53a43377ec9aaf2ff64dfc7a1f539334",
+    "version": 0
+    }
+
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-windows-node-rsrc-use.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-windows-node-rsrc-use.yaml
@@ -1,0 +1,975 @@
+# Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) "k8s-windows-node-rsrc-use" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    {{- if $.Values.grafana.sidecar.dashboards.label }}
+    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- end }}
+    app: {{ template "prometheus-operator.name" $ }}-grafana
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+data:
+  k8s-windows-node-rsrc-use.json: |-
+    {
+    "__inputs": [ ],
+    "__requires": [ ],
+    "annotations": {
+        "list": [ ]
+    },
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [ ],
+    "refresh": "10s",
+    "rows": [
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 2,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_cpu_utilisation:avg1m{instance=\"$instance\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Utilisation",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Utilisation",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 3,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "sum by (core) (irate(wmi_cpu_time_total{job=\"wmi-exporter\", mode!=\"idle\", instance=\"$instance\"}[5m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{core}}`}}",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Usage Per Core",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "CPU",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 4,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 4,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_memory_utilisation:{instance=\"$instance\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Memory",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Utilisation %",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 5,
+                "legend": {
+                    "alignAsTable": false,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "rightSide": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 4,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "max(\n  wmi_os_visible_memory_bytes{job=\"wmi-exporter\", instance=\"$instance\"}\n  - wmi_memory_available_bytes{job=\"wmi-exporter\", instance=\"$instance\"}\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "memory used",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "max(node:windows_node_memory_totalCached_bytes:sum{job=\"wmi-exporter\", instance=\"$instance\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "memory cached",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "max(wmi_memory_available_bytes{job=\"wmi-exporter\", instance=\"$instance\"})",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "memory free",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Usage",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 6,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 4,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_memory_swap_io_pages:irate{instance=\"$instance\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Swap IO",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Saturation (Swap I/O) Pages",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Memory",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 7,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_disk_utilisation:avg_irate{instance=\"$instance\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Utilisation",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Disk IO Utilisation",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": null,
+                "fill": 1,
+                "id": 8,
+                "legend": {
+                    "alignAsTable": false,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "rightSide": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "repeat": null,
+                "seriesOverrides": [
+                    {
+                        "alias": "read",
+                        "yaxis": 1
+                    },
+                    {
+                        "alias": "io time",
+                        "yaxis": 2
+                    }
+                ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "max(rate(wmi_logical_disk_read_bytes_total{job=\"wmi-exporter\", instance=\"$instance\"}[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "read",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "max(rate(wmi_logical_disk_write_bytes_total{job=\"wmi-exporter\", instance=\"$instance\"}[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "written",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "max(rate(wmi_logical_disk_read_seconds_total{job=\"wmi-exporter\",  instance=\"$instance\"}[2m]) + rate(wmi_logical_disk_write_seconds_total{job=\"wmi-exporter\",  instance=\"$instance\"}[2m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "io time",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Disk I/O",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "ms",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Disk IO",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 9,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_net_utilisation:sum_irate{instance=\"$instance\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Utilisation",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Net Utilisation (Transmitted)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "Bps",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                },
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 10,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 6,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_net_saturation:sum_irate{instance=\"$instance\"}",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Saturation",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Net Saturation (Dropped)",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "Bps",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Net",
+            "titleSize": "h6"
+        },
+        {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+                {
+                "aliasColors": { },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fill": 1,
+                "id": 11,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [ ],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [ ],
+                "spaceLength": 10,
+                "span": 12,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                    {
+                        "expr": "node:windows_node_filesystem_usage:{instance=\"$instance\"}\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{`{{volume}}`}}",
+                        "legendLink": null,
+                        "step": 10
+                    }
+                ],
+                "thresholds": [ ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Disk Utilisation",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": [ ]
+                },
+                "yaxes": [
+                    {
+                        "format": "percentunit",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                    }
+                ]
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Disk Space",
+            "titleSize": "h6"
+        }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+        "kubernetes-mixin"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                "text": "default",
+                "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Instance",
+                "multi": false,
+                "name": "instance",
+                "options": [ ],
+                "query": "label_values(wmi_system_system_up_time, instance)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "Kubernetes / USE Method / Node (Windows)",
+    "uid": "96e7484b0bb53b74fbc2bcb7723cd40b",
+    "version": 0
+    }
+
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/windows.node.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/windows.node.rules.yaml
@@ -1,0 +1,125 @@
+# Generated from 'node-exporter.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" .) "windows-node.rules" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    app: {{ template "prometheus-operator.name" . }}
+{{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: windows.node.rules
+    rules:
+    - expr: |-
+        count (
+          wmi_system_system_up_time{job="wmi-exporter"}
+        )
+      record: 'node:windows_node:sum'
+    - expr: |-
+        count by (instance) (sum by (instance, core) (
+          wmi_cpu_time_total{job="wmi-exporter"}
+        ))
+      record: 'node:windows_node_num_cpu:sum'
+    - expr: |-
+        1 - avg(rate(wmi_cpu_time_total{job="wmi-exporter",mode="idle"}[1m]))
+      record: ':windows_node_cpu_utilisation:avg1m'
+    - expr: |-
+        1 - avg by (instance) (
+          rate(wmi_cpu_time_total{job="wmi-exporter",mode="idle"}[1m])
+        )
+      record: 'node:windows_node_cpu_utilisation:avg1m'
+    - expr: |-
+        1 -
+           sum(wmi_memory_available_bytes{job="wmi-exporter"})
+           /
+          sum(wmi_os_visible_memory_bytes{job="wmi-exporter"})
+      record: ':windows_node_memory_utilisation:'
+    - expr: sum(wmi_memory_available_bytes{job="wmi-exporter"} + wmi_memory_cache_bytes{job="wmi-exporter"})
+      record: ':windows_node_memory_MemFreeCached_bytes:sum'
+    - expr: (wmi_memory_cache_bytes{job="wmi-exporter"} + wmi_memory_modified_page_list_bytes{job="wmi-exporter"} + wmi_memory_standby_cache_core_bytes{job="wmi-exporter"} + wmi_memory_standby_cache_normal_priority_bytes{job="wmi-exporter"} + wmi_memory_standby_cache_reserve_bytes{job="wmi-exporter"})
+      record: 'node:windows_node_memory_totalCached_bytes:sum'
+    - expr: sum(wmi_os_visible_memory_bytes{job="wmi-exporter"})
+      record: ':windows_node_memory_MemTotal_bytes:sum'
+    - expr: |-
+        sum by (instance) (
+        (wmi_memory_available_bytes{job="wmi-exporter"})
+        )
+      record: 'node:windows_node_memory_bytes_available:sum'
+    - expr: |-
+        sum by (instance) (
+        wmi_os_visible_memory_bytes{job="wmi-exporter"}
+        )
+      record: 'node:windows_node_memory_bytes_total:sum'
+    - expr: |-
+        (node:windows_node_memory_bytes_total:sum - node:windows_node_memory_bytes_available:sum)
+        /
+        scalar(sum(node:windows_node_memory_bytes_total:sum))
+      record: 'node:windows_node_memory_utilisation:ratio'
+    - expr: |-
+        1 - (node:windows_node_memory_bytes_available:sum / node:windows_node_memory_bytes_total:sum)
+      record: 'node:windows_node_memory_utilisation:'
+
+    - expr: |-
+        irate(wmi_memory_swap_page_operations_total{job="wmi-exporter"}[5m])
+      record: 'node:windows_node_memory_swap_io_pages:irate'
+
+    - expr: |-
+          avg(irate(wmi_logical_disk_read_seconds_total{job="wmi-exporter"}[1m]) + 
+              irate(wmi_logical_disk_write_seconds_total{job="wmi-exporter"}[1m])
+          )
+      record: ':windows_node_disk_utilisation:avg_irate'
+    - expr: |-
+        avg by (instance) (
+          (irate(wmi_logical_disk_read_seconds_total{job="wmi-exporter"}[1m]) +
+           irate(wmi_logical_disk_write_seconds_total{job="wmi-exporter"}[1m]))
+        )
+      record: 'node:windows_node_disk_utilisation:avg_irate'
+
+    - expr: |-
+        max by (instance,volume)(
+              (wmi_logical_disk_size_bytes{job="wmi-exporter"}
+              - wmi_logical_disk_free_bytes{job="wmi-exporter"})
+              / wmi_logical_disk_size_bytes{job="wmi-exporter"}
+        )
+      record: 'node:windows_node_filesystem_usage:'
+
+    - expr: |-
+        max by (instance, volume) (wmi_logical_disk_free_bytes{job="wmi-exporter"} / wmi_logical_disk_size_bytes{job="wmi-exporter"})
+      record: 'node:windows_node_filesystem_avail:'
+
+    - expr: |-
+        sum(irate(wmi_net_bytes_total{job="wmi-exporter"}[1m]))
+      record: ':windows_node_net_utilisation:sum_irate'
+
+    - expr: |-
+        sum by (instance) (
+           (irate(wmi_net_bytes_total{job="wmi-exporter"}[1m]))
+        )
+      record: 'node:windows_node_net_utilisation:sum_irate'
+
+    - expr: |-
+        sum(irate(wmi_net_packets_received_discarded{job="wmi-exporter"}[1m])) +
+        sum(irate(wmi_net_packets_outbound_discarded{job="wmi-exporter"}[1m]))
+      record: ':windows_node_net_saturation:sum_irate'
+
+    - expr: |-
+        sum by (instance) (
+           (irate(wmi_net_packets_received_discarded{job="wmi-exporter"}[1m]) +
+            irate(wmi_net_packets_outbound_discarded{job="wmi-exporter"}[1m]))
+        )
+      record: 'node:windows_node_net_saturation:sum_irate'
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/windows.pod.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/windows.pod.rules.yaml
@@ -1,0 +1,59 @@
+# Generated from 'node-exporter.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if .Values.enableWindowsMonitoring.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" .) "windows-pod.rules" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "prometheus-operator.namespace" . }}
+  labels:
+    app: {{ template "prometheus-operator.name" . }}
+{{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: windows.pod.rules
+    rules:
+    - expr: |-
+        wmi_container_available{job="wmi-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)
+      record: 'windows_container_available'
+    - expr: |-
+        wmi_container_cpu_usage_seconds_total{job="wmi-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)
+      record: 'windows_container_total_runtime'
+    - expr: |-
+        wmi_container_memory_usage_commit_bytes{job="wmi-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)
+      record: 'windows_container_memory_usage'
+    - expr: |-
+        wmi_container_memory_usage_private_working_set_bytes{job="wmi-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)
+      record: 'windows_container_private_working_set_usage'
+    - expr: |-
+        wmi_container_network_receive_bytes_total{job="wmi-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)
+      record: 'windows_container_network_receive_bytes_total'
+    - expr: wmi_container_network_transmit_bytes_total{job="wmi-exporter"} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{job="kube-state-metrics"}) by(container, container_id, pod, namespace)
+      record: 'windows_container_network_transmit_bytes_total'
+    - expr: kube_pod_container_resource_requests_memory_bytes {job="kube-state-metrics"} * on(container,pod,namespace) (windows_container_available)
+      record: 'kube_pod_windows_container_resource_memory_request'
+    - expr: kube_pod_container_resource_limits_memory_bytes {job="kube-state-metrics"} * on(container,pod,namespace) (windows_container_available)
+      record: 'kube_pod_windows_container_resource_memory_limit'
+    - expr: |-
+        kube_pod_container_resource_requests_cpu_cores  {job="kube-state-metrics"} * on(container,pod,namespace) (windows_container_available)
+      record: 'kube_pod_windows_container_resource_cpu_cores_request'
+    - expr: |-
+        kube_pod_container_resource_limits_cpu_cores  {job="kube-state-metrics"} * on(container,pod,namespace) (windows_container_available)
+      record: 'kube_pod_windows_container_resource_cpu_cores_limit'
+    - expr: |-
+        sum by (namespace, pod, container) (
+                rate(windows_container_total_runtime{}[5m])
+        )
+      record: 'namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate'
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -98,6 +98,11 @@ global:
 ## Configuration for alertmanager
 ## ref: https://prometheus.io/docs/alerting/alertmanager/
 ##
+
+enableWindowsMonitoring:
+  ## Deploy the windows specific dashboards and rules
+  enabled: false
+
 alertmanager:
 
   ## Deploy alertmanager


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR adds the Windows monitoring dashboards and rules as optional configuration from https://github.com/kubernetes-monitoring/kubernetes-mixin.
These rules/dashboards expect the input data from the windows-exporter for Windows(https://github.com/prometheus-community/windows_exporter).
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
