### PR TITLE
[stable/gocd] Deprecate stable gocd helm chart

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.31.0
+* [71ebc3374](https://github.com/kubernetes/charts/commit/71ebc3374): Deprecate GoCD Helm Chart.
 ### 1.30.0
 * [e97a5d88f](https://github.com/kubernetes/charts/commit/e97a5d88f): Bump up GoCD Version to 20.7.0
 ### 1.29.0

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.30.0
+version: 1.31.0
 appVersion: 20.7.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png
@@ -16,10 +16,12 @@ keywords:
 - continuous-testing
 sources:
 - https://github.com/gocd/gocd
-maintainers:
-- name: arvindsv
-  email: arvind@thoughtworks.com
-- name: ganeshspatil
-  email: ganeshpl@thoughtworks.com
-- name: varshavaradarajan
-  email: varshasvaradarajan@gmail.com
+deprecated: true
+# NOTE: Deprecated charts can't have maintainers but leaving commented-out for posterity.
+# maintainers:
+# - name: arvindsv
+#  email: arvind@thoughtworks.com
+# - name: ganeshspatil
+#  email: ganeshpl@thoughtworks.com
+# - name: varshavaradarajan
+#  email: varshasvaradarajan@gmail.com

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -4,6 +4,24 @@
 
 [GoCD](https://www.gocd.org/) is an open-source continuous delivery server to model and visualize complex workflow with ease.
 
+# Deprecated
+With upcoming deprecation of `helm/charts` repository,  this chart is deprecated in favor of GoCD's [Official Helm Chart](https://github.com/gocd/helm-chart).
+
+You can use this new repository by doing:
+
+```bash
+helm repo add gocd https://gocd.github.io/helm-chart
+helm repo update
+```
+You can now use `gocd/gocd` instead of `stable/gocd` in all your Helm commands, e.g.:
+
+```bash
+# New installation
+helm install --name <RELEASE_NAME> gocd/gocd
+# Upgrade existing installation
+helm upgrade --name <RELEASE_NAME> gocd/gocd
+```
+
 # Introduction
 
 This chart bootstraps a single node GoCD server and GoCD agents on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.


### PR DESCRIPTION
#### What this PR does / why we need it:

With upcoming deprecation of `helm/charts` repository,  the `stable/gocd` chart is deprecated in favor of GoCD's [Official Helm Chart](https://github.com/gocd/helm-chart).


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
