### PR TITLE
[stable/seq] Add an easy way to set the cache size limit

### DIFF
--- a/stable/seq/Chart.yaml
+++ b/stable/seq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: seq
-version: 2.2.0
+version: 2.3.0
 appVersion: 2020
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:

--- a/stable/seq/README.md
+++ b/stable/seq/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the Seq chart and their
 | `persistence.accessMode`             | ReadWriteOnce or ReadOnly                                                                             | `ReadWriteOnce`                       |
 | `persistence.subPath`                | Mount a sub directory of the persistent volume if set                                                 | `""`                                  |
 | `resources`                          | CPU/Memory resource requests/limits                                                                   | `{}`                                  |
+| `cache.targetSize`                   | The target amount of RAM to use for the in-memory cache                                               | `0.7`                                 |
 | `nodeSelector`                       | Node labels for pod assignment                                                                        | `{}`                                  |
 | `affinity`                           | Affinity settings for pod assignment                                                                  | `{}`                                  |
 | `tolerations`                        | Toleration labels for pod assignment                                                                  | `[]`                                  |

--- a/stable/seq/templates/deployment.yaml
+++ b/stable/seq/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
             - name: "BASE_URI"
               value: "{{ .Values.baseURI }}"
 {{- end }}
+            - name: "SEQ_CACHE_SYSTEMRAMTARGET"
+              value: "{{ .Values.cache.targetSize }}"
           ports:
             - name: ingestion
               containerPort: 5341

--- a/stable/seq/values.yaml
+++ b/stable/seq/values.yaml
@@ -66,16 +66,19 @@ ingress:
   #      - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # We recommend uncommenting these and specifying an explicit memory limit that
+  # suits your workload.
   # limits:
-  #  cpu: 100m
   #  memory: 256Mi
   # requests:
-  #  cpu: 100m
   #  memory: 256Mi
+
+cache:
+  # The fraction of RAM that the cache should try fit within. Specifying a larger
+  # value may allow more events in RAM at the expense of potential instability.
+  # Setting it to `0` will disable the cache completely.
+  # 70% (`0.7`) is a good starting point for machines with up to ~8GB of RAM.
+  targetSize: 0.7
 
 nodeSelector: {}
 


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Surfaces the `cache.systemRamTarget` configuration variable with a reasonably conservative default value for Kubernetes so that users experiencing any instability can tweak the value.

Also updates our recommendations around the `resources` confiruation.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
