### PR TITLE
[stable/hlf-ord] Fix metrics configuration

### DIFF
--- a/stable/hlf-ord/Chart.yaml
+++ b/stable/hlf-ord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ord
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.4.3
 keywords:
   - blockchain

--- a/stable/hlf-ord/README.md
+++ b/stable/hlf-ord/README.md
@@ -88,6 +88,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `image.pullPolicy`                 | Image pull policy                                             | `IfNotPresent`                                             |
 | `service.port`                     | TCP port                                                      | `7050`                                                     |
 | `service.type`                     | K8S service type exposing ports, e.g. `ClusterIP`             | `ClusterIP`                                                |
+| `service.portMetrics`              | TCP port for the metrics service                              | `9443`                                                     |
 | `ingress.enabled`                  | If true, Ingress will be created                              | `false`                                                    |
 | `ingress.annotations`              | Ingress annotations                                           | `{}`                                                       |
 | `ingress.path`                     | Ingress path                                                  | `/`                                                        |
@@ -101,7 +102,6 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `ord.mspID`                        | ID of MSP the Orderer belongs to                              | `OrdererMSP`                                               |
 | `ord.tls.server.enabled`           | Do we enable server-side TLS?                                 | `false`                                                    |
 | `ord.tls.client.enabled`           | Do we enable client-side TLS?                                 | `false`                                                    |
-| `ord.operations.listenAddress`     | Host and port for the operations server                       | ``                                                         |
 | `ord.metrics.provider`             | Metrics provider, can be `statsd`, `prometheus` or `disabled` | `disabled`                                                 |
 | `ord.metrics.statsd.network`       | Network type, can be `udp` or `tcp`                           | `udp`                                                      |
 | `ord.metrics.statsd.address`       | Address of the StatsD server                                  | `127.0.0.1:8125`                                           |

--- a/stable/hlf-ord/templates/configmap--ord.yaml
+++ b/stable/hlf-ord/templates/configmap--ord.yaml
@@ -35,8 +35,11 @@ data:
   ##############
   # Operations #
   ##############
-  {{- if .Values.ord.operations.listenAddress }}
-  ORDERER_OPERATIONS_LISTENADDRESS: {{ .Values.ord.operations.listenAddress | quote }}
+  {{- if eq .Values.ord.metrics.provider "prometheus" }}
+  ORDERER_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443
+  {{- end }}
+  {{- if eq .Values.ord.metrics.provider "statsd" }}
+  ORDERER_OPERATIONS_LISTENADDRESS: 127.0.0.1:8125
   {{- end }}
   ###########
   # Metrics #

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -85,6 +85,11 @@ spec:
             - name: ord-port
               containerPort: 7050
               protocol: TCP
+            {{- if eq .Values.ord.metrics.provider "prometheus" }}
+            - name: metrics
+              containerPort: 9443
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/stable/hlf-ord/templates/service.yaml
+++ b/stable/hlf-ord/templates/service.yaml
@@ -11,6 +11,12 @@ spec:
       targetPort: 7050
       protocol: TCP
       name: grpc
+    {{- if eq .Values.ord.metrics.provider "prometheus" }}
+    - port: {{ .Values.service.portMetrics }}
+      targetPort: 9443
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     app: {{ include "hlf-ord.name" . }}
     release: {{ .Release.Name }}

--- a/stable/hlf-ord/values.yaml
+++ b/stable/hlf-ord/values.yaml
@@ -11,6 +11,7 @@ service:
   # Cluster IP or LoadBalancer
   type: ClusterIP
   port: 7050
+  portMetrics: 9443
 
 ingress:
   enabled: false
@@ -55,8 +56,6 @@ ord:
       enabled: "false"
     client:
       enabled: "false"
-  operations:
-    listenAddress: ""
   metrics:
     provider: "disabled"
     statsd:


### PR DESCRIPTION
#### What this PR does / why we need it:
As the operation server port was not exposed by the container the service we were unable to gather metrics with prometheus as prometheus was unable to query the `<service-dns-name>:9443/metrics` endpoint.
This PR enable metrics collection with Prometheus.

#### Special notes for your reviewer:
N/A

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
