### PR TITLE
[incubator/zookeeper] Update erroneous env variables

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.4
+version: 2.1.5
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -279,7 +279,7 @@ env:
   ## internal time.
   ZK_TICK_TIME: 2000
 
-  ## The time interval in hours for which the purge task has to be triggered. 
+  ## The time interval in hours for which the purge task has to be triggered.
   ## Set to a positive integer (1 and above) to enable the auto purging. Defaults to 0.
   ZK_PURGE_INTERVAL: 0
 

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -278,9 +278,16 @@ env:
   ## The number of wall clock ms that corresponds to a Tick for the ensembles
   ## internal time.
   ZK_TICK_TIME: 2000
+  
+  ## The time interval in hours for which the purge task has to be triggered. 
+  ## Set to a positive integer (1 and above) to enable the auto purging. Defaults to 0.
+  ZK_PURGE_INTERVAL: 0
 
-  ZOO_AUTOPURGE_PURGEINTERVAL: 0
-  ZOO_AUTOPURGE_SNAPRETAINCOUNT: 3
+  ## When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most
+  ## recent snapshots and the corresponding transaction logs in the dataDir and dataLogDir
+  ## respectively and deletes the rest. Defaults to 3. Minimum value is 3.
+  ZK_SNAP_RETAIN_COUNT: 3
+
   ZOO_STANDALONE_ENABLED: false
 
 jobs:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -278,7 +278,7 @@ env:
   ## The number of wall clock ms that corresponds to a Tick for the ensembles
   ## internal time.
   ZK_TICK_TIME: 2000
-  
+
   ## The time interval in hours for which the purge task has to be triggered. 
   ## Set to a positive integer (1 and above) to enable the auto purging. Defaults to 0.
   ZK_PURGE_INTERVAL: 0


### PR DESCRIPTION
 * Properly label ZK_PURGE_INTERVAL and ZK_SNAP_RETAIN_COUNT variables
 * Include description of variables in values.yaml

Signed-off-by: Benjamin Lofo Follo <benjamin.lofo@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

ZK_PURGE_INTERVAL and ZK_SNAP_RETAIN_COUNT were mislabeled, based on line 76 and 77 of `templates/config-script.yaml` inside the `incubator/zookeeper` chart. This ensures the environment variables are properly assigned, and description is included to help understand each one of them.

#### Which issue this PR fixes

#23629  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
