### PR TITLE
[stable/presto] add graceful shutdown in presto workers

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 329
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.2.1
+version: 0.2.2
 home: https://prestosql.io
 icon: https://prestosql.io/docs/current/_static/presto.png
 sources:

--- a/stable/presto/README.md
+++ b/stable/presto/README.md
@@ -22,24 +22,25 @@ $ helm install --name my-release stable/presto
 
 Configurable values are documented in the `values.yaml`:
 
-| Parameter                               | Description                                                                 | Default                  |
-|-----------------------------------------|-----------------------------------------------------------------------------|--------------------------|
-| `server.workers`                        | Numbers of prestosql worker nodes.                                          | `2`                      |
-| `server.node.environment`               | The name of the environment.                                                | `production`             |
-| `server.node.dataDir`                   | The location (filesystem path) of the data directory.                       | `/data/presto`           |
-| `server.note.pluginDir`                 | The location of the plugin directory.                                       | `/usr/lib/presto/plugin` |
-| `server.log.presto.level`               | The minimum log level of named logger `io.prestosql`.                       | `INFO`                   |
-| `server.config.path`                    | The location of customize configuration.                                    | `/usr/lib/presto/etc`    |
-| `server.config.http.port`               | The port number of coordinator service                                      | `8080`                   |
-| `server.config.query.maxMemory`         | The maximum amount of distributed memory, that a query may use.             | `4GB`                    |
+| Parameter                               | Description                                                  | Default                  |
+| --------------------------------------- | ------------------------------------------------------------ | ------------------------ |
+| `server.workers`                        | Numbers of prestosql worker nodes.                           | `2`                      |
+| `server.node.environment`               | The name of the environment.                                 | `production`             |
+| `server.node.dataDir`                   | The location (filesystem path) of the data directory.        | `/data/presto`           |
+| `server.note.pluginDir`                 | The location of the plugin directory.                        | `/usr/lib/presto/plugin` |
+| `server.log.presto.level`               | The minimum log level of named logger `io.prestosql`.        | `INFO`                   |
+| `server.config.path`                    | The location of customize configuration.                     | `/usr/lib/presto/etc`    |
+| `server.config.http.port`               | The port number of coordinator service                       | `8080`                   |
+| `server.config.query.maxMemory`         | The maximum amount of distributed memory, that a query may use. | `4GB`                    |
 | `server.config.query.maxMemoryPerNode`  | The maximum amount of user memory, that a query may use on any one machine. | `1GB`                    |
-| `server.jvm.maxHeapSize`                | The value for JVM option `-Xmx`                                             | `8G`                     |
-| `server.jvm.gcMethod.type`              | Portion of the value for JVM option `-XX:`                                  | `UseG1GC`                |
-| `server.jvm.gcMethod.g1.heapRegionSize` | The value for JVM option `-XX:G1HeapRegionSize=`                            | `32M`                    |
-| `image.repository`                      | `prestosql` image repository.                                               | `prestosql/presto`       |
-| `image.tag`                             | `prestosql` image tag.                                                      | `329`                    |
-| `image.securityContext.runAsUser`       | The `uid` of `prestosql` image repository.                                  | `1000`                   |
-| `image.securityContext.runAsGroup`      | The `gid` of `prestosql` image repository.                                  | `1000`                   |
+| `server.jvm.maxHeapSize`                | The value for JVM option `-Xmx`                              | `8G`                     |
+| `server.jvm.gcMethod.type`              | Portion of the value for JVM option `-XX:`                   | `UseG1GC`                |
+| `server.jvm.gcMethod.g1.heapRegionSize` | The value for JVM option `-XX:G1HeapRegionSize=`             | `32M`                    |
+| server.shutdownGracePeriod              | The grace period of shutting down presto workers (in seconds) | `600`                    |
+| `image.repository`                      | `prestosql` image repository.                                | `prestosql/presto`       |
+| `image.tag`                             | `prestosql` image tag.                                       | `329`                    |
+| `image.securityContext.runAsUser`       | The `uid` of `prestosql` image repository.                   | `1000`                   |
+| `image.securityContext.runAsGroup`      | The `gid` of `prestosql` image repository.                   | `1000`                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/presto/templates/configmap-worker.yaml
+++ b/stable/presto/templates/configmap-worker.yaml
@@ -40,5 +40,19 @@ data:
     #!/bin/bash 
     curl --silent {{ template "presto.fullname" . }}:{{ .Values.server.config.http.port }}/v1/node | tr "," "\n" | grep --silent $(hostname -i)
 
+    graceful_shutdown.sh: |
+    #!/bin/bash
+    curl -v -XPUT -d "\"SHUTTING_DOWN\"" --header "Content-Type: application/json" localhost:8080/v1/info/state
+    zeroTasks="0"
+    while true
+      do
+        tasks=$(curl localhost:8080/v1/task | python -c 'import json,sys;obj=json.load(sys.stdin);print(len(filter(lambda x: x["taskStatus"]["state"]=="RUNNING", obj)))')
+        if [ "$tasks" = "$zeroTasks" ]; then
+          exit 0
+        else
+          sleep 30
+        fi
+      done
+
 ---
 {{- end }}

--- a/stable/presto/templates/deployment-worker.yaml
+++ b/stable/presto/templates/deployment-worker.yaml
@@ -27,6 +27,7 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "presto.worker" . }}
+      terminationGracePeriodSeconds: {{ .Values.server.shutdownGracePeriod }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -34,6 +35,12 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - {{ .Values.server.config.path }}/graceful_shutdown.sh
           livenessProbe:
             exec:
               command:

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -1,5 +1,6 @@
 server:
   workers: 2
+  shutdownGracePeriod: 600
   node:
     environment: production
     dataDir: /data/presto


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR adds graceful shutdown in presto workers so running queries don't get killed because of scale in and scale out.


#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
