### PR TITLE
[stable/grafana] Make extraVolumeMounts[].existingClaim optional

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.5.5
+version: 5.5.6
 appVersion: 7.1.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -206,6 +206,23 @@ ingress:
     readOnly: false
 ```
 
+### Example of extraVolumeMounts with extraContainerVolumes
+
+If you want to trust system's certificates in Grafana, so that you can add SSL URIs to your datasources for example,
+you can use a construction like this:
+
+```yaml
+extraVolumeMounts:
+- name: etc-ssl-certs
+  mountPath: /etc/ssl/certs
+
+extraContainerVolumes:
+- name: etc-ssl-certs
+  hostPath:
+    path: /etc/ssl/certs
+    type: Directory
+```
+
 ## Import dashboards
 
 There are a few methods to import dashboards to Grafana. Below are some examples and explanations as to how to use each method:

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -434,9 +434,11 @@ volumes:
       defaultMode: {{ .defaultMode }}
 {{- end }}
 {{- range .Values.extraVolumeMounts }}
+  {{- if .existingClaim }}
   - name: {{ .name }}
     persistentVolumeClaim:
       claimName: {{ .existingClaim }}
+  {{- end }}
 {{- end }}
 {{- range .Values.extraEmptyDirMounts }}
   - name: {{ .name }}


### PR DESCRIPTION
Make `extraVolumeMounts[].existingClaim` optional so that `extraVolumeMounts` can be used in conjunction with `extraContainerVolumes`. Also, provide an example in `README.md` on how to use both, in order to trust system certificates in the Grafana container.

Signed-off-by: Catalin Cirstoiu <Catalin.Cirstoiu@gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
