### PR TITLE
[stable/airflow] remove newline from connections secret name

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.11.2
+version: 7.11.3
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/stable/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -309,7 +309,7 @@ spec:
         {{- if or (.Values.scheduler.connections) (.Values.scheduler.existingSecretConnections) }}
         - name: connections
           secret:
-            secretName: |
+            secretName: |-
               {{- if .Values.scheduler.existingSecretConnections }}
               {{ .Values.scheduler.existingSecretConnections }}
               {{- else }}


### PR DESCRIPTION
This fixes an issue where newline character is added to the end of the `scheduler.connections` Secret name.

This was raised here: https://github.com/helm/charts/pull/23843#discussion_r500123974