### PR TITLE
[stable/airflow] Adding airflow scheduler existing secret connections option

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.10.1
+version: 7.11.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -114,6 +114,22 @@ removing them before adding them when they are automatically being imported. The
 default value is true, so if a user wants to add a password after the initial
 deployment, they should set `scheduler.refreshConnections` to false.
 
+
+We expose the `scheduler.existingSecretConnections` value to allow connections from an existing secrets resource. This may be desireable when you have shared resources between different deployments or you want to use a custom resource, e.g. ExternalSecrets, to avoid exposing credentials. The resulting existing secret should have an `add-connections.sh` data containing `airflow connections --add` statements, like below:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-custom-airflow-connections
+type: Opaque
+stringData:
+  add-connections.sh: |-
+    #!/usr/bin/env bash
+    airflow connections --add --conn_id my_aws_custom_conn --conn_type "aws"  --conn_extra "{\n  \"aws_access_key_id\": \"XXXXXXXXXXXXXXXXXXX\",\n  \"aws_secret_access_key\": \"XXXXXXXXXXXXXXX\",\n  \"region_name\":\"eu-central-1\"\n}\n"
+```
+If this variable is defined and set to any valid value, the `scheduler.connections` and `scheduler.refreshConnections` values will be ignored.
+
+
 __NOTE:__ As connections may include sensitive data, we store the bash script which generates the connections in a Kubernetes Secret, and mount this to the pods.
 
 __WARNING:__ Because some values are sensitive, you should take care to store your custom `values.yaml` securely before passing it to helm with: `helm -f <my-secret-values.yaml>`

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -51,6 +51,7 @@ kubectl exec \
 > NOTE: for chart version numbers, see [Chart.yaml](Chart.yaml) or [helm hub](https://hub.helm.sh/charts/stable/airflow).
 
 For steps you must take when upgrading this chart, please review:
+* [v7.10.X → v7.11.0](UPGRADE.md#v710x--v7110)
 * [v7.9.X → v7.10.0](UPGRADE.md#v79x--v7100)
 * [v7.8.X → v7.9.0](UPGRADE.md#v78x--v790)
 * [v7.7.X → v7.8.0](UPGRADE.md#v77x--v780)

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -115,7 +115,12 @@ default value is true, so if a user wants to add a password after the initial
 deployment, they should set `scheduler.refreshConnections` to false.
 
 
-We expose the `scheduler.existingSecretConnections` value to allow connections from an existing secrets resource. This may be desireable when you have shared resources between different deployments or you want to use a custom resource, e.g. ExternalSecrets, to avoid exposing credentials. The resulting existing secret should have an `add-connections.sh` data containing `airflow connections --add` statements, like below:
+We expose the `scheduler.existingSecretConnections` value to allow connections from an existing secrets resource. This may be desireable when you have shared resources between different deployments or you want to use a custom resource, e.g. ExternalSecrets, to avoid exposing credentials. The resulting existing secret should have an `add-connections.sh` data containing `airflow connections --add` statements. There's a few ways to achieve them, including:
+
+- Secret
+
+This is a straight-forward way to keep credentials away from the values in the chart, which can be useful to avoid commiting them to a git repository, for example. Here's an example:
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -127,7 +132,34 @@ stringData:
     #!/usr/bin/env bash
     airflow connections --add --conn_id my_aws_custom_conn --conn_type "aws"  --conn_extra "{\n  \"aws_access_key_id\": \"XXXXXXXXXXXXXXXXXXX\",\n  \"aws_secret_access_key\": \"XXXXXXXXXXXXXXX\",\n  \"region_name\":\"eu-central-1\"\n}\n"
 ```
-If this variable is defined and set to any valid value, the `scheduler.connections` and `scheduler.refreshConnections` values will be ignored.
+
+- ExternalSecret
+
+You can create an external secret to keep credentials safe in a Secret Manager, adding governance layers and avoiding exposing its values in your Kubernetes cluster. [More information on how to implement this in your cluster here](https://github.com/godaddy/kubernetes-external-secrets#install-with-helm).
+Here's an example using AWS Secret Manager ([read more about it here](https://github.com/godaddy/kubernetes-external-secrets#install-with-helm)):
+
+```yaml
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: my-safe-custom-airflow-connections
+spec:
+  roleArn: arn:aws:iam::123456789012:role/my-secret-manager-role
+  template:
+    type: Opaque
+  backendType: secretsManager
+  data:
+    - key: secrets/manager/key
+      name: username
+      property: username
+    - key: secrets/manager/key
+      name: password
+      property: password
+```
+(This resource is only appliable after the custom resource is correcly installed)
+
+
+If `scheduler.existingSecretConnections` is defined and set to any valid value, the `scheduler.connections` and `scheduler.refreshConnections` values will be ignored.
 
 
 __NOTE:__ As connections may include sensitive data, we store the bash script which generates the connections in a Kubernetes Secret, and mount this to the pods.

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrading Steps
 
+## `v7.10.X` → `v7.11.0`
+
+__The following IMPROVEMENTS have been made:__
+* We can now pass existing secrets containing Scheduler Connections in `scheduler.existingSecretConnections`, allowing for other ways to create those connections without declaring them on Chart Values.
+
 ## `v7.9.X` → `v7.10.0`
 
 __The following IMPROVEMENTS have been made:__

--- a/stable/airflow/templates/config/secret-connections.yaml
+++ b/stable/airflow/templates/config/secret-connections.yaml
@@ -15,7 +15,7 @@
   {{- if .extra }} --conn_extra {{ .extra | quote }} {{ end -}}
   {{- end }}
 {{- end }}
-{{- if .Values.scheduler.connections }}
+{{- if and (.Values.scheduler.connections) (not .Values.scheduler.existingSecretConnections) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/stable/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -194,7 +194,7 @@ spec:
               mountPath: {{ .Values.logs.path }}
               subPath: {{ .Values.logs.persistence.subPath }}
             {{- end }}
-            {{- if .Values.scheduler.connections }}
+            {{- if or (.Values.scheduler.connections) (.Values.scheduler.existingSecretConnections)  }}
             - name: connections
               mountPath: /home/airflow/connections
             {{- end}}
@@ -251,7 +251,7 @@ spec:
                && echo "*** adding Airflow variables..." \
                && airflow variables -i /home/airflow/variables-pools/variables.json \
               {{- end }}
-              {{- if .Values.scheduler.connections }}
+              {{- if or (.Values.scheduler.connections) (.Values.scheduler.existingSecretConnections)  }}
                && echo "*** adding Airflow connections..." \
                && /home/airflow/connections/add-connections.sh \
               {{- end }}
@@ -314,10 +314,12 @@ spec:
             defaultMode: 0700
         {{- end }}
         {{- end }}
-        {{- if .Values.scheduler.connections }}
+        {{- if or (.Values.scheduler.connections) (.Values.scheduler.existingSecretConnections) }}
         - name: connections
           secret:
-            secretName: {{ include "airflow.fullname" . }}-connections
+            secretName: {{ if .Values.scheduler.existingSecretConnections }}{{ .Values.scheduler.existingSecretConnections }}
+                        {{- else }}{{ include "airflow.fullname" . }}-connections
+                        {{- end }}
             defaultMode: 0755
         {{- end }}
         {{- if or (.Values.scheduler.variables) (.Values.scheduler.pools) }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -240,6 +240,11 @@ scheduler:
   ##
   connections: []
 
+  ## existingSecretConnections can receive an existing secret name to add connections using a custom secrets resource
+  ## if this variable is set to any valid value, scheduler.connections will be ignored
+  ##
+  ## existingSecretConnections: "custom-connections"
+
   ## if we remove before adding a connection resulting in a refresh
   ##
   refreshConnections: true

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -240,14 +240,14 @@ scheduler:
   ##
   connections: []
 
+  ## if we remove before adding a connection resulting in a refresh
+  ##
+  refreshConnections: true
+
   ## existingSecretConnections can receive an existing secret name to add connections using a custom secrets resource
   ## if this variable is set to any valid value, scheduler.connections will be ignored
   ##
   ## existingSecretConnections: "custom-connections"
-
-  ## if we remove before adding a connection resulting in a refresh
-  ##
-  refreshConnections: true
 
   ## custom airflow variables for the airflow scheduler
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds the option of using an existing secrets resources for scheduler connections. This is desirable since some organizations prefer to use other secret kinds like ExternalSecrets.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
