### PR TITLE
[stable/mongodb-replicaset] Deprecate chart

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,16 +1,13 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.17.1
-appVersion: 3.6
-description: NoSQL document-oriented database that stores JSON-like documents with
+version: "3.17.2"
+appVersion: "3.6"
+description: DEPRECATED - NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg
 sources:
   - https://github.com/mongodb/mongo
   - https://github.com/percona/mongodb_exporter
-maintainers:
-  - name: unguiculus
-    email: unguiculus@gmail.com
-  - name: steven-sheehy
-    email: ssheehy@firescope.com
+# This chart is deprecated and no longer maintained
+deprecated: true

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -1,4 +1,10 @@
-# MongoDB Helm Chart
+# ⚠️ DEPRECATED
+
+This chart is deprecated and no longer maintained.
+
+It is recommended to use the Bitnami maintained
+[MongoDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mongodb) which
+has a similar feature set.
 
 ## Prerequisites Details
 

--- a/stable/mongodb-replicaset/templates/NOTES.txt
+++ b/stable/mongodb-replicaset/templates/NOTES.txt
@@ -1,3 +1,14 @@
+*******************
+****DEPRECATED*****
+*******************
+*
+* This chart is deprecated and no longer maintained.
+*
+* It is recommended to use the Bitnami maintained MongoDB chart
+* (https://github.com/bitnami/charts/tree/master/bitnami/mongodb)
+* which has a similar feature set.
+
+
 1. After the statefulset is created completely, one can check which instance is primary by running:
 
     $ for ((i = 0; i < {{ .Values.replicas }}; ++i)); do kubectl exec --namespace {{ template "mongodb-replicaset.namespace" . }} {{ template "mongodb-replicaset.fullname" . }}-$i -- sh -c 'mongo --eval="printjson(rs.isMaster())"'; done


### PR DESCRIPTION
This deprecated the mongodb-replicaset chart.

It is recommended to use the Bitnami maintained
[MongoDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mongodb)
which has a similar feature set.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
