### PR TITLE
[stable/oauth2-proxy] Quote ingress host as it may contain special char

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.2
+version: 3.2.3
 apiVersion: v1
 appVersion: 5.1.0
 home: https://pusher.github.io/oauth2_proxy/

--- a/stable/oauth2-proxy/templates/ingress.yaml
+++ b/stable/oauth2-proxy/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote }}
       http:
         paths:
 {{ if $extraPaths }}


### PR DESCRIPTION

#### Which issue this PR fixes
* When the list `ingress.hosts` contains a star certificate (eg. *.example.com) then templating dies with YAML parse error 

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)