### PR TITLE
[incubator/gogs] Gogs update patch for Kubernetes 1.16 and up

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.7.11
-appVersion: 0.11.86
+version: 0.7.12
+appVersion: 0.12.0
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico
 maintainers:

--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -8,5 +8,6 @@ icon: https://gogs.io/img/favicon.ico
 maintainers:
   - name: obeyler
   - name: poblin-orange
+  - name: alexmirkhaydarov
 keywords:
 - git

--- a/incubator/gogs/OWNERS
+++ b/incubator/gogs/OWNERS
@@ -1,6 +1,8 @@
 approvers:
 - obeyler
 - poblin-orange
+- alexmirkhaydarov
 reviewers:
 - obeyler
 - poblin-orange
+- alexmirkhaydarov

--- a/incubator/gogs/requirements.lock
+++ b/incubator/gogs/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.6.0
-digest: sha256:711e4e8a93ba272728e7f04b65f8f3345b6bae19f83cf3d53b9fc844ef6309d5
-generated: 2017-11-25T16:04:31.861896792+01:00
+  version: 8.6.4
+digest: sha256:c6a166f2760c0a0a07be70588512d47be6dc04eed0b369b82c4a44c22d528622
+generated: "2020-08-25T20:20:43.200715+01:00"

--- a/incubator/gogs/requirements.lock
+++ b/incubator/gogs/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 8.6.4
 digest: sha256:c6a166f2760c0a0a07be70588512d47be6dc04eed0b369b82c4a44c22d528622
-generated: "2020-08-25T20:20:43.200715+01:00"
+generated: "2020-09-02T20:29:05.697325+01:00"

--- a/incubator/gogs/requirements.lock
+++ b/incubator/gogs/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.6.4
-digest: sha256:c6a166f2760c0a0a07be70588512d47be6dc04eed0b369b82c4a44c22d528622
-generated: "2020-09-02T20:29:05.697325+01:00"

--- a/incubator/gogs/requirements.yaml
+++ b/incubator/gogs/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: 0.6.0
+    version: 8.6.4
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.install

--- a/incubator/gogs/templates/_helpers.tpl
+++ b/incubator/gogs/templates/_helpers.tpl
@@ -91,20 +91,12 @@ Determine database SSL mode based on use of postgresql dependency.
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
 {{- end -}}

--- a/incubator/gogs/templates/_helpers.tpl
+++ b/incubator/gogs/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Determine database name based on use of postgresql dependency.
 */}}
 {{- define "gogs.database.name" -}}
 {{- if .Values.postgresql.install -}}
-{{- .Values.postgresql.postgresDatabase | quote -}}
+{{- .Values.postgresql.postgresqlDatabase | quote -}}
 {{- else -}}
 {{- .Values.service.gogs.databaseName | quote -}}
 {{- end -}}

--- a/incubator/gogs/templates/_helpers.tpl
+++ b/incubator/gogs/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Determine database user based on use of postgresql dependency.
 */}}
 {{- define "gogs.database.user" -}}
 {{- if .Values.postgresql.install -}}
-{{- .Values.postgresql.postgresUser | quote -}}
+{{- .Values.postgresql.postgresqlUsername | quote -}}
 {{- else -}}
 {{- .Values.service.gogs.databaseUser | quote -}}
 {{- end -}}
@@ -59,7 +59,7 @@ Determine database password based on use of postgresql dependency.
 */}}
 {{- define "gogs.database.password" -}}
 {{- if .Values.postgresql.install -}}
-{{- .Values.postgresql.postgresPassword | quote -}}
+{{- .Values.postgresql.postgresqlPassword | quote -}}
 {{- else -}}
 {{- .Values.service.gogs.databasePassword | quote -}}
 {{- end -}}

--- a/incubator/gogs/templates/_helpers.tpl
+++ b/incubator/gogs/templates/_helpers.tpl
@@ -86,3 +86,25 @@ Determine database SSL mode based on use of postgresql dependency.
 {{- .Values.service.gogs.databaseSSLMode | quote -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "common.capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gogs.fullname" . }}

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "gogs.fullname" . }}

--- a/incubator/gogs/templates/ingress.yaml
+++ b/incubator/gogs/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := default "gogs" .Values.service.nameOverride -}}
 {{- $httpPort := .Values.service.httpPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "gogs.gogs.fullname" . }}

--- a/incubator/gogs/templates/ingress.yaml
+++ b/incubator/gogs/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := default "gogs" .Values.service.nameOverride -}}
 {{- $httpPort := .Values.service.httpPort -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "gogs.gogs.fullname" . }}

--- a/incubator/gogs/templates/secrets.yaml
+++ b/incubator/gogs/templates/secrets.yaml
@@ -9,4 +9,4 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  postgresql-user: {{ .Values.postgresql.postgresUser | b64enc | quote }}
+  postgresql-user: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -358,16 +358,21 @@ postgresql:
 
   ### PostgreSQL User to create.
   ##
-  postgresUser: gogs
+  postgresqlUsername: gogs
 
   ## PostgreSQL Password for the new user.
   ## If not set, a random 10 characters password will be used.
   ##
-  postgresPassword: gogs
+  postgresqlPassword: gogs
+
+  ## PostgreSQL admin password
+  ## (used when postgresqlUsername is not postgres)
+  ##
+  postgresqlPostgresPassword: gogs
 
   ## PostgreSQL Database to create.
   ##
-  postgresDatabase: gogs
+  postgresqlDatabase: gogs
 
   ## PostgreSQL SSL Mode
   ##

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 1
 
 image:
   repository: gogs/gogs
-  tag: 0.11.86
+  tag: 0.12.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The `extensions/v1beta1` was removed in K8s 1.16 and up.

apiVersion updated from `extensions/v1beta1` to `apps/v1` in `Deployment` and `networking.k8s.io/v1beta1` in `Ingress`
postgresql dependecy upgraded from `0.6.0` to `8.6.4`

Source: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Which issue this PR fixes
  - fixes #21694

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
