### PR TITLE
[stable/selenium]: Add volumes to firefox pods

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.1.2
+version: 1.2.0
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -161,6 +161,8 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `firefox.securityContext` |	SecurityContext on the firefox pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `firefox.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `firefox.javaOpts` | The java options for a selenium node firefox JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
+| `firefox.volumeMounts` | Additional volumes to mount, the default provides a larger shared memory | `[{"mountPath":"/dev/shm", "name":"dshm"}]` |
+| `firefox.volumes` | Additional volumes import, the default provides a larger shared memory | `[{"name":"dshm", "emptyDir":{"medium":"Memory"}}]` |
 | `firefox.resources` | The resources for the hub container, defaults to minimum half a cpu and maximum 1,000 mb | `{"limits":{"cpu":".5", "memory":"1000Mi"}}` |
 | `firefox.screenWidth` | | `nil` |
 | `firefox.screenHeight` | | `nil` |
@@ -190,6 +192,8 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `firefoxDebug.securityContext` |	SecurityContext on the firefox debug pods |	`{"runAsUser": 1000, "fsGroup": 1000}` |
 | `firefoxDebug.extraEnvs` |  Any additional environment variables to set in the pods | `[]` |
 | `firefoxDebug.javaOpts` | The java options for a selenium node firefox debug JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
+| `firefoxDebug.volumeMounts` | Additional volumes to mount, the default provides a larger shared | `[{"mountPath":"/dev/shm", "name":"dshm"}]` |
+| `firefoxDebug.volumes` | Additional volumes import, the default provides a larger shared | `[{"name":"dshm", "emptyDir":{"medium":"Memory"}}]` |
 | `firefoxDebug.resources` | The resources for the selenium node firefox debug container, defaults to minimum half a cpu and maximum 1,000 mb | `{"limits":{"cpu":".5", "memory":"1000Mi"}}` |
 | `firefoxDebug.screenWidth` | | `nil` |
 | `firefoxDebug.screenHeight` | | `nil` |

--- a/stable/selenium/templates/firefox-daemonset.yaml
+++ b/stable/selenium/templates/firefox-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         heritage: "{{ .Release.Service }}"
       {{- with .Values.firefox.podLabels }}
       {{ toYaml .| indent 2 }}
-      {{- end }}  
+      {{- end }}
       {{- if .Values.firefox.podAnnotations }}
       annotations:
 {{ toYaml .Values.firefox.podAnnotations | indent 8 }}
@@ -105,11 +105,19 @@ spec:
             {{- if .Values.firefox.extraEnvs }}
 {{ toYaml .Values.firefox.extraEnvs | indent 12 }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.firefox.volumeMounts -}}
+{{ toYaml .Values.firefox.volumeMounts | trim | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.firefox.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.firefox.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.firefox.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
+{{- end }}
+      volumes:
+{{ if .Values.firefox.volumes -}}
+{{ toYaml .Values.firefox.volumes | trim | indent 8 }}
 {{- end }}
       hostAliases:
 {{ toYaml .Values.global.hostAliases | indent 8 }}

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         heritage: "{{ .Release.Service }}"
       {{- with .Values.firefox.podLabels }}
       {{ toYaml .| indent 2 }}
-      {{- end }}  
+      {{- end }}
       {{- if .Values.firefox.podAnnotations }}
       annotations:
 {{ toYaml .Values.firefox.podAnnotations | indent 8 }}
@@ -110,11 +110,19 @@ spec:
             {{- if .Values.firefox.extraEnvs }}
 {{ toYaml .Values.firefox.extraEnvs | indent 12 }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.firefox.volumeMounts -}}
+{{ toYaml .Values.firefox.volumeMounts | trim | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.firefox.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.firefox.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.firefox.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
+{{- end }}
+      volumes:
+{{ if .Values.firefox.volumes -}}
+{{ toYaml .Values.firefox.volumes | trim | indent 8 }}
 {{- end }}
       hostAliases:
 {{ toYaml .Values.global.hostAliases | indent 8 }}

--- a/stable/selenium/templates/firefoxDebug-daemonset.yaml
+++ b/stable/selenium/templates/firefoxDebug-daemonset.yaml
@@ -108,11 +108,19 @@ spec:
             {{- if .Values.firefoxDebug.extraEnvs }}
 {{ toYaml .Values.firefoxDebug.extraEnvs | indent 12 }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.firefoxDebug.volumeMounts -}}
+{{ toYaml .Values.firefoxDebug.volumeMounts | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.firefoxDebug.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.firefoxDebug.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.firefoxDebug.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
+{{- end }}
+      volumes:
+{{ if .Values.firefoxDebug.volumes -}}
+{{ toYaml .Values.firefoxDebug.volumes | indent 8 }}
 {{- end }}
       hostAliases:
 {{ toYaml .Values.global.hostAliases | indent 8 }}

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -112,11 +112,19 @@ spec:
             {{- if .Values.firefoxDebug.extraEnvs }}
 {{ toYaml .Values.firefoxDebug.extraEnvs | indent 12 }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.firefoxDebug.volumeMounts -}}
+{{ toYaml .Values.firefoxDebug.volumeMounts | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.firefoxDebug.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.firefoxDebug.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.firefoxDebug.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
+{{- end }}
+      volumes:
+{{ if .Values.firefoxDebug.volumes -}}
+{{ toYaml .Values.firefoxDebug.volumes | indent 8 }}
 {{- end }}
       hostAliases:
 {{ toYaml .Values.global.hostAliases | indent 8 }}

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -430,6 +430,15 @@ firefox:
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
 
+  volumes:
+    ## https://docs.openshift.com/container-platform/3.6/dev_guide/shared_memory.html
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:
@@ -522,6 +531,15 @@ firefoxDebug:
   ##   -Dcom.sun.management.jmxremote.ssl=false
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
+
+  volumes:
+    ## https://docs.openshift.com/container-platform/3.6/dev_guide/shared_memory.html
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
 
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Sometimes selenium tests with Firefox fail because there is not enough space for shm.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X ] Chart Version bumped
- [X ] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
