### PR TITLE
[stable/prometheus] Unify labels and annotations

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.12.0
+version: 11.13.0
 appVersion: 2.20.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -161,9 +161,12 @@ Parameter | Description | Default
 `alertmanager.persistentVolume.subPath` | Subdirectory of alertmanager data Persistent Volume to mount | `""`
 `alertmanager.podAnnotations` | annotations to be added to alertmanager pods | `{}`
 `alertmanager.podLabels` | labels to be added to Prometheus AlertManager pods | `{}`
-`alertmanager.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
+`alertmanager.deploymentAnnotations` | annotations to be added to alertmanager deployment | `{}`
+`alertmanager.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
 `alertmanager.replicaCount` | desired number of alertmanager pods | `1`
 `alertmanager.statefulSet.enabled` | If true, use a statefulset instead of a deployment for pod management | `false`
+`alertmanager.statefulSet.annotations` | annotations to be added to alertmanager stateful set | `{}`
+`alertmanager.statefulSet.labels` | labels to be added to alertmanager stateful set | `{}`
 `alertmanager.statefulSet.podManagementPolicy` | podManagementPolicy of alertmanager pods | `OrderedReady`
 `alertmanager.statefulSet.headless.annotations` | annotations for alertmanager headless service | `{}`
 `alertmanager.statefulSet.headless.labels` | labels for alertmanager headless service | `{}`
@@ -224,7 +227,7 @@ Parameter | Description | Default
 `nodeExporter.pod.labels` | labels to be added to node-exporter pods | `{}`
 `nodeExporter.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
 `nodeExporter.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
-`nodeExporter.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
+`nodeExporter.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
 `nodeExporter.podSecurityPolicy.enabled` | Specify if a Pod Security Policy for node-exporter must be created | `false`
 `nodeExporter.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `nodeExporter.priorityClassName` | node-exporter priorityClassName | `nil`
@@ -253,7 +256,9 @@ Parameter | Description | Default
 `pushgateway.ingress.tls` | pushgateway Ingress TLS configuration (YAML) | `[]`
 `pushgateway.nodeSelector` | node labels for pushgateway pod assignment | `{}`
 `pushgateway.podAnnotations` | annotations to be added to pushgateway pods | `{}`
-`pushgateway.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
+`pushgateway.podLabels` | labels to be added to pushgateway pods | `{}`
+`pushgateway.deploymentAnnotations` | annotations to be added to pushgateway deployment | `{}`
+`pushgateway.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
 `pushgateway.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `pushgateway.replicaCount` | desired number of pushgateway pods | `1`
 `pushgateway.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
@@ -330,7 +335,7 @@ Parameter | Description | Default
 `server.podLabels` | labels to be added to Prometheus server pods | `{}`
 `server.alertmanagers` | Prometheus AlertManager configuration for the Prometheus server | `{}`
 `server.deploymentAnnotations` | annotations to be added to Prometheus server deployment | `{}`
-`server.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
+`server.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
 `server.replicaCount` | desired number of Prometheus server pods | `1`
 `server.statefulSet.enabled` | If true, use a statefulset instead of a deployment for pod management | `false`
 `server.statefulSet.annotations` | annotations to be added to Prometheus server stateful set | `{}`
@@ -394,7 +399,7 @@ Parameter | Description | Default
 `extraScrapeConfigs` | Prometheus server additional scrape configuration | ""
 `alertRelabelConfigs` | Prometheus server [alert relabeling configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs) for H/A prometheus | ""
 `networkPolicy.enabled` | Enable NetworkPolicy | `false`
-`forceNamespace` | Force resources to be namespaced | `null` |
+`forceNamespace` | Force resources to be namespaced | `null`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus/templates/deployments/alertmanager.yaml
+++ b/stable/prometheus/templates/deployments/alertmanager.yaml
@@ -2,6 +2,10 @@
 apiVersion: {{ template "prometheus.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
+{{- if .Values.alertmanager.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.alertmanager.deploymentAnnotations | nindent 4 }}
+{{- end }}
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
@@ -20,7 +24,7 @@ spec:
     metadata:
     {{- if .Values.alertmanager.podAnnotations }}
       annotations:
-{{ toYaml .Values.alertmanager.podAnnotations | indent 8 }}
+        {{ toYaml .Values.alertmanager.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
         {{- include "prometheus.alertmanager.labels" . | nindent 8 }}

--- a/stable/prometheus/templates/deployments/pushgateway.yaml
+++ b/stable/prometheus/templates/deployments/pushgateway.yaml
@@ -2,6 +2,10 @@
 apiVersion: {{ template "prometheus.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
+{{- if .Values.pushgateway.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.pushgateway.deploymentAnnotations | nindent 4 }}
+{{- end }}
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
@@ -23,10 +27,13 @@ spec:
     metadata:
     {{- if .Values.pushgateway.podAnnotations }}
       annotations:
-{{ toYaml .Values.pushgateway.podAnnotations | indent 8 }}
+        {{ toYaml .Values.pushgateway.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
         {{- include "prometheus.pushgateway.labels" . | nindent 8 }}
+        {{- if .Values.pushgateway.podLabels}}
+        {{ toYaml .Values.pushgateway.podLabels | nindent 8 }}
+        {{- end}}
     spec:
       serviceAccountName: {{ template "prometheus.serviceAccountName.pushgateway" . }}
       {{- if .Values.pushgateway.extraInitContainers }}

--- a/stable/prometheus/templates/deployments/server.yaml
+++ b/stable/prometheus/templates/deployments/server.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.server.deploymentAnnotations | indent 4 }}
+    {{ toYaml .Values.server.deploymentAnnotations | nindent 4 }}
 {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
@@ -25,7 +25,7 @@ spec:
     metadata:
     {{- if .Values.server.podAnnotations }}
       annotations:
-{{ toYaml .Values.server.podAnnotations | indent 8 }}
+        {{ toYaml .Values.server.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
         {{- include "prometheus.server.labels" . | nindent 8 }}

--- a/stable/prometheus/templates/statefulsets/alertmanager.yaml
+++ b/stable/prometheus/templates/statefulsets/alertmanager.yaml
@@ -2,8 +2,15 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+{{- if .Values.alertmanager.statefulSet.annotations }}
+  annotations:
+    {{ toYaml .Values.alertmanager.statefulSet.annotations | nindent 4 }}
+{{- end }}
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+    {{- if .Values.alertmanager.statefulSet.labels}}
+    {{ toYaml .Values.alertmanager.statefulSet.labels | nindent 4 }}
+    {{- end}}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
@@ -17,10 +24,13 @@ spec:
     metadata:
     {{- if .Values.alertmanager.podAnnotations }}
       annotations:
-{{ toYaml .Values.alertmanager.podAnnotations | indent 8 }}
+        {{ toYaml .Values.alertmanager.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
         {{- include "prometheus.alertmanager.labels" . | nindent 8 }}
+        {{- if .Values.alertmanager.podLabels}}
+        {{ toYaml .Values.alertmanager.podLabels | nindent 8 }}
+        {{- end}}
     spec:
 {{- if .Values.alertmanager.affinity }}
       affinity:

--- a/stable/prometheus/templates/statefulsets/server.yaml
+++ b/stable/prometheus/templates/statefulsets/server.yaml
@@ -5,7 +5,7 @@ kind: StatefulSet
 metadata:
 {{- if .Values.server.statefulSet.annotations }}
   annotations:
-{{ toYaml .Values.server.statefulSet.annotations | indent 4 }}
+    {{ toYaml .Values.server.statefulSet.annotations | nindent 4 }}
 {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
@@ -25,12 +25,12 @@ spec:
     metadata:
     {{- if .Values.server.podAnnotations }}
       annotations:
-{{ toYaml .Values.server.podAnnotations | indent 8 }}
+        {{ toYaml .Values.server.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
         {{- include "prometheus.server.labels" . | nindent 8 }}
-        {{- if .Values.server.statefulSet.labels}}
-        {{ toYaml .Values.server.statefulSet.labels | nindent 8 }}
+        {{- if .Values.server.podLabels}}
+        {{ toYaml .Values.server.podLabels | nindent 8 }}
         {{- end}}
     spec:
 {{- if .Values.server.priorityClassName }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -261,6 +261,8 @@ alertmanager:
     ##
     enabled: false
 
+    annotations: {}
+    labels: {}
     podManagementPolicy: OrderedReady
 
     ## Alertmanager headless service to use for the statefulset
@@ -1033,6 +1035,10 @@ pushgateway:
   ## Annotations to be added to pushgateway pods
   ##
   podAnnotations: {}
+
+  ## Labels to be added to pushgateway pods
+  ##
+  podLabels: {}
 
   ## Specify if a Pod Security Policy for node-exporter must be created
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR unify labels and annotations across all deploymets and statefulsets in stable/prometheus Helm chart
\+ removed useless trailing pipe chars (|) in README.md

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
