### PR TITLE
[stable/rethinkdb] Update to RethinkDB 2.4.0 and small fixes.

### DIFF
--- a/stable/rethinkdb/Chart.yaml
+++ b/stable/rethinkdb/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 name: rethinkdb
 description: The open-source database for the realtime web
-version: 1.1.2
-appVersion: 0.1.0
+version: 2.4.0
+appVersion: 2.4.0
 keywords:
-- rethinkdb
-- database
-- nosql
+  - rethinkdb
+  - database
+  - nosql
 home: https://www.rethinkdb.com
 sources:
-- https://hub.docker.com/r/codylundquist/helm-rethinkdb-cluster/
+  - https://hub.docker.com/r/codylundquist/helm-rethinkdb-cluster/
 icon: http://i.imgur.com/bZ75N6r.jpg
 maintainers:
-- name: meenie
-  email: cody.lundquist@gmail.com
+  - name: meenie
+    email: cody.lundquist@gmail.com

--- a/stable/rethinkdb/README.md
+++ b/stable/rethinkdb/README.md
@@ -1,14 +1,17 @@
-# RethinkDB 2.3.5 Helm Chart
+# RethinkDB 2.4.0 Helm Chart
 
 ## Prerequisites Details
-* Kubernetes 1.5+ with Beta APIs enabled.
-* PV support on the underlying infrastructure.
+
+- Kubernetes 1.5+ with Beta APIs enabled.
+- PV support on the underlying infrastructure.
 
 ## StatefulSet Details
-* https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/
+
+- https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/
 
 ## StatefulSet Caveats
-* https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations
+
+- https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations
 
 ## Acknowledgment of Previous Works
 
@@ -30,40 +33,41 @@ $ helm install --name my-release stable/rethinkdb
 
 The following table lists the configurable parameters of the rethinkdb chart and their default values.
 
-Parameter | Description | Default
----|---|---
-`image.name` | Custom RethinkDB image name for auto-joining and probe | `codylundquist/helm-rethinkdb-cluster`
-`image.tag` | Custom RethinkDB image tag | `0.1.0`
-`image.pullPolicy` | Custom RethinkDB image pull policy | `IfNotPresent`
-`cluster.replicas` | Number of RethinkDB Cluster replicas | `3`
-`cluster.resources` | Resource configuration for each RethinkDB Cluster Pod | `{}`
-`cluster.podAnnotations` | Annotations to be added to RethinkDB Cluster Pods | `{}`
-`cluster.service.annotations` | Annotations to be added to RethinkDB Cluster Service | `{}`
-`cluster.storageClass.enabled` | If `true`, create a StorageClass for the cluster. **Note**: You must set a provisioner | `false`
-`cluster.storageClass.provisioner` | Provisioner definition for StorageClass | `undefined`
-`cluster.storageClass.parameters` | Parameters for StorageClass | `undefined`
-`cluster.persistentVolume.enabled` | If `true`, persistent volume claims are created | `true`
-`cluster.persistentVolume.storageClass` | Persistent volume storage class | `default`
-`cluster.persistentVolume.accessMode` | Persistent volume access modes | `[ReadWriteOnce]`
-`cluster.persistentVolume.size` | Persistent volume size | `1Gi`
-`cluster.persistentVolume.annotations` | Persistent volume annotations | `{}`
-`cluster.rethinkCacheSize` | RethinkDB `cache-size` value in MB | `100`
-`proxy.replicas` | Number of RethinkDB Proxy replicas | `1`
-`proxy.resources` | Resource configuration for each RethinkDB Proxy Pod | `{}`
-`proxy.podAnnotations` | Annotations to be added to RethinkDB Proxy Pods | `{}`
-`proxy.service.type` | RethinkDB Proxy Service Type | `ClusterIP`
-`proxy.service.annotations` | Annotations to be added to RethinkDB Cluster Service | `{}`
-`proxy.service.clusterIP` | Internal controller proxy service IP | `""`
-`proxy.service.externalIPs` | Controller service external IP addresses | `[]`
-`proxy.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`proxy.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`proxy.driverTLS.enabled` | Should RethinkDB Proxy TLS be enabled. **Note**: If enabled, you must set a key and cert | `false`
-`proxy.driverTLS.key` | RSA Private Key | `undefined`
-`proxy.driverTLS.cert` | Certificate | `undefined`
-`ports.cluster` | RethinkDB Cluster Port | `29015`
-`ports.driver` | RethinkDB Driver Port | `28015`
-`ports.admin` | RethinkDB Admin Port | `8080`
-`rethinkdbPassword` | Password for the RethinkDB Admin user | `rethinkdb`
+| Parameter                                | Description                                                                              | Default                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------- |
+| `image.name`                             | Custom RethinkDB image name for auto-joining and probe                                   | `codylundquist/helm-rethinkdb-cluster` |
+| `image.tag`                              | Custom RethinkDB image tag                                                               | `2.4.0`                                |
+| `image.pullPolicy`                       | Custom RethinkDB image pull policy                                                       | `IfNotPresent`                         |
+| `cluster.replicas`                       | Number of RethinkDB Cluster replicas                                                     | `3`                                    |
+| `cluster.resources`                      | Resource configuration for each RethinkDB Cluster Pod                                    | `{}`                                   |
+| `cluster.podAnnotations`                 | Annotations to be added to RethinkDB Cluster Pods                                        | `{}`                                   |
+| `cluster.service.annotations`            | Annotations to be added to RethinkDB Cluster Service                                     | `{}`                                   |
+| `cluster.storageClass.enabled`           | If `true`, create a StorageClass for the cluster. **Note**: You must set a provisioner   | `false`                                |
+| `cluster.storageClass.provisioner`       | Provisioner definition for StorageClass                                                  | `undefined`                            |
+| `cluster.storageClass.parameters`        | Parameters for StorageClass                                                              | `undefined`                            |
+| `cluster.persistentVolume.enabled`       | If `true`, persistent volume claims are created                                          | `true`                                 |
+| `cluster.persistentVolume.storageClass`  | Persistent volume storage class                                                          | `default`                              |
+| `cluster.persistentVolume.accessMode`    | Persistent volume access modes                                                           | `[ReadWriteOnce]`                      |
+| `cluster.persistentVolume.size`          | Persistent volume size                                                                   | `1Gi`                                  |
+| `cluster.persistentVolume.annotations`   | Persistent volume annotations                                                            | `{}`                                   |
+| `cluster.rethinkCacheSize`               | RethinkDB `cache-size` value in MB                                                       | `100`                                  |
+| `cluster.rethinkCores`                   | RethinkDB `cores` value. If blank, RethinkDB uses the number of cores of the CPU         | `undefined`                            |
+| `proxy.replicas`                         | Number of RethinkDB Proxy replicas                                                       | `1`                                    |
+| `proxy.resources`                        | Resource configuration for each RethinkDB Proxy Pod                                      | `{}`                                   |
+| `proxy.podAnnotations`                   | Annotations to be added to RethinkDB Proxy Pods                                          | `{}`                                   |
+| `proxy.service.type`                     | RethinkDB Proxy Service Type                                                             | `ClusterIP`                            |
+| `proxy.service.annotations`              | Annotations to be added to RethinkDB Cluster Service                                     | `{}`                                   |
+| `proxy.service.clusterIP`                | Internal controller proxy service IP                                                     | `""`                                   |
+| `proxy.service.externalIPs`              | Controller service external IP addresses                                                 | `[]`                                   |
+| `proxy.service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                     | `""`                                   |
+| `proxy.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                          | `[]`                                   |
+| `proxy.driverTLS.enabled`                | Should RethinkDB Proxy TLS be enabled. **Note**: If enabled, you must set a key and cert | `false`                                |
+| `proxy.driverTLS.key`                    | RSA Private Key                                                                          | `undefined`                            |
+| `proxy.driverTLS.cert`                   | Certificate                                                                              | `undefined`                            |
+| `ports.cluster`                          | RethinkDB Cluster Port                                                                   | `29015`                                |
+| `ports.driver`                           | RethinkDB Driver Port                                                                    | `28015`                                |
+| `ports.admin`                            | RethinkDB Admin Port                                                                     | `8080`                                 |
+| `rethinkdbPassword`                      | Password for the RethinkDB Admin user                                                    | `rethinkdb`                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -75,9 +79,10 @@ $ helm install --name my-release -f values.yaml stable/rethinkdb
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-## Important: Admin Password Management ##
+## Important: Admin Password Management
 
-The initial admin password is set by the config value `rethinkdbPassword`.  This value is also used by the probe which periodically checks if the RethinkDB Cluster and Proxy are still running.  If you change the RethinkDB admin password via a query (i.e. `r.db('rethinkdb').table('users').update({password: 'new-password'})`) this will cause the probe to fail which then restarts the pods over and over.  To stablize the cluster, you also need to use `helm upgrade` to update the password in the Kubernetes Secrets storage by doing:
+The initial admin password is set by the config value `rethinkdbPassword`. This value is also used by the probe which periodically checks if the RethinkDB Cluster and Proxy are still running. If you change the RethinkDB admin password via a query (i.e. `r.db('rethinkdb').table('users').update({password: 'new-password'})`) this will cause the probe to fail which then restarts the pods over and over. To stablize the cluster, you also need to use `helm upgrade` to update the password in the Kubernetes Secrets storage by doing:
+
 ```console
 $ helm upgrade --set rethinkdbPassword=new-password my-release stable/rethinkdb
 ```
@@ -85,10 +90,12 @@ $ helm upgrade --set rethinkdbPassword=new-password my-release stable/rethinkdb
 ## Opening Up the RethinkDB Admin Console
 
 The admin port is not available outside of the cluster for security reasons. The only way to access the admin console is to use a [Kubernetes Proxy](https://kubernetes.io/docs/concepts/cluster-administration/access-cluster/#manually-constructing-apiserver-proxy-urls). To open up the admin console:
+
 ```console
 $ kubectl proxy
 Starting to serve on 127.0.0.1:8001
 ```
+
 Then use the following URL: http://localhost:8001/api/v1/namespaces/NAMESPACE/services/RELEASE_NAME-rethinkdb-admin/proxy
 Make sure a replace `NAMEPSPACE` with the correct namespace and `RELEASE_NAME` that was used when installing the chart.
 
@@ -108,6 +115,7 @@ $ kubectl delete pvc -l release=my-release
 
 If any RethinkDB server fails it gets re-joined eventually.
 You can test the scenario by killing process of one of the pods:
+
 ```console
 $ kubectl get pods -l release=my-release
 NAME                                          READY     STATUS    RESTARTS   AGE
@@ -127,6 +135,7 @@ $ kubectl exec -it my-release-rethinkdb-cluster-0 -- kill 7
 ## Scaling
 
 Scaling should be managed by `helm upgrade`, which is the recommended way. Example:
+
 ```
 $ helm upgrade --set cluster.replicas=4 my-release stable/rethinkdb
 ```

--- a/stable/rethinkdb/init/Dockerfile
+++ b/stable/rethinkdb/init/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rethinkdb:2.3.5
-MAINTAINER Cody Lundquist <cody.lundquist@gmail.com>
+FROM rethinkdb:2.4.0
+LABEL maintainer="Cody Lundquist <cody.lundquist@gmail.com>"
 
 RUN apt-get update && \
-    apt-get install -yq curl && \
-    rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
+  apt-get install -yq curl && \
+  rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
 
 ADD http://stedolan.github.io/jq/download/linux64/jq /usr/bin/jq
 RUN chmod +x /usr/bin/jq

--- a/stable/rethinkdb/init/Makefile
+++ b/stable/rethinkdb/init/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG = 0.1.0
+TAG = 2.4.0
 PREFIX = codylundquist/helm-rethinkdb-cluster
 
 buildprobe:

--- a/stable/rethinkdb/init/rethinkdb-probe/Dockerfile.build
+++ b/stable/rethinkdb/init/rethinkdb-probe/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.11.1
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
 # Build container to have a consistent go build environment

--- a/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
@@ -8,22 +8,20 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 spec:
-  serviceName: "{{ template "rethinkdb.fullname" . }}-cluster"
-  replicas: {{ .Values.cluster.replicas }}
   selector:
     matchLabels:
       app: "{{ template "rethinkdb.name" . }}-cluster"
-      heritage: {{ .Release.Service | quote }}
       release: {{ .Release.Name | quote }}
-      chart: {{ template "rethinkdb.chart" . }}
+  serviceName: "{{ template "rethinkdb.fullname" . }}-cluster"
+  replicas: {{ .Values.cluster.replicas }}
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       name: "{{ template "rethinkdb.fullname" . }}-cluster"
       labels:
         app: "{{ template "rethinkdb.name" . }}-cluster"
-        heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: {{ template "rethinkdb.chart" . }}
       annotations:
       {{- if .Values.cluster.podAnnotations }}
 {{ toYaml .Values.cluster.podAnnotations | indent 8 }}
@@ -45,6 +43,10 @@ spec:
             - "--no-http-admin"
             - "--cache-size"
             - {{ .Values.cluster.rethinkCacheSize | quote }}
+            {{- if .Values.cluster.rethinkCores }}
+            - "--cores"
+            - {{ .Values.cluster.rethinkCores | quote }}
+            {{- end }}
           volumeMounts:
             - name: "datadir"
               mountPath: "/data"
@@ -70,17 +72,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           livenessProbe:
-{{ toYaml .Values.cluster.livenessProbe | indent 12 }}          
+{{ toYaml .Values.cluster.livenessProbe | indent 12 }}
           readinessProbe:
 {{ toYaml .Values.cluster.readinessProbe | indent 12 }}
-            exec:
-              command:
-                - /rethinkdb-probe
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
           resources:
 {{ toYaml .Values.cluster.resources | indent 12 }}
 {{- if .Values.cluster.persistentVolume.enabled }}

--- a/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
@@ -8,21 +8,17 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 spec:
-  replicas: {{ .Values.proxy.replicas }}
   selector:
     matchLabels:
       app: {{ template "rethinkdb.name" . }}-proxy
-      heritage: {{ .Release.Service | quote }}
       release: {{ .Release.Name | quote }}
-      chart: {{ template "rethinkdb.chart" . }}
+  replicas: {{ .Values.proxy.replicas }}
   template:
     metadata:
       name: {{ template "rethinkdb.fullname" . }}-proxy
       labels:
         app: {{ template "rethinkdb.name" . }}-proxy
-        heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: {{ template "rethinkdb.chart" . }}
       annotations:
       {{- if .Values.proxy.podAnnotations }}
 {{ toYaml .Values.proxy.podAnnotations | indent 8 }}
@@ -43,6 +39,8 @@ spec:
           args:
             - "--bind"
             - "all"
+            - "--driver-port"
+            - "{{ .Values.ports.driver }}"
             {{- if .Values.proxy.driverTLS.enabled }}
             - "--driver-tls-key"
             - "/secrets/driver-key.pem"

--- a/stable/rethinkdb/templates/rethinkdb-proxy-service.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-service.yaml
@@ -13,8 +13,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.proxy.service.type }}
-{{- if .Values.proxy.service.clusterIP }}
-  clusterIP: {{ .Values.proxy.service.clusterIP | quote }}
+{{- if not .Values.proxy.service.omitClusterIP }}
+  {{ with .Values.proxy.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.proxy.service.externalIPs }}
   externalIPs:

--- a/stable/rethinkdb/values.yaml
+++ b/stable/rethinkdb/values.yaml
@@ -1,7 +1,7 @@
 # Specs for the RethinkDB image
 image:
   name: codylundquist/helm-rethinkdb-cluster
-  tag: 0.1.0
+  tag: 2.4.0
   pullPolicy: IfNotPresent
 
 # RethinkDB Cluster Config
@@ -30,12 +30,16 @@ cluster:
       - ReadWriteOnce
     size: 1Gi
     annotations: {}
-  # RethinkDB Cache Size in MB
+  # RethinkDB: Cache Size in MB
   rethinkCacheSize: 100
+  # RethinkDB: Number of Cores to use. If left blank,
+  # RethinkDB uses the number of available cores
+  rethinkCores:
+
   livenessProbe:
     exec:
       command:
-        - /rethinkdb-probe
+      - /rethinkdb-probe
     failureThreshold: 3
     initialDelaySeconds: 15
     periodSeconds: 10
@@ -44,7 +48,7 @@ cluster:
   readinessProbe:
     exec:
       command:
-        - /rethinkdb-probe
+      - /rethinkdb-probe
     failureThreshold: 3
     initialDelaySeconds: 15
     periodSeconds: 10
@@ -65,7 +69,9 @@ proxy:
   service:
     annotations: {}
     type: ClusterIP
-    clusterIP: ""
+    omitClusterIP: true
+    # clusterIP: ""
+
     # List of IP addresses at which the proxy service is available
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     #


### PR DESCRIPTION
Signed-off-by: Cody Lundquist <cody.lundquist@gmail.com>


#### Is this a new chart
No

#### What this PR does / why we need it:
This PR does the following things:
 1. Updates the docker image for RethinkDB to 2.4.0
 1. Introduces a new param to set the `--cores` value when initializing the RethinkDB cluster
 1. Removes a couple of selectors from the StatefulSet and Deployment config so that you can more easily update them in the future when the version of the chart changes.  Once they are initially set, K8s will not let you change them again unless you force it to.
 1. Because of change #3, I have bumped the chart version to a new major version and have aligned it with the `appVersion`. I'm not sure if it's best practice to align it with the `appVersion`, but it does need to be bumped up another major version. Someone else can make the call if I should lower the `version` to just `2.0.0`.
 1. Some small syntax fixes and reformatting

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
