### PR TITLE
[stable/node-problem-detector] Customize rollout strategy

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.7.6"
+version: "1.8.0"
 appVersion: v0.8.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters for this chart and their d
 | `labels`                              | Optional daemonset labels                  | `{}`                                                         |
 | `extraVolumes`                        | Optional daemonset volumes to add          | `[]`                                                         |
 | `extraVolumeMounts`                   | Optional daemonset volumeMounts to add     | `[]`                                                         |
+| `updateStrategy`                      | Manage the daemonset update strategy       | `RollingUpdate`                                              |
+| `maxUnavailable`                      | The max pods unavailable during an update  | `1`                                                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters.
-

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -11,6 +11,12 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+{{- if eq .Values.updateStrategy "RollingUpdate"}}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable }}
+{{- end}}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -100,3 +100,6 @@ env:
 extraVolumes: []
 
 extraVolumeMounts: []
+
+updateStrategy: RollingUpdate
+maxUnavailable: 1


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
The default rollout strategy only allow for `1` pod to be disrupted at a time, this results in very long rollouts in large environments.  We need the ability to control the quantity of pods that are allowed to be unavailable during an update.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
Thanks for looking! @max-rocket-internet @Random-Liu @andyxning @wangzhen127

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
