### PR TITLE
[stable/mongodb-replicaset] ssl/tls flags, helm helpers

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.17.1
+version: 4.17.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -6,6 +6,18 @@
 * Kubernetes beta APIs enabled only if `podDisruptionBudget` is enabled
 * PV support on the underlying infrastructure
 
+### Upgrading the chart from 3.x to 4.x
+
+Starting in version 4.2, MongoDB provides `net.tls` settings and
+[deprecates old `net.ssl`](https://docs.mongodb.com/manual/release-notes/4.2/#tls)
+settings. In order to support version across this deprecation boundary, we
+renamed `tls.mode` parameter values:
+
+ * `disable` does not change
+ * `allowSSL` become `allow`
+ * `preferSSL` become `prefer`
+ * `requireSSL` become `require`
+
 ## StatefulSet Details
 
 * https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/
@@ -65,7 +77,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `persistentVolume.annotations`      | Persistent volume annotations                                             | `{}`                                                |
 | `terminationGracePeriodSeconds`     | Duration in seconds the pod needs to terminate gracefully                 | `30`                                                |
 | `tls.enabled`                       | Enable MongoDB TLS support including authentication                       | `false`                                             |
-| `tls.mode`                          | Set the SSL operation mode (disabled, allowSSL, preferSSL, requireSSL)    | `requireSSL`                                        |
+| `tls.mode`                          | Set the SSL operation mode (disabled, allow, prefer, require)             | `require`                                           |
 | `tls.cacert`                        | The CA certificate used for the members                                   | Our self signed CA certificate                      |
 | `tls.cakey`                         | The CA key used for the members                                           | Our key for the self signed CA certificate          |
 | `init.resources`                    | Pod resource requests and limits (for init containers)                    | `{}`                                                |

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -21,7 +21,6 @@ replica_set="$REPLICA_SET"
 script_name=${0##*/}
 SECONDS=0
 timeout="${TIMEOUT:-900}"
-tls_mode="${TLS_MODE}"
 
 if [[ "$AUTH" == "true" ]]; then
     admin_user="$ADMIN_USER"
@@ -116,8 +115,8 @@ if [ -f "$ca_crt"  ]; then
     log "Generating certificate"
     ca_key=/data/configdb/tls.key
     pem=/work-dir/mongo.pem
-    ssl_args=(--ssl --sslCAFile "$ca_crt" --sslPEMKeyFile "$pem")
-    ssl_server_args=(--sslMode "$tls_mode" --sslCAFile "$ca_crt" --sslPEMKeyFile "$pem")
+    ssl_args=($SSL_ARGS)
+    ssl_server_args=($SSL_SERVER_ARGS)
 
 # Move into /work-dir
 pushd /work-dir

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -134,8 +134,10 @@ spec:
               value: "{{ .Values.init.timeout }}"
             - name: SKIP_INIT
               value: "{{ .Values.skipInitialization }}"
-            - name: TLS_MODE
-              value: {{ .Values.tls.mode }}
+            - name: SSL_ARGS
+              value: {{ include "mongodb-replicaset.client-tls-flags" . }}
+            - name: SSL_SERVER_ARGS
+              value: {{ include "mongodb-replicaset.server-tls-flags" . }}
           {{- if .Values.auth.enabled }}
             - name: AUTH
               value: "true"
@@ -200,20 +202,12 @@ spec:
             - --auth
             - --keyFile=/data/configdb/key.txt
           {{- end }}
-          {{- if .Values.tls.enabled }}
-            - --sslMode={{ .Values.tls.mode }}
-            - --sslCAFile=/data/configdb/tls.crt
-            - --sslPEMKeyFile=/work-dir/mongo.pem
-          {{- end }}
+          {{- include "mongodb-replicaset.server-tls-flags-list" . | indent 12 }}
           livenessProbe:
             exec:
               command:
                 - mongo
-              {{- if .Values.tls.enabled }}
-                - --ssl
-                - --sslCAFile=/data/configdb/tls.crt
-                - --sslPEMKeyFile=/work-dir/mongo.pem
-              {{- end }}
+              {{- include "mongodb-replicaset.client-tls-flags-list" . | indent 16 }}
                 - --eval
                 - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -226,11 +220,7 @@ spec:
             exec:
               command:
                 - mongo
-              {{- if .Values.tls.enabled }}
-                - --ssl
-                - --sslCAFile=/data/configdb/tls.crt
-                - --sslPEMKeyFile=/work-dir/mongo.pem
-              {{- end }}
+              {{- include "mongodb-replicaset.client-tls-flags-list" . | indent 16 }}
                 - --eval
                 - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
@@ -243,11 +233,7 @@ spec:
             exec:
               command:
                 - mongo
-              {{- if .Values.tls.enabled }}
-                - --ssl
-                - --sslCAFile=/data/configdb/tls.crt
-                - --sslPEMKeyFile=/work-dir/mongo.pem
-              {{- end }}
+              {{- include "mongodb-replicaset.client-tls-flags-list" . | indent 16 }}
                 - --eval
                 - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -60,6 +60,8 @@ spec:
       {{- if .Values.tls.enabled }}
         - name: tls
           mountPath: /tls
+        - name: SSL_ARGS
+          value: {{ include "mongodb-replicaset.client-tls-flags" . }}
       {{- end }}
   volumes:
     - name: tools

--- a/stable/mongodb-replicaset/tests/mongodb-up-test.sh
+++ b/stable/mongodb-replicaset/tests/mongodb-up-test.sh
@@ -40,7 +40,7 @@ EOL
         -CA "$CACRT_FILE" -CAkey "$CAKEY_FILE" -CAcreateserial \
         -out mongo.crt -days 3650 -extensions v3_req -extfile openssl.cnf
     cat mongo.crt mongo.key > $MONGOPEM
-    MONGOARGS="$MONGOARGS --ssl --sslCAFile $CACRT_FILE --sslPEMKeyFile $MONGOPEM"
+    MONGOARGS="$MONGOARGS $SSL_ARGS"
 fi
 
 if [[ "${AUTH}" == "true" ]]; then

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -162,8 +162,8 @@ terminationGracePeriodSeconds: 30
 tls:
   # Enable or disable MongoDB TLS support
   enabled: false
-  # Set the SSL operation mode (disabled|allowSSL|preferSSL|requireSSL)
-  mode: requireSSL
+  # Set the SSL operation mode (disabled|allow|prefer|require)
+  mode: require
   # Please generate your own TLS CA by generating it via:
   # $ openssl genrsa -out ca.key 2048
   # $ openssl req -x509 -new -nodes -key ca.key -days 10000 -out ca.crt -subj "/CN=mydomain.com"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR makes ssl/tls flags a bit DRYer, at the same time supporting either ssl and tls so we can support mongo version pre/post 4.2 and its feature [deprecation](https://docs.mongodb.com/manual/release-notes/4.2/#tls).
By centralizing every char's tls configuration in those helpers which generate:
 * plaintext parameters lists
 * yaml formatted parameters arrays
 * uri-encoded parameters list

it should be simpler and less error prone to keep them in sync. Also adding other new ssl features that get introduced w/ new versions, eg. in 4.0 and 4.2, will be easier to implement and maintain.


Thank you, regards

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
