### PR TITLE
[stable/logstash] concatenate the lines that specify flags. ISSUE-23830 

### DIFF
--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -113,9 +113,7 @@ spec:
           args:
             - >-
               sleep 60;
-              exec /logstash_exporter
-                --logstash.endpoint=http://localhost:{{ .Values.exporter.logstash.target.port }}
-                --web.listen-address=:{{ .Values.exporter.logstash.port }}
+              exec /logstash_exporter --logstash.endpoint=http://localhost:{{ .Values.exporter.logstash.target.port }} --web.listen-address=:{{ .Values.exporter.logstash.port }}
           ports:
             - name: ls-exporter
               containerPort: {{ .Values.exporter.logstash.port }}


### PR DESCRIPTION
Resolves [ISSUE-23830](https://github.com/helm/charts/issues/23830)

concatenate the lines that specify flags with the executable line since argument run line by line