### PR TITLE
[stable/traefik] Removed type: Opaque from ConfigMap

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.2
+version: 1.87.3
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/client-ca-configmap.yaml
+++ b/stable/traefik/templates/client-ca-configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-type: Opaque
 data:
 {{- range $idx, $caCert := .Values.ssl.mtls.clientCaCerts }}
   clientCaCert-{{ $idx }}.crt: {{ $caCert | quote }}


### PR DESCRIPTION
This PR fixes https://github.com/helm/charts/issues/21479
It's not necessary to use a Secret since CA certificate are suppose to be public.
This has been tested on my K3S node.
Thank you so much
@krancour @elsonrodriguez 
Signed-off-by: Zhiqiang Wang <wang.9264@gmail.com>

#### What this PR does / why we need it:
  There is a bug preventing enable m-tls function of traefik
#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/21479

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
