### PR TITLE
[stable/clamav] Enable use of both freshclamConfig and clamdConfig

### DIFF
--- a/stable/clamav/Chart.yaml
+++ b/stable/clamav/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6"
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 name: clamav
-version: 1.0.5
+version: 1.0.6
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 maintainers:

--- a/stable/clamav/templates/deployment.yaml
+++ b/stable/clamav/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ default "apps/v1beta2" .Values.kubeMeta.deploymentApiVersion }}
+apiVersion: {{ default "apps/v1" .Values.kubeMeta.deploymentApiVersion }}
 kind: Deployment
 metadata:
   name: {{ include "clamav.fullname" . }}

--- a/stable/clamav/templates/deployment.yaml
+++ b/stable/clamav/templates/deployment.yaml
@@ -60,7 +60,6 @@ spec:
             name: {{ include "clamav.fullname" . }}-freshclam
 {{- end }}
 {{- if .Values.clamdConfig }}
-      volumes:
         - name: clamd-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-clamd

--- a/stable/clamav/templates/deployment.yaml
+++ b/stable/clamav/templates/deployment.yaml
@@ -52,8 +52,9 @@ spec:
             initialDelaySeconds: 300
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.freshclamConfig }}
+{{- if or .Values.freshclamConfig .Values.clamdConfig }}
       volumes:
+{{- if .Values.freshclamConfig }}
         - name: freshclam-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-freshclam
@@ -63,6 +64,7 @@ spec:
         - name: clamd-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-clamd
+{{- end }}
 {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/clamav/values.yaml
+++ b/stable/clamav/values.yaml
@@ -68,4 +68,4 @@ affinity: {}
 # Metadata surrounding the kubernetes distribution being deployed to.
 kubeMeta:
   # The api that Deployments are under.
-  deploymentApiVersion: apps/v1beta2
+  deploymentApiVersion: apps/v1


### PR DESCRIPTION
Signed-off-by: Markus Schöpke <markus.schoepke@bedag.ch>

#### What this PR does / why we need it:
Enable use of both freshclamConfig and clamdConfig

#### Which issue this PR fixes
The `volumes` key is currently duplicated when using both `freshclamConfig` and `clamdConfig`.
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
