### PR TITLE
[stable/rabbitmq-ha] Deprecate chart

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -2,10 +2,9 @@ name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.7
 version: 1.47.1
-# Ths chart is deprecated and no longer maintained. For details,
-# including how to un-deprecate a chart see the PROCESSES.md file.
+# Ths chart is deprecated and no longer maintained.
 deprecated: true
-description: DEPRECATED Highly available RabbitMQ cluster, the open source message broker
+description: DEPRECATED - Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:
 - rabbitmq

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,8 +1,11 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.7
-version: 1.47.0
-description: Highly available RabbitMQ cluster, the open source message broker
+version: 1.47.1
+# Ths chart is deprecated and no longer maintained. For details,
+# including how to un-deprecate a chart see the PROCESSES.md file.
+deprecated: true
+description: DEPRECATED Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:
 - rabbitmq
@@ -16,5 +19,3 @@ icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 sources:
 - https://github.com/rabbitmq/rabbitmq
 - https://github.com/docker-library/rabbitmq
-maintainers:
-- name: steven-sheehy

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -1,8 +1,8 @@
-# DEPRECATED - RabbitMQ High Available
+# ⚠️ DEPRECATED - RabbitMQ High Available
 
-Deprecated and no longer maintained. It is recommended to use the Bitnami maintained
-[RabbitMQ chart](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq) which
-has a similar feature set, including high availability.
+This chart is deprecated and no longer maintained. It is recommended to use the Bitnami
+maintained [RabbitMQ chart](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq)
+which has a similar feature set, including high availability.
 
 [RabbitMQ](https://www.rabbitmq.com) is an open source message broker software
 that implements the Advanced Message Queuing Protocol (AMQP).

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -1,4 +1,8 @@
-# RabbitMQ High Available
+# DEPRECATED - RabbitMQ High Available
+
+Deprecated and no longer maintained. It is recommended to use the Bitnami maintained
+[RabbitMQ chart](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq) which
+has a similar feature set, including high availability.
 
 [RabbitMQ](https://www.rabbitmq.com) is an open source message broker software
 that implements the Advanced Message Queuing Protocol (AMQP).

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -1,7 +1,10 @@
-DEPRECATED and no longer maintained. It is recommended to use the Bitnami maintained
-[RabbitMQ chart](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq) which
-has a similar feature set, including high availability.
+*******************
+*** DEPRECATED ****
+*******************
 
+This chart is deprecated and no longer maintained. It is recommended to use the Bitnami
+maintained RabbitMQ chart (https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq)
+which has a similar feature set, including high availability.
 
 ** Please be patient while the chart is being deployed **
 

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -1,3 +1,8 @@
+DEPRECATED and no longer maintained. It is recommended to use the Bitnami maintained
+[RabbitMQ chart](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq) which
+has a similar feature set, including high availability.
+
+
 ** Please be patient while the chart is being deployed **
 
   Credentials:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Deprecates the rabbitmq-ha chart. It is recommended to use the Bitnami maintained [RabbitMQ chart](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq) which has a similar feature set. Specifically, the Bitnami chart now has high availability which was the whole reason for rabbitmq-ha chart's creation.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
