### PR TITLE
[stable/gitlab-ee] Removing the logo as it is not accessible

### DIFF
--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: gitlab-ee
 deprecated: true
-version: 0.2.2
+version: 0.2.3
 appVersion: 9.4.1
 description: GitLab Enterprise Edition
 keywords:
@@ -14,4 +15,3 @@ home: https://about.gitlab.com
 sources:
 - https://hub.docker.com/r/gitlab/gitlab-ee/
 - https://docs.gitlab.com/omnibus/
-icon: https://gitlab.com/uploads/group/avatar/6543/gitlab-logo-square.png


### PR DESCRIPTION
The logo is causing issues with Artifact Hub
