### PR TITLE
[stable/airflow] explicitly allow event watching

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.8.0
+version: 7.9.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -39,6 +39,7 @@ kubectl exec \
 > NOTE: for chart version numbers, see [Chart.yaml](Chart.yaml) or [helm hub](https://hub.helm.sh/charts/stable/airflow).
 
 For steps you must take when upgrading this chart, please review:
+* [v7.8.X → v7.9.0](UPGRADE.md#v78x--v790)
 * [v7.7.X → v7.8.0](UPGRADE.md#v77x--v780)
 * [v7.6.X → v7.7.0](UPGRADE.md#v76x--v770)
 * [v7.5.X → v7.6.0](UPGRADE.md#v75x--v760)
@@ -674,6 +675,7 @@ __Airflow Kubernetes Values:__
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `rbac.create` | if Kubernetes RBAC resources are created | `true` |
+| `rbac.events` | if the created RBAR role has GET/LIST access to Event resources | `false` |
 | `serviceAccount.create` | if a Kubernetes ServiceAccount is created | `true` |
 | `serviceAccount.name` | the name of the ServiceAccount | `""` |
 | `serviceAccount.annotations` | annotations for the ServiceAccount | `{}` |

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrading Steps
 
+## `v7.8.X` → `v7.9.0`
+
+__The following IMPROVEMENTS have been made:__
+
+* You can now give the airflow ServiceAccount GET/LIST on Event resources
+    * This is needed for `KubernetesPodOperator(log_events_on_failure=True)`
+    * To enable, set `rbac.events` to `true` (Default: `false`)
+
+__The following values have been ADDED:__
+* `rbac.events`
+
 ## `v7.7.X` → `v7.8.0`
 
 > __WARNING:__ 

--- a/stable/airflow/templates/rbac/airflow-role.yaml
+++ b/stable/airflow/templates/rbac/airflow-role.yaml
@@ -9,16 +9,37 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-- apiGroups: [""]
+{{- if .Values.rbac.events }}
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - "get"
+  - "list"
+{{- end }}
+- apiGroups:
+  - ""
   resources:
   - pods
-  verbs: ["create", "get", "delete", "list", "watch"]
-- apiGroups: [""]
+  verbs:
+  - "create"
+  - "get"
+  - "delete"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
   resources:
   - "pods/log"
-  verbs: ["get", "list"]
-- apiGroups: [""]
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - ""
   resources:
   - "pods/exec"
-  verbs: ["create", "get"]
+  verbs:
+  - "create"
+  - "get"
 {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1168,6 +1168,13 @@ rbac:
   ##
   create: true
 
+  ## if the created RBAC Role has GET/LIST on Event resources
+  ##
+  ## NOTE:
+  ## - this is needed for KubernetesPodOperator() to use `log_events_on_failure=True`
+  ##
+  events: false
+
 ###################################
 # Kubernetes - Service Account
 ###################################


### PR DESCRIPTION

#### Is this a new chart
No
#### What this PR does / why we need it:
This PR adds the ability to watch events to the airflow role when RBAC is used.

If the airflow chart is installed in a non-default namespace
in (at least) GKE, tasks using the KubernetesPodOperator will
be marked failed because the worker does not have the ability
to watch the event stream.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
