### PR TITLE
[stable/hlf-peer] Fix metrics configuration

### DIFF
--- a/stable/hlf-peer/Chart.yaml
+++ b/stable/hlf-peer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-peer
-version: 1.6.0
+version: 1.6.1
 appVersion: 1.4.3
 keywords:
   - blockchain

--- a/stable/hlf-peer/README.md
+++ b/stable/hlf-peer/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.pullPolicy`                  | Image pull policy                                              | `IfNotPresent`            |
 | `service.portRequest`               | TCP port for requests to Peer                                  | `7051`                    |
 | `service.portEvent`                 | TCP port for event service on Peer                             | `7053`                    |
+| `service.portMetrics`               | TCP port for the metrics service on Peer                       | `9443`                    |
 | `service.type`                      | K8S service type exposing ports, e.g. `ClusterIP`              | `ClusterIP`               |
 | `persistence.accessMode`            | Use volume as ReadOnly or ReadWrite                            | `ReadWriteOnce`           |
 | `persistence.annotations`           | Persistent Volume annotations                                  | `{}`                      |
@@ -113,7 +114,6 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `peer.chaincode.runtime.golang`     | Image of the chaincode runtime for Go                          | ``                        |
 | `peer.chaincode.runtime.java`       | Image of the chaincode runtime for Java                        | ``                        |
 | `peer.chaincode.runtime.node`       | Image of the chaincode runtime for Node.js                     | ``                        |
-| `peer.operations.listenAddress`     | Host and port for the operations server                        | ``                        |
 | `peer.metrics.provider`             | Metrics provider, can be `statsd`, `prometheus`, or `disabled` | `disabled`                |
 | `peer.metrics.statsd.network`       | Network type, can be `tcp` or `udp`                            | `udp`                     |
 | `peer.metrics.statsd.address`       | Address of the StatsD server                                   | `127.0.0.1:8125`          |

--- a/stable/hlf-peer/templates/configmap--peer.yaml
+++ b/stable/hlf-peer/templates/configmap--peer.yaml
@@ -82,8 +82,11 @@ data:
 ##############
 # Operations #
 ##############
-  {{- if .Values.peer.operations.listenAddress }}
-  CORE_OPERATIONS_LISTENADDRESS: {{ .Values.peer.operations.listenAddress | quote }}
+  {{- if eq .Values.peer.metrics.provider "prometheus" }}
+  CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443
+  {{- end }}
+  {{- if eq .Values.peer.metrics.provider "statsd" }}
+  CORE_OPERATIONS_LISTENADDRESS: 127.0.0.1:8125
   {{- end }}
 ###########
 # Metrics #

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -111,6 +111,11 @@ spec:
             - name: event
               containerPort: 7053
               protocol: TCP
+            {{- if eq .Values.peer.metrics.provider "prometheus" }}
+            - name: metrics
+              containerPort: 9443
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/stable/hlf-peer/templates/service.yaml
+++ b/stable/hlf-peer/templates/service.yaml
@@ -15,6 +15,12 @@ spec:
       targetPort: 7053
       protocol: TCP
       name: event
+    {{- if eq .Values.peer.metrics.provider "prometheus" }}
+    - port: {{ .Values.service.portMetrics }}
+      targetPort: 9443
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     app: {{ include "hlf-peer.name" . }}
     release: {{ .Release.Name }}

--- a/stable/hlf-peer/values.yaml
+++ b/stable/hlf-peer/values.yaml
@@ -12,6 +12,7 @@ service:
   type: ClusterIP
   portRequest: 7051
   portEvent: 7053
+  portMetrics: 9443
 
 # Path of the docker socket on the host
 dockerSocketPath: /var/run/docker.sock
@@ -89,8 +90,6 @@ peer:
       golang: ""
       java: ""
       node: ""
-  operations:
-    listenAddress: ""
   metrics:
     provider: "disabled"
     statsd:


### PR DESCRIPTION
#### What this PR does / why we need it:

As the operation server port was not exposed by the container the service we were unable to gather metrics with prometheus as prometheus was unable to query the `<service-dns-name>:9443/metrics` endpoint.
This PR enable metrics collection with Prometheus.

#### Special notes for your reviewer:

`peer.operations.listenAddress` was removed from the values as this setting (`CORE_OPERATIONS_LISTENADDRESS`) should be managed in the same way as the `CORE_PEER_LISTENADDRESS`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
