### PR TITLE
[stable/fluent-bit] Remove duplicate image.pullSecrets from README.md

### DIFF
--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -131,7 +131,6 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `image.pullSecrets`                | Image pull secrets                         | `nil`                                             |
 | `nameOverride`                     | Override name of app                   | `nil`                                        |
 | `fullnameOverride`                 | Override full name of app              | `nil`                                        |
-| `image.pullSecrets`                | Specify image pull secrets                 | `nil`                                             |
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
 | `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
 | `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |


### PR DESCRIPTION
Signed-off-by: Noam Lerner <noamler@fb.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

Remove duplicated line from fluent-bit's README.md

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped (I'm not sure this is necessary for this README.md change)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
