### PR TITLE
[stable/coredns] Allow to set port for NodePort service type

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.13.3
+version: 1.13.4
 appVersion: 1.7.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -64,6 +64,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.loadBalancerIP`                | IP address to assign to load balancer (if supported)                                  | `""`                                                        |
 | `service.externalTrafficPolicy`         | Enable client source IP preservation                                                  | []                                                          |
 | `service.annotations`                   | Annotations to add to service                                                         | {}                                                          |
+| `service.nodePort`                      | Port that set explicitly, when service type is set to NodePort                        |                                                             |
 | `serviceAccount.create`                 | If true, create & use serviceAccount                                                  | false                                                       |
 | `serviceAccount.name`                   | If not set & create is true, use template fullname                                    |                                                             |
 | `rbac.create`                           | If true, create & use RBAC resources                                                  | true                                                        |

--- a/stable/coredns/templates/_helpers.tpl
+++ b/stable/coredns/templates/_helpers.tpl
@@ -70,10 +70,18 @@ Generate the list of ports automatically from the server definitions
     {{/* Write out the ports according to the info collected above */}}
     {{- range $port, $innerdict := $ports -}}
         {{- if index $innerdict "isudp" -}}
-            {{- printf "- {port: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+            {{- if and (eq $.Values.serviceType "NodePort") ($.Values.service.nodePort) -}}
+                {{- printf "- {port: %v, protocol: UDP, name: udp-%s, nodePort: %v }\n" $port $port $.Values.service.nodePort -}}
+            {{- else -}}
+                {{- printf "- {port: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+            {{- end -}}
         {{- end -}}
         {{- if index $innerdict "istcp" -}}
-            {{- printf "- {port: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+            {{- if and (eq $.Values.serviceType "NodePort") ($.Values.service.nodePort) -}}
+                {{- printf "- {port: %v, protocol: TCP, name: tcp-%s, nodePort: %v }\n" $port $port $.Values.service.nodePort -}}
+            {{- else -}}
+                {{- printf "- {port: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+            {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -64,9 +64,9 @@ service:
 # externalTrafficPolicy: ""
   annotations: {}
 
-# If serviceType is NodePort explicitly set port number. 
+# If serviceType is NodePort explicitly set port number.
 # https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
-# nodePort: 12345  
+# nodePort: 12345
 
 serviceAccount:
   create: false

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -64,6 +64,10 @@ service:
 # externalTrafficPolicy: ""
   annotations: {}
 
+# If serviceType is NodePort explicitly set port number. 
+# https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+# nodePort: 12345  
+
 serviceAccount:
   create: false
   # The name of the ServiceAccount to use


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow to set port for service type of NodePort

#### Special notes for your reviewer:
This PR is particularly useful when working with cloud providers that do not support UDP load balancers. In such case some people would implement their own load balancers, which forwards traffic to NodePort service. In that case ports should be predefined, to list them in load balancer configuration.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
