### PR TITLE
[stable/eventrouter] Add image pull secrets support

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.3
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/README.md
+++ b/stable/eventrouter/README.md
@@ -24,6 +24,7 @@ The following table lists the configurable parameters of the eventrouter chart a
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `image.repository`      | Container image name                                                                                                        | `gcr.io/heptio-images/eventrouter` |
 | `image.tag`             | Container image tag                                                                                                         | `v0.3`                             |
+| `image.pullSecrets`     | A list of image pull secrets                                                                                                | `[]`                               |
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                             |
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                                 |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                             |

--- a/stable/eventrouter/templates/deployment.yaml
+++ b/stable/eventrouter/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "eventrouter.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/stable/eventrouter/values.yaml
+++ b/stable/eventrouter/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: gcr.io/heptio-images/eventrouter
   tag: v0.3
   pullPolicy: IfNotPresent
+  pullSecrets: []
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds image pull secrets support to eventrouter helm chart.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
