### PR TITLE
[incubator/aws-alb-ingress-controller] Add imagePullSecretes to aws-alb-ingress-controller

### DIFF
--- a/incubator/aws-alb-ingress-controller/Chart.yaml
+++ b/incubator/aws-alb-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-alb-ingress-controller
 description: A Helm chart for AWS ALB Ingress Controller
-version: 1.0.2
+version: 1.0.1
 appVersion: "v1.1.8"
 engine: gotpl
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller

--- a/incubator/aws-alb-ingress-controller/templates/deployment.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/deployment.yaml
@@ -23,6 +23,12 @@ spec:
       annotations: {{ toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: "{{ . }}"
       {{- end }}

--- a/incubator/aws-alb-ingress-controller/values.yaml
+++ b/incubator/aws-alb-ingress-controller/values.yaml
@@ -82,6 +82,10 @@ image:
   tag: "v1.1.8"
   pullPolicy: IfNotPresent
 
+# One or more secrets to be used when pulling images
+imagePullSecrets: []
+# - registrySecretName
+
 replicaCount: 1
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Signed-off-by: Armin <armin@coralic.nl>

#### What this PR does / why we need it:
Adding the imagePullSecrets to the aws-alb-ingress-controller deployments to allow authenticated Docker registries.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
