### PR TITLE
[stable/airflow] remove maver1ck from OWNERS

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.10.0
+version: 7.10.1
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/OWNERS
+++ b/stable/airflow/OWNERS
@@ -1,8 +1,6 @@
 approvers:
 - gsemet
-- maver1ck
 - thesuperzapper
 reviewers:
 - gsemet
-- maver1ck
 - thesuperzapper


### PR DESCRIPTION
as far as I can see @maver1ck is inactive, and its quite inconvenient because the bot always assigns him, so we never see the incoming PR's