### PR TITLE
[stable/prisma] Add missing config param: `rawAccess`

### DIFF
--- a/stable/prisma/Chart.yaml
+++ b/stable/prisma/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prisma
-version: 1.2.3
+version: 1.2.2
 appVersion: 1.34.0
 kubeVersion: "^1.8.0-0"
 description: Prisma turns your database into a realtime GraphQL API

--- a/stable/prisma/Chart.yaml
+++ b/stable/prisma/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prisma
-version: 1.2.2
-appVersion: 1.29.1
+version: 1.2.3
+appVersion: 1.34.0
 kubeVersion: "^1.8.0-0"
 description: Prisma turns your database into a realtime GraphQL API
 home: https://www.prisma.io/

--- a/stable/prisma/Chart.yaml
+++ b/stable/prisma/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prisma
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.34.0
 kubeVersion: "^1.8.0-0"
 description: Prisma turns your database into a realtime GraphQL API

--- a/stable/prisma/README.md
+++ b/stable/prisma/README.md
@@ -56,6 +56,7 @@ Parameter                        | Description                                  
 `database.migrations`            | Enable database migrations                   | `true`
 `database.ssl`                   | Enable SSL for DB connections                | `false`
 `database.connectionLimit`       | The maximum number of database connections   | `2`
+`database.rawAcces`              | Specifies whether the executeRaw mutation will be enabled in the Prisma API. The MongoDB connector currently doesn't support raw access, so you need to set this to false or omit it.   | `false`
 `auth.enabled`                   | Enable Prisma Management API authentication  | `false`
 `auth.secret`                    | Secret to use for authentication             | `nil`
 `service.type`                   | Type of Service                              | `ClusterIP`

--- a/stable/prisma/README.md
+++ b/stable/prisma/README.md
@@ -56,7 +56,7 @@ Parameter                        | Description                                  
 `database.migrations`            | Enable database migrations                   | `true`
 `database.ssl`                   | Enable SSL for DB connections                | `false`
 `database.connectionLimit`       | The maximum number of database connections   | `2`
-`database.rawAcces`              | Specifies whether the executeRaw mutation will be enabled in the Prisma API. The MongoDB connector currently doesn't support raw access, so you need to set this to false or omit it.   | `false`
+`database.rawAccess`              | Specifies whether the executeRaw mutation will be enabled in the Prisma API. The MongoDB connector currently doesn't support raw access, so you need to set this to false or omit it.   | `false`
 `auth.enabled`                   | Enable Prisma Management API authentication  | `false`
 `auth.secret`                    | Secret to use for authentication             | `nil`
 `service.type`                   | Type of Service                              | `ClusterIP`

--- a/stable/prisma/templates/configmap.yaml
+++ b/stable/prisma/templates/configmap.yaml
@@ -24,3 +24,4 @@ data:
         database: $PRISMA_DB_NAME
         ssl: $PRISMA_DB_SSL
         connectionLimit: $PRISMA_DB_CONNECTIONLIMIT
+        rawAccess: $PRISMA_DB_RAWACCESS

--- a/stable/prisma/templates/deployment.yaml
+++ b/stable/prisma/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: {{ .Values.database.ssl | quote }}
             - name: PRISMA_DB_CONNECTIONLIMIT
               value: {{ .Values.database.connectionLimit | quote }}
+            - name: PRISMA_DB_RAWACCESS
+              value: {{ .Values.database.rawAccess | quote }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/prisma/templates/deployment.yaml
+++ b/stable/prisma/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "prisma.fullname" . }}

--- a/stable/prisma/templates/ingress.yaml
+++ b/stable/prisma/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "prisma.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/prisma/templates/ingress.yaml
+++ b/stable/prisma/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "prisma.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/prisma/values.yaml
+++ b/stable/prisma/values.yaml
@@ -19,7 +19,7 @@ image:
 
   ## Prisma image version
   ##
-  tag: 1.29.1-heroku
+  tag: 1.34-heroku
 
   ## Specify an imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -55,6 +55,10 @@ database:
   ## Enable database migrations
   ##
   migrations: true
+
+  ## Enable database rawAccess
+  ## https://v1.prisma.io/docs/1.34/releases-and-maintenance/features-in-preview/mongodb-b6o5/#prisma_config
+  rawAccess: false
 
 auth:
   ## Prisma's Management API authentication


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds missing config params: `rawAccess`, Specifies whether the executeRaw mutation will be enabled in the Prisma API.

[https://v1.prisma.io/docs/1.27/prisma-graphql-api/reference/raw-database-access-qwe4/](https://v1.prisma.io/docs/1.27/prisma-graphql-api/reference/raw-database-access-qwe4/)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@giacomoguiulfo
