### PR TITLE
[stable/prometheus-blackbox-exporter] Improve blackbox exporter to handle custom relabelings

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 deprecated: true
 description: DEPRECATED Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.3.1
+version: 4.4.1
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -88,6 +88,8 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `serviceMonitor.defaults.interval`        | Interval for prometheus operator endpoint                                        | `30s`                                                                        |
 | `serviceMonitor.defaults.scrapeTimeout`   | Scrape timeout for prometheus operator endpoint                                  | `30s`                                                                        |
 | `serviceMonitor.defaults.module`          | The module that blackbox will use if serviceMonitor is enabled                   | `http_2xx`                                                                   |
+| `serviceMonitor.defaults.relabelings`     | Add custom target relabelings for all targets if empty for them                  |                                                                              |
+| `serviceMonitor.defaults.metricRelabelings` | Add custom metricsRelabelings for all targets if empty for them                |                                                                              |
 | `serviceMonitor.targets.[]`               | List of targets to scrape                                                        | `[]`                                                                         |
 | `serviceMonitor.targets.[].name`          | Human readable name for the job. It will also appear in job labels in Prometheus | `example`                                                                    |
 | `serviceMonitor.targets.[].url`           | The URL that blackbox will scrape if serviceMonitor is enabled                   | `http://example.com/healthz`                                                 |
@@ -95,6 +97,8 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `serviceMonitor.targets.[].interval`      | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.interval }}`                                     |
 | `serviceMonitor.targets.[].scrapeTimeout` | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.scrateTimeout }}`                                |
 | `serviceMonitor.targets.[].module`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.module }}`                                       |
+| `serviceMonitor.targets.[].relabelings`   | See above in `serviceMonitor.relabelings`                                        | `{{ serviceMonitor.defaults.relabelings }}`                                  |
+| `serviceMonitor.targets.[].metricRelabelings` | See above in `serviceMonitor.metricRelabelings`                              | `{{ serviceMonitor.defaults.metricRelabelings }}`                            |
 | `prometheusRule.enabled`                  | Set this to true to create PrometheusRule for Prometheus operator | `false`     |
 | `prometheusRule.additionalLabels`         | Additional labels that can be passed to PrometheusRule | `{}`  |
 | `prometheusRule.namespace`                | Namespace where PrometheusRule resource should be created |      |

--- a/stable/prometheus-blackbox-exporter/ci/servicemonitor-values.yaml
+++ b/stable/prometheus-blackbox-exporter/ci/servicemonitor-values.yaml
@@ -1,0 +1,22 @@
+serviceMonitor:
+  enabled: true
+  defaults: 
+    labels:
+      release: prometheus-operator
+  targets:
+    - name: Github
+      url: https://www.github.com/
+      module: http_2xx
+      interval: 1m
+      relabelings:
+        - target_label: mynewlabel
+          replacement: 'myvalue'
+          action: replace
+
+    - name: Google
+      url: https://www.google.com/
+      module: http_2xx
+      interval: 1m
+      metricRelabelings:
+        - target_label: mylabel
+          action: keep

--- a/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -25,11 +25,18 @@ spec:
       - {{ .module | default $.Values.serviceMonitor.defaults.module }}
       target:
       - {{ .url }}
+    {{- if .relabelings }} 
+    relabelings:
+      {{- toYaml (.relabelings | default $.Values.serviceMonitor.defaults.relabelings) | nindent 6 }}
+    {{- end }}
     metricRelabelings:
       - targetLabel: instance
         replacement: {{ .url }}
       - targetLabel: target
         replacement: {{ .name }}
+      {{- if .metricRelabelings }}
+      {{- toYaml (.metricRelabelings | default $.Values.serviceMonitor.defaults.metricRelabelings) | nindent 6 }}
+      {{- end }}
   jobLabel: "{{ $.Release.Name }}"
   selector:
     matchLabels:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -133,6 +133,8 @@ serviceMonitor:
     interval: 30s
     scrapeTimeout: 30s
     module: http_2xx
+    relabelings:
+    metricRelabelings:
 
   targets:
 #    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Relabelings confings are completly missing in current helm chart.
Relabeling could be very useful to add custom labels for example.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
