### PR TITLE
[stable/selenium] Enabled use of runAsDaemonSet when scheduling a node firefoxDebug Pod

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.2.0
+version: 1.2.1
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/firefoxDebug-daemonset.yaml
+++ b/stable/selenium/templates/firefoxDebug-daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if eq true .Values.firefoxDebug.enabled -}}
+{{- if and (eq true .Values.firefoxDebug.enabled) (eq true .Values.firefoxDebug.runAsDaemonSet) -}}
 apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:


### PR DESCRIPTION
@flah00 @diemol @ekirmayer 

#### What this PR does / why we need it:

When scheduling a node `firefoxDebug` Pod the `runAsDaemonSet` parameter was not checked and would always be scheduled. This causes a clash of names and error when `firefoxDebug` is enabled: `Error: deployments.apps "selenium-selenium-firefox-debug" already exists`

#### Special notes for your reviewer:

`chromeDebug` already checks the `runAsDaemonSet` parameter inside the template.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
