### PR TITLE
[stable/spinnaker] fix: update minio to get rid of template error

### DIFF
--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 10.5.3
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.9
-digest: sha256:106d25a8f1fb7a20ce2e7289bc150dca8c23a45d1e63b27df5b21bd8a6d642bd
-generated: "2020-02-20T14:53:08.2196-05:00"
+  version: 5.0.33
+digest: sha256:87f9ce020cf7ea59e9574750e427d53ca77c4621fb9d8551aa0b5ba0f0b190ff
+generated: "2020-09-27T11:45:19.778164735+02:00"

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: redis.enabled
 - name: minio
-  version: 5.0.9
+  version: 5.0.33
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: minio.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

When using the current Spinnaker chart version:

```bash
helm install -n spinnaker --version 2.2.3 spinnaker stable/spinnaker --dry-run
```

I get the following issue:

```
Error: template: spinnaker/charts/minio/templates/deployment.yaml:210:20: executing "spinnaker/charts/minio/templates/deployment.yaml" at <(not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) (not .Values.b2gateway.enabled)>: can't give argument to non-function not .Values.gcsgateway.enabled
```

It turns out that the issue was already fixed [here](https://github.com/helm/charts/commit/89a712556d2e3bb8c18acc350dca0bc9a5baba8d). That's why the spinnaker chart needs bumping the `minio` dependency version to `>=5.0.16`. The highest version as of the time of writing is `5.0.33` and since it's a patch nothing should break.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
