### PR TITLE
[stable/jenkins] Added backup service account annotations and pod securitycontext

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -591,6 +591,9 @@ Adds a backup CronJob for jenkins, along with required RBAC resources.
 | `backup.env`                             | Backup environment variables                                      | `[]`                              |
 | `backup.resources`                       | Backup CPU/Memory resource requests/limits                        | Memory: `1Gi`, CPU: `1`           |
 | `backup.destination`                     | Destination to store backup artifacts                             | `s3://jenkins-data/backup`        |
+| `backup.usePodSecurityContext`           | Enable pod security context (must be `true` if `runAsUser` or `fsGroup` are set) | `true` |
+| `backup.runAsUser`                | uid that jenkins runs with           | `1000`                                    |
+| `backup.fsGroup`                  | uid that will be used for persistent volume | `1000`                             |
 
 ### Restore from backup
 

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -97,6 +97,15 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+{{- if .Values.backup.usePodSecurityContext }}
+          securityContext:
+            runAsUser: {{ default 0 .Values.backup.runAsUser }}
+{{- if and (.Values.backup.runAsUser) (.Values.backup.fsGroup) }}
+{{- if not (eq (int .Values.backup.runAsUser) 0) }}
+            fsGroup: {{ .Values.backup.fsGroup }}
+{{- end }}
+{{- end }}
+{{- end }}
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:

--- a/stable/jenkins/templates/jenkins-backup-rbac.yaml
+++ b/stable/jenkins/templates/jenkins-backup-rbac.yaml
@@ -10,6 +10,10 @@ metadata:
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
+  {{- if .Values.backup.annotations }}
+  annotations: 
+{{ toYaml .Values.backup.annotations | indent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Ive checked this on my local project and it works fine, adds annotation to the service account Jenkins-backup and sets proper securitycontext to the backup pod.

#### What this PR does / why we need it: Adds annotations to the jenkins-backup service account and securitycontext runAsUser and fsGroup to the pod generated by backup Cronjob

#### Which issue this PR fixes
  - fixes 22670

#### Special notes for your reviewer:

This is my first PR so dunno if ive done everything right, please guide me if there is something wrong. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@torstenwalter New PR regarding the old one (https://github.com/helm/charts/pull/22730) that had some issues along the way with signoff. Hope this one will be ok ? 