### PR TITLE
[stable/opa] Adding imagePullSecret to OPA

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.14.2
+version: 1.14.3
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
         app: {{ template "opa.fullname" . }}
       name: {{ template "opa.fullname" . }}
     spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+{{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -109,6 +109,10 @@ image: openpolicyagent/opa
 imageTag: 0.15.1
 imagePullPolicy: IfNotPresent
 
+# One or more secrets to be used when pulling images
+imagePullSecrets: []
+# - registrySecretName
+
 # Port to which the opa pod will bind itself
 # NOTE IF you use a different port make sure it maches the ones in the readinessProbe
 # and livenessProbe


### PR DESCRIPTION
Signed-off-by: Armin <armin@coralic.nl>
#### What this PR does / why we need it:
Adding the `imagePullSecrets` to the OPA deployments to allow authenticated Docker registries.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
