### PR TITLE
[stable/airflow] Update redis.existingSecretKey option to align w/ stable/redis

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.6.0
+version: 7.7.0
 appVersion: 1.10.10
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -39,6 +39,7 @@ kubectl exec \
 > NOTE: for chart version numbers, see [Chart.yaml](Chart.yaml) or [helm hub](https://hub.helm.sh/charts/stable/airflow).
 
 For steps you must take when upgrading this chart, please review:
+* [v7.6.X → v7.7.0](UPGRADE.md#v76x--v770)
 * [v7.5.X → v7.6.0](UPGRADE.md#v75x--v760)
 * [v7.4.X → v7.5.0](UPGRADE.md#v74x--v750)
 * [v7.3.X → v7.4.0](UPGRADE.md#v73x--v740)
@@ -712,7 +713,7 @@ __Airflow Redis (Internal) Values:__
 | `redis.enabled` | if the `stable/redis` chart is used | `true` |
 | `redis.password` | the redis password | `airflow` |
 | `redis.existingSecret` | the name of a pre-created secret containing the redis password | `""` |
-| `redis.existingSecretKey` | the key within `redis.existingSecret` containing the password string | `redis-password` |
+| `redis.existingSecretPasswordKey` | the key within `redis.existingSecret` containing the password string | `redis-password` |
 | `redis.cluster.*` | configs for redis cluster mode | `<see values.yaml>` |
 | `redis.master.*` | configs for the redis master | `<see values.yaml>` |
 | `redis.slave.*` | configs for the redis slaves | `<see values.yaml>` |

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrading Steps
 
+## `v7.6.X` → `v7.7.0`
+
+__If you are using an INTERNAL redis database, some configs have changed:__
+
+| 7.6.x | 7.7.x | Notes |
+| --- | --- | ---|
+| `redis.existingSecretKey` | `redis.existingSecretPasswordKey` | Changed to align with [stable/redis](https://github.com/helm/charts/tree/master/stable/redis) |
+
 ## `v7.5.X` → `v7.6.0`
 
 > __WARNING:__ 

--- a/stable/airflow/examples/google-gke/custom-values.yaml
+++ b/stable/airflow/examples/google-gke/custom-values.yaml
@@ -449,7 +449,7 @@ redis:
 
   ## the key in `redis.existingSecret` containing the password string
   ##
-  existingSecretKey: "redis-password"
+  existingSecretPasswordKey: "redis-password"
 
   ## configs for redis cluster mode
   ##

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -145,7 +145,7 @@ When applicable, we use the secrets created by the postgres/redis charts (which 
   valueFrom:
     secretKeyRef:
       name: {{ .Values.redis.existingSecret }}
-      key: {{ .Values.redis.existingSecretKey }}
+      key: {{ .Values.redis.existingSecretPasswordKey }}
 {{- else }}
 - name: REDIS_PASSWORD
   valueFrom:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1326,7 +1326,7 @@ redis:
 
   ## the key within `redis.existingSecret` containing the password string
   ##
-  existingSecretKey: "redis-password"
+  existingSecretPasswordKey: "redis-password"
 
   ## configs for redis cluster mode
   ##


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Update the `redis.externalSecretKey` option to `redis.externalSecretPasswordKey` to align with the stable/redis chart.

#### Which issue this PR fixes
  - fixes #23719 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
