### PR TITLE
[stable/fluent-bit] PSP : allow projected volumes

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.10.1
+version: 2.10.2
 appVersion: 1.3.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/psp.yaml
+++ b/stable/fluent-bit/templates/psp.yaml
@@ -16,6 +16,7 @@ spec:
     - 'configMap'
     - 'secret'
     - 'hostPath'
+    - 'projected'
   allowedHostPaths:
     - pathPrefix: "/var/log"
     - pathPrefix: "/var/lib/docker/containers"


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR changes the Pod Security Policy to allow projected volumes. This is a requirement for pods to be able to mount the token of Service Account created by the chart as a volume.

Otherwise, the daemonset fails to spawn the pods.

Context:
* RBAC and PSP are enabled
* The chart is deployed on AWS EKS
* Service account is annotated to match an IAM role using [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
* This IAM role is used to access AWS services (Cloudwatch logs)

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
