### PR TITLE
[stable/unifi] deprecate unifi helm chart

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 appVersion: 5.12.35
-description: Ubiquiti Network's Unifi Controller
+# The unifi chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
+description: DEPRECATED - Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.10.1
+version: 0.10.2
 keywords:
   - ubiquiti
   - unifi
@@ -12,8 +13,4 @@ icon: https://blog.ubnt.com/wp-content/uploads/2016/10/unifi-app-logo.png
 sources:
   - https://github.com/jacobalberty/unifi-docker
   - https://github.com/helm/charts/tree/master/stable/unifi
-maintainers:
-  - name: billimek
-    email: jeff@billimek.com
-  - name: mcronce
-    email: mike@quadra-tec.net
+deprecated: true

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -1,4 +1,9 @@
-# Ubiquiti Network's Unifi Controller
+# DEPRECATED - Network's Unifi Controller
+
+|**This chart has been deprecated and moved to its new home:**
+|
+|- **GitHub repo:** https://github.com/k8s-at-home/charts/tree/master/charts/unifi
+|- **Charts repo:** https://k8s-at-home.com/charts/
 
 This is a helm chart for [Ubiquiti Network's][ubnt] [Unifi Controller][ubnt 2].
 

--- a/stable/unifi/templates/NOTES.txt
+++ b/stable/unifi/templates/NOTES.txt
@@ -1,3 +1,8 @@
+This Helm chart is deprecated
+
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the unifi maintained Helm chart is now located at k8s-at-home/charts (https://github.com/k8s-at-home/charts/tree/master/charts/unifi).
+
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This deprecates the unifi chart and references the new home.

#### Special notes for your reviewer:

@scottrigby can you please add link to this PR in #21103 ?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
