### PR TITLE
[stable/luigi] Use non-deprecated apiVersion(k8s 1.16 compatibility)

### DIFF
--- a/stable/luigi/Chart.yaml
+++ b/stable/luigi/Chart.yaml
@@ -18,5 +18,5 @@ keywords:
 - spark
 - kubernetes job manager
 name: luigi
-version: 2.7.5
+version: 2.7.6
 appVersion: 2.7.2

--- a/stable/luigi/templates/deployment.yaml
+++ b/stable/luigi/templates/deployment.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: apps/v1
+{{- else -}}
 apiVersion: apps/v1beta2
+{{- end }}
 kind: Deployment
 metadata:
   name: {{ template "luigi.fullname" . }}

--- a/stable/luigi/templates/deployment.yaml
+++ b/stable/luigi/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: apps/v1
 {{- else -}}
 apiVersion: apps/v1beta2

--- a/stable/luigi/templates/ingress_api.yaml
+++ b/stable/luigi/templates/ingress_api.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingressAPI.enabled -}}
 {{- $serviceName := include "luigi.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ template "luigi.fullname" . }}-api

--- a/stable/luigi/templates/ingress_ui.yaml
+++ b/stable/luigi/templates/ingress_ui.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingressUI.enabled -}}
 {{- $serviceName := include "luigi.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ template "luigi.fullname" . }}-ui


### PR DESCRIPTION
Signed-off-by: Oleg Ievtushok yevtushok@gmail.com

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

To be able to use this chart in k8s>=1.16(apiVersion compatibility)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
