### PR TITLE
[stable/fluent-bit] Fixing extraVolumeMounts and extraVolumes parameters description

### DIFF
--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -110,8 +110,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `extraEntries.output`              |   Extra entries for existing [OUPUT] section                     | ``                    |
 | `extraEntries.service`             |   Extra entries for existing [SERVICE] section                   | ``                    |
 | `extraPorts`                       | List of extra ports                        |                       |
-| `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
-| `extraVolume`                      | Extra volume                               |                                                |
+| `extraVolumeMounts`                | Mount extra volumes, required to mount ssl certificates when elasticsearch has tls enabled  | `[]`     |
+| `extraVolumes`                     | Extra volumes                              | `[]`                                           |
 | `initContainers`                   | Init containers                            | `{}`                                           |
 | `service.flush`                    | Interval to flush output (seconds)        | `1`                   |
 | `service.logLevel`                 | Diagnostic level (error/warning/info/debug/trace)        | `info`                   |


### PR DESCRIPTION
#### What this PR does / why we need it:

I'd like to fix quite an evil error in the README which I spent some desperate hours because of.
Correct name of the parameter is `extraVolumes` not `extraVolume`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
