### PR TITLE
[stable/nextcloud] deprecate nextcloud helm chart

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.12.0
+version: 1.12.1
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
@@ -13,8 +13,4 @@ home: https://nextcloud.com/
 icon: https://cdn.rawgit.com/docker-library/docs/defa5ffc7123177acd60ddef6e16bddf694cc35f/nextcloud/logo.svg
 sources:
 - https://github.com/nextcloud/docker
-maintainers:
-- name: chrisingenhaag
-  email: christian.ingenhaag@googlemail.com
-- name: billimek
-  email: jeff@billimek.com
+deprecated: true

--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 name: nextcloud
 version: 1.12.1
 appVersion: 17.0.0
-description: A file sharing server that puts the control and security of your own data back into your hands.
+# The nextcloud chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
+description: DEPRECATED - A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - nextcloud
 - storage

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -1,4 +1,9 @@
-# nextcloud
+# DEPRECATED - nextcloud
+
+|**This chart has been deprecated and moved to its new home:**
+|
+|- **GitHub repo:** https://github.com/nextcloud/helm/tree/master/charts/nextcloud
+|- **Charts repo:** https://nextcloud.github.io/helm/
 
 [nextcloud](https://nextcloud.com/) is a file sharing server that puts the control and security of your own data back into your hands.
 

--- a/stable/nextcloud/templates/NOTES.txt
+++ b/stable/nextcloud/templates/NOTES.txt
@@ -1,3 +1,8 @@
+This Helm chart is deprecated
+
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Nextcloud maintained Helm chart is now located at nextcloud/helm (https://github.com/nextcloud/helm/tree/master/charts/nextcloud).
+
+
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 {{- if empty .Values.nextcloud.host -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This deprecates the nextcloud chart and references the new home.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
