### PR TITLE
[incubator/kafka] Move securityContext to proper place

### DIFF
--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -241,16 +241,16 @@ spec:
           name: {{ include "kafka.fullname" . }}-metrics
           {{- end }}
       {{- end }}
-      {{- if .Values.securityContext }}
-      securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
-      {{- end }}
       {{- range .Values.secrets }}
       {{- if .mountPath }}
       - name: {{ include "kafka.fullname" $ }}-{{ .name }}
         secret:
           secretName: {{ .name }}
       {{- end }}
+      {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Bug fix. Section "securityContext"  is in wrong place. It causes error during helm install ...

#### Special notes for your reviewer:

Current version doesn't work if you use both:
```
securityContext:
  runAsUser: 104
  runAsGroup: 109
  fsGroup: 2000
```

```
secrets:
- name: myKafkaSecret
  keys:
    - username
    - password
  # mountPath: /opt/kafka/secret
- name: myZkSecret
  keys:
    - user
    - pass
  mountPath: /opt/zookeeper/secret
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
