### PR TITLE
[stable/chartmuseum] fixed name of service account

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.13.2
+version: 2.13.3
 appVersion: 0.12.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -163,7 +163,9 @@ spec:
     {{- if .Values.deployment.schedulerName }}
       schedulerName: {{ .Values.deployment.schedulerName }}
     {{- end -}}
-    {{- if .Values.serviceAccount.create }}
+    {{- if and .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+    {{- else if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "chartmuseum.fullname" . }}
     {{- else if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/stable/chartmuseum/templates/serviceaccount.yaml
+++ b/stable/chartmuseum/templates/serviceaccount.yaml
@@ -3,7 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{- else }}
   name: {{ include "chartmuseum.fullname" . }}
+{{- end }}
   labels:
 {{ include "chartmuseum.labels.standard" . | indent 4 }}
 {{- if .Values.serviceAccount.annotations }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

There is a bug in the chart museum helm chart. There is a value `Values.serviceAccount.name` that allows you to specify the name of your service account. This is important because the name of the service account needs to be known for IRSA role mapping. However, the helm chart always defaults to `{{ include "chartmuseum.fullname" . }}`.

This PR solves this with the usual conditional logic for these values.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
