### PR TITLE
[stable/chartmuseum] Add runAsNonRoot, supplementalGroups and containerSecurityContext as security options

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.13.4
+version: 2.14.0
 appVersion: 0.12.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.13.3
+version: 2.13.4
 appVersion: 0.12.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -102,6 +102,9 @@ their default values. See values.yaml for all available options.
 | `serviceAccount.annotations`            | Additional Service Account annotations                                      | `{}`                                 |
 | `securityContext.enabled`               | Enable securityContext                                                      | `true`                               |
 | `securityContext.fsGroup`               | Group ID for the container                                                  | `1000`                               |
+| `securityContext.runAsNonRoot`          | Running Pods as non-root                                                    | ``                                   |
+| `securityContext.supplementalGroups`    | Control which group IDs containers add                                      | ``                                   |
+| `containerSecurityContext`              | Additional Container securityContext (ex. allowPrivilegeEscalation)         | `{}`                                 |
 | `priorityClassName      `               | priorityClassName                                                           | `""`                                 |
 | `nodeSelector`                          | Map of node labels for pod assignment                                       | `{}`                                 |
 | `tolerations`                           | List of node taints to tolerate                                             | `[]`                                 |

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -44,11 +44,18 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- if .Values.securityContext.runAsNonRoot }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        {{- else if .Values.securityContext.supplementalGroups }}
+        supplementalGroups: {{ .Values.securityContext.supplementalGroups }}
+        {{- end }}
       {{- else if .Values.persistence.enabled }}
       initContainers:
       - name: volume-permissions
         image: {{ template "chartmuseum.volumePermissions.image" . }}
         imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         command: ['sh', '-c', 'chown -R {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.path }}']
         volumeMounts:
         - mountPath: {{ .Values.persistence.path }}
@@ -59,6 +66,8 @@ spec:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         env:
 {{- range $name, $value := .Values.env.open }}
 {{- if not (empty $value) }}

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -46,7 +46,8 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         {{- if .Values.securityContext.runAsNonRoot }}
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-        {{- else if .Values.securityContext.supplementalGroups }}
+        {{- end }}
+        {{- if .Values.securityContext.supplementalGroups }}
         supplementalGroups: {{ .Values.securityContext.supplementalGroups }}
         {{- end }}
       {{- else if .Values.persistence.enabled }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -189,6 +189,12 @@ serviceAccount:
 securityContext:
   enabled: true
   fsGroup: 1000
+  ## Optionally, specify supplementalGroups and/or
+  ## runAsNonRoot for security purposes
+  # runAsNonRoot: true
+  # supplementalGroups: [1000]
+
+containerSecurityContext: {}
 
 priorityClassName: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it: 

It adds runAsNonRoot and supplementalGroups as optional Pod securityContext options. It also adds containerSecurityContext, where people can define securityContext options on container level (ex. allowPrivilegeEscalation and capabilities).

#### Special notes for your reviewer:
I want to implement this chart, but am unable to currently due to OPA updates. Being able to add the necessary securityContext options gives users the possibility to add more security to their deployments of this chart! (and gives me the ability to deploy it as well :smile: )

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
