### PR TITLE
[stable/logstash]  Set a secret name for inputs and outputs

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.4.1
+version: 2.4.2
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -128,8 +128,10 @@ The following table lists the configurable parameters of the chart and its defau
 | `files`                         | Logstash custom files configuration                | `nil`                                            |
 | `binaryFiles`                   | Logstash custom binary files                       | `nil`                                            |
 | `inputs`                        | Logstash inputs configuration                      | beats                                            |
+| `inputs.existingSecret`         | Logstash inputs secret name               | unset                                            |
 | `filters`                       | Logstash filters configuration                     | `nil`                                            |
 | `outputs`                       | Logstash outputs configuration                     | elasticsearch                                    |
+| `outputs.existingSecret`        | Logstash outputs secret name                       | unset                                    |
 | `securityContext.fsGroup`       | Group ID for the container                         | `1000`                                           |
 | `securityContext.runAsUser`     | User ID for the container                          | `1000`                                           |
 | `args`                          | Additional arguments to pass to Logstash           | `1000`                                           |

--- a/stable/logstash/templates/pipeline-config.yaml
+++ b/stable/logstash/templates/pipeline-config.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.filters (not .Values.inputs.existingSecret) (not .Values.outputs.existingSecret) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,17 +9,23 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{- range $key, $value := .Values.inputs }}
-  input_{{ $key }}.conf: |-
-{{ $value | indent 4 }}
-{{- end }}
-
 {{- range $key, $value := .Values.filters }}
   filter_{{ $key }}.conf: |-
 {{ $value | indent 4 }}
 {{- end }}
 
+{{- if not .Values.inputs.existingSecret }}
+{{- range $key, $value := .Values.inputs }}
+  input_{{ $key }}.conf: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- end }}
+
+{{- if not .Values.outputs.existingSecret }}
 {{- range $key, $value := .Values.outputs }}
   output_{{ $key }}.conf: |-
 {{ $value | indent 4 }}
+{{- end }}
+{{- end }}
+
 {{- end }}

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -29,7 +29,9 @@ spec:
       annotations:
         checksum/patterns: {{ include (print $.Template.BasePath "/patterns-config.yaml") . | sha256sum }}
         checksum/templates: {{ include (print $.Template.BasePath "/files-config.yaml") . | sha256sum }}
+        {{- if or .Values.filters (not .Values.inputs.existingSecret) (not .Values.outputs.existingSecret) }}
         checksum/pipeline: {{ include (print $.Template.BasePath "/pipeline-config.yaml") . | sha256sum }}
+        {{- end }}
       {{- if .Values.podAnnotations }}
         ## Custom pod annotations
         {{- range $key, $value := .Values.podAnnotations }}
@@ -157,8 +159,20 @@ spec:
           configMap:
             name: {{ template "logstash.fullname" . }}-files
         - name: pipeline
-          configMap:
-            name: {{ template "logstash.fullname" . }}-pipeline
+          projected:
+            sources:
+            {{- if or .Values.filters (not .Values.inputs.existingSecret) (not .Values.outputs.existingSecret) }}
+              - configMap:
+                  name: {{ template "logstash.fullname" . }}-pipeline
+            {{- end }}
+            {{- if .Values.inputs.existingSecret }}
+            - secret:
+                name: {{ .Values.inputs.existingSecret }}
+            {{- end }}
+            {{- if .Values.outputs.existingSecret }}
+            - secret:
+                name: {{ .Values.outputs.existingSecret }}
+            {{- end }}
     {{- with .Values.volumes }}
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -315,6 +315,7 @@ inputs:
       #   type => "example"
       # }
     }
+  existingSecret: ""
 
 filters:
   # main: |-
@@ -338,6 +339,7 @@ outputs:
       #   topic_id => "destination"
       # }
     }
+  existingSecret: ""
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The input and/or output configuration for logstash can contain credentials. To avoid plain text credentials I added the possibility to set the secret name, and have the configuration including the credentials in a secret. If this is set it will also be read into a secret and not into a config map. 

#### Which issue this PR fixes
none

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)