### PR TITLE
[stable/vsphere-cpi] Update for CPI v1.2.1

### DIFF
--- a/stable/vsphere-cpi/Chart.yaml
+++ b/stable/vsphere-cpi/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.1.0
+appVersion: 1.2.1
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: vsphere-cpi
-version: 0.1.3
+version: 0.2.0
 keywords:
   - vsphere
   - vmware

--- a/stable/vsphere-cpi/README.md
+++ b/stable/vsphere-cpi/README.md
@@ -66,12 +66,12 @@ The following table lists the configurable parameters of the vSphere CPI chart a
 
 |             Parameter                    |            Description              |                  Default               |
 |------------------------------------------|-------------------------------------|----------------------------------------|
-| `podSecurityPolicy.enabled`              | Enable pod sec policy (k8s > 1.17)  |  false                                 |
+| `podSecurityPolicy.enabled`              | Enable pod sec policy (k8s > 1.17)  |  true                                  |
 | `podSecurityPolicy.annotations`          | Annotations for pd sec policy       |  nil                                   |
 | `securityContext.enabled`                | Enable sec context for container    |  false                                 |
-| `securityContext.runAsUser`              | RunAsUser. Default is `nobody` in   |  65534                                 |
+| `securityContext.runAsUser`              | RunAsUser. Default is `nobody` in   |  1001                                 |
 |                                          |    distroless image                 |                                        |
-| `securityContext.fsGroup`                | FsGroup. Default is `nobody` in     |  65534                                 |
+| `securityContext.fsGroup`                | FsGroup. Default is `nobody` in     |  1001                                 |
 |                                          |    distroless image                 |                                        |
 | `config.enabled`                         | Create a simple single VC config    |  false                                 |
 | `config.vcenter`                         | FQDN or IP of vCenter               |  vcenter.local                         |

--- a/stable/vsphere-cpi/templates/common.yaml
+++ b/stable/vsphere-cpi/templates/common.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: common-configmap
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: cloud-controller
+    component: cloud-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/stable/vsphere-cpi/templates/configmap.yaml
+++ b/stable/vsphere-cpi/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.enabled -}}
+{{- if .Values.config.enabled | default .Values.global.config.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,15 +13,19 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   vsphere.conf: |
-    [Global]
-    # properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
-    port = "443" #Optional
-    insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
-    # settings for using k8s secret
-    secret-name = "vsphere-cpi"
-    secret-namespace = "{{ .Release.Namespace }}"
+    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    global:
+      port: 443
+      # set insecure-flag to true if the vCenter uses a self-signed cert
+      insecureFlag: true
+      # settings for using k8s secret
+      secretName: vsphere-cpi
+      secretNamespace: {{ .Release.Namespace }}
 
-    [VirtualCenter "{{ .Values.config.vcenter }}"]
-    datacenters = "{{ .Values.config.datacenter }}"
-    # port, insecure-flag will be used from Global section.
+    # VirtualCenter section
+    vcenter:
+      {{ .Release.Name }}:
+        server: {{ .Values.config.vcenter | default .Values.global.config.vcenter }}
+        datacenters:
+          - {{ .Values.config.datacenter | default .Values.global.config.datacenter }}
 {{- end -}}

--- a/stable/vsphere-cpi/templates/daemonset.yaml
+++ b/stable/vsphere-cpi/templates/daemonset.yaml
@@ -6,14 +6,16 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: daemonset
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: cloud-controller
+    component: cloud-controller-manager
+    tier: control-plane
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-{{- if .Values.daemonset.annotations }}
   annotations:
-{{ toYaml .Values.daemonset.annotations | indent 4 }}
-{{- end }}
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+    {{- if .Values.daemonset.annotations }}
+    {{- toYaml .Values.daemonset.annotations | indent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -22,46 +24,44 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-{{- if .Values.daemonset.podAnnotations }}
+      {{- if .Values.daemonset.podAnnotations }}
       annotations:
-{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
-{{- end }}
+      {{- toYaml .Values.daemonset.podAnnotations | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "cpi.name" . }}
-        component: cloud-controller
+        component: cloud-controller-manager
+        tier: control-plane
         release: {{ .Release.Name }}
         vsphere-cpi-infra: daemonset
-{{- if .Values.daemonset.podLabels }}
-{{ toYaml .Values.daemonset.podLabels | indent 8 }}
-{{- end }}
+        {{- if .Values.daemonset.podLabels }}
+        {{- toYaml .Values.daemonset.podLabels | indent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
-{{- if .Values.daemonset.nodeSelector }}
-{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
-{{- else }}
         node-role.kubernetes.io/master: ""
-{{- end }}
-      securityContext:
-        runAsUser: 0
+      {{- if .Values.daemonset.nodeSelector }}
+      {{- toYaml .Values.daemonset.nodeSelector | indent 8 }}
+      {{- end }}
       tolerations:
-{{- if .Values.daemonset.tolerations }}
-{{ toYaml .Values.daemonset.tolerations | indent 8 }}
-{{- else }}
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
- {{- end }}
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
+        operator: Exists
+      {{- if .Values.daemonset.tolerations }}
+      {{- toYaml .Values.daemonset.tolerations | indent 8 }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- if .Values.daemonset.useHostNetwork }}
       hostNetwork: true
-      {{- end }}
       dnsPolicy: {{ .Values.daemonset.dnsPolicy }}
       containers:
       - name: {{ template "cpi.name" . }}
@@ -91,8 +91,10 @@ spec:
           - mountPath: {{ .Values.daemonset.cmdline.cloudConfig.dir }}
             name: vsphere-config-volume
             readOnly: true
+        {{- if .Values.daemonset.resources }}
         resources:
-{{ toYaml .Values.daemonset.resources | indent 10 }}
+          {{- toYaml .Values.daemonset.resources | indent 10 }}
+        {{- end }}
       volumes:
         - name: vsphere-config-volume
           configMap:

--- a/stable/vsphere-cpi/templates/ingress.yaml
+++ b/stable/vsphere-cpi/templates/ingress.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ingress.enabled -}}
-{{- $servicePort := .Values.service.endpointPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -14,7 +13,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if .Values.ingress.annotations }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{- toYaml .Values.ingress.annotations | indent 4 }}
   {{- end }}
 spec:
   rules:
@@ -25,10 +24,10 @@ spec:
           - path: /
             backend:
               serviceName: {{ template "cpi.name" $ }}
-              servicePort: {{ $servicePort }}
+              servicePort: {{ .Values.service.endpointPort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- toYaml .Values.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/stable/vsphere-cpi/templates/podsecuritypolicy.yaml
+++ b/stable/vsphere-cpi/templates/podsecuritypolicy.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ template "cpi.name" . }}
   labels:
     app: {{ template "cpi.name" . }}
-    component: cloud-controller
-    release: {{ .Release.Name }}
     vsphere-cpi-infra: pod-security-policy
-{{- if .Values.podSecurityPolicy.annotations }}
+    component: cloud-controller-manager
+    release: {{ .Release.Name }}
+  {{- if .Values.podSecurityPolicy.annotations }}
   annotations:
-{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
-{{- end }}
+  {{- toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+  {{- end }}
 spec:
   allowPrivilegeEscalation: false
   privileged: false

--- a/stable/vsphere-cpi/templates/role-binding.yaml
+++ b/stable/vsphere-cpi/templates/role-binding.yaml
@@ -11,7 +11,7 @@ items:
       app: {{ template "cpi.name" . }}
       vsphere-cpi-infra: role-binding
       chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      component: cloud-controller
+      component: cloud-controller-manager
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
     namespace: {{ .Release.Namespace }}
@@ -30,18 +30,18 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
-    name: system:{{ .Values.serviceAccount.name }}
+    name: {{ .Values.serviceAccount.name }}
     labels:
       app: {{ template "cpi.name" . }}
       vsphere-cpi-infra: cluster-role-binding
       chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      component: cloud-controller
+      component: cloud-controller-manager
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: system:{{ .Values.serviceAccount.name }}
+    name: {{ .Values.serviceAccount.name }}
   subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}

--- a/stable/vsphere-cpi/templates/role.yaml
+++ b/stable/vsphere-cpi/templates/role.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:{{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
   labels:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: role
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: cloud-controller
+    component: cloud-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:
@@ -40,6 +40,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/stable/vsphere-cpi/templates/secret.yaml
+++ b/stable/vsphere-cpi/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.enabled -}}
+{{- if .Values.config.enabled | default .Values.global.config.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,11 +7,11 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: secret
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: cloud-controller
+    component: cloud-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-data:
-  {{ .Values.config.vcenter }}.username: {{ .Values.config.username | b64enc }}
-  {{ .Values.config.vcenter }}.password: {{ .Values.config.password | b64enc }}
+stringData:
+  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.username: {{ .Values.config.username | default .Values.global.config.username }}
+  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.password: {{ .Values.config.password | default .Values.global.config.password }}
 {{- end -}}

--- a/stable/vsphere-cpi/templates/service-account.yaml
+++ b/stable/vsphere-cpi/templates/service-account.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: service-account
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: cloud-controller
+    component: cloud-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/stable/vsphere-cpi/templates/service.yaml
+++ b/stable/vsphere-cpi/templates/service.yaml
@@ -7,14 +7,14 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: cloud-controller
+    component: cloud-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-{{- if .Values.service.annotations }}
+  {{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+  {{- toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   ports:
   - name: cpi-api
@@ -23,9 +23,8 @@ spec:
     targetPort: {{ .Values.service.targetPort }}
   selector:
     app: {{ template "cpi.name" . }}
-    component: cloud-controller
-    release: {{ .Release.Name }}
-    vsphere-cpi-infra: vsphere-cpi-daemonset
+    vsphere-cpi-infra: service
+    component: cloud-controller-manager
   type: {{ .Values.service.type }}
 {{- template "loadBalancerSourceRanges" .Values }}
 {{- end -}}

--- a/stable/vsphere-cpi/values.yaml
+++ b/stable/vsphere-cpi/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # vSohere CPI values are grouped by component
 
+global:
+  config:
+    enabled: false
+
 config:
   enabled: false
   vcenter: "vcenter.local"
@@ -25,9 +29,9 @@ podSecurityPolicy:
 
 # Run containers to have security context. Default is 'nobody' (65534/65534) in distroless
 securityContext:
-  enabled: false
-  runAsUser: 65534
-  fsGroup: 65534
+  enabled: true
+  runAsUser: 1001
+  fsGroup: 1001
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -42,7 +46,7 @@ serviceAccount:
 daemonset:
   annotations: {}
   image: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  tag: v1.1.0
+  tag: v1.2.1
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdline:


### PR DESCRIPTION
## What this PR does / why we need it:
This PR makes the following updates:
- bumps the version of the CPI chart to the latest release v1.2.0 (https://github.com/kubernetes/cloud-provider-vsphere/releases/tag/v1.2.1)
- When the option to generate the configmap is selected, the YAML based cloud-config is generated instead of INI
- updates to RBAC needed for CPI
- uses stringdata instead of base64 encoding secret data
- the security context is set to `true` now and the runAs is set to the new non-root user 1001 as supported in the CPI image
- `useHostNetwork: true` is default set to true

#### Which issue this PR fixes
NA

#### Special notes for your reviewer:
Tested using on vSphere 7.0:
- configmap generation
- provided my own configmap

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
