### PR TITLE
[incubator/jenkins-operator]: Deprecate the chart

### DIFF
--- a/incubator/jenkins-operator/Chart.yaml
+++ b/incubator/jenkins-operator/Chart.yaml
@@ -12,4 +12,4 @@ home: https://github.com/samsung-cnct/jenkins-operator
 sources:
 - https://github.com/samsung-cnct/jenkins-operator
 - https://github.com/jenkinsci/jenkins
-maintainers:
+maintainers: []

--- a/incubator/jenkins-operator/Chart.yaml
+++ b/incubator/jenkins-operator/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 appVersion: 0.3.0
 description: "DEPRECATED: A Helm chart for Kubernetes Jenkins Operator"
+# See https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
 deprecated: true
 name: jenkins-operator
 version: 0.3.1

--- a/incubator/jenkins-operator/Chart.yaml
+++ b/incubator/jenkins-operator/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 appVersion: 0.3.0
-description: A Helm chart for Kubernetes Jenkins Operator
+description: "DEPRECATED: A Helm chart for Kubernetes Jenkins Operator"
+deprecated: true
 name: jenkins-operator
-version: 0.3.0
+version: 0.3.1
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
 keywords:
 - jenkins
@@ -12,5 +13,3 @@ sources:
 - https://github.com/samsung-cnct/jenkins-operator
 - https://github.com/jenkinsci/jenkins
 maintainers:
-- name: maratoid
-  email: maratoid@gmail.com

--- a/incubator/jenkins-operator/README.md
+++ b/incubator/jenkins-operator/README.md
@@ -1,4 +1,6 @@
-# DEPRECATED: Please consider using https://github.com/jenkinsci/kubernetes-operator
+# ⚠️ DEPRECATED
+
+Please consider using https://github.com/jenkinsci/kubernetes-operator. See https://jenkinsci.github.io/kubernetes-operator/docs/installation/#using-helm-chart for instructions.
 # Jenkins Operator
 
 [jenkins-operator](https://github.com/samsung-cnct/jenkins-operator) simplifies

--- a/incubator/jenkins-operator/README.md
+++ b/incubator/jenkins-operator/README.md
@@ -1,3 +1,4 @@
+# DEPRECATED: Please consider using https://github.com/jenkinsci/kubernetes-operator
 # Jenkins Operator
 
 [jenkins-operator](https://github.com/samsung-cnct/jenkins-operator) simplifies

--- a/incubator/jenkins-operator/templates/NOTES.txt
+++ b/incubator/jenkins-operator/templates/NOTES.txt
@@ -1,3 +1,12 @@
+**************
+* DEPRECATED *
+**************
+
+Please consider using https://github.com/jenkinsci/kubernetes-operator.
+See https://jenkinsci.github.io/kubernetes-operator/docs/installation/#using-helm-chart for instructions.
+
+**************
+
 1.  jenkins-operator deployed.
 
     Check the jenkins-operator logs:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Deprecate the chart in favor of whatever official JenkinsCI kubernetes operator uses.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
