### PR TITLE
[stable/airflow] provide additional labels configuration

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.11.4
+version: 7.12.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -52,6 +52,7 @@ kubectl exec \
 
 Chart version numbers: [Chart.yaml](Chart.yaml) or [Helm Hub](https://hub.helm.sh/charts/stable/airflow)
 
+- [v7.11.X → v7.12.0](UPGRADE.md#v711x--v7120)
 - [v7.10.X → v7.11.0](UPGRADE.md#v710x--v7110)
 - [v7.9.X → v7.10.0](UPGRADE.md#v79x--v7100)
 - [v7.8.X → v7.9.0](UPGRADE.md#v78x--v790)

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrading Steps
 
+## `v7.11.X` → `v7.12.0`
+
+__The following values have been ADDED:__
+* `ingress.web.labels`
+* `ingress.flower.labels`
+* `ingress.flower.precedingPaths`
+* `ingress.flower.succeedingPaths`
+
 ## `v7.10.X` → `v7.11.0`
 
 __The following IMPROVEMENTS have been made:__

--- a/stable/airflow/templates/flower/flower-ingress.yaml
+++ b/stable/airflow/templates/flower/flower-ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.ingress.flower.labels }}
+    {{- toYaml .Values.ingress.flower.labels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.flower.tls.enabled }}
   tls:
@@ -23,9 +26,21 @@ spec:
   rules:
     - http:
         paths:
+          {{- range .Values.ingress.flower.precedingPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
           - path: {{ .Values.ingress.flower.path }}
             backend:
               serviceName: {{ include "airflow.fullname" . }}-flower
               servicePort: flower
+          {{- range .Values.ingress.flower.succeedingPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
       host: {{ .Values.ingress.flower.host }}
 {{- end }}

--- a/stable/airflow/templates/webserver/webserver-ingress.yaml
+++ b/stable/airflow/templates/webserver/webserver-ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.ingress.web.labels }}
+    {{- toYaml .Values.ingress.web.labels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.web.tls.enabled }}
   tls:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1077,6 +1077,10 @@ ingress:
     ##
     annotations: {}
 
+    ## additional labels for the web Ingress
+    ##
+    labels: {}
+
     ## the path for the web Ingress
     ##
     ## WARNING:
@@ -1144,6 +1148,10 @@ ingress:
     ##
     annotations: {}
 
+    ## additional labels for the flower Ingress
+    ##
+    labels: {}
+
     ## the path for the flower Ingress
     ##
     ## WARNING:
@@ -1184,6 +1192,26 @@ ingress:
       ## - this MUST be specified if `ingress.flower.tls.enabled` is true
       ##
       secretName: ""
+
+    ## http paths to add to the flower Ingress before the default path
+    ##
+    ## EXAMPLE:
+    ##   precedingPaths:
+    ##     - path: "/*"
+    ##       serviceName: "ssl-redirect"
+    ##       servicePort: "use-annotation"
+    ##
+    precedingPaths: []
+
+    ## http paths to add to the flower Ingress after the default path
+    ##
+    ## EXAMPLE:
+    ##   succeedingPaths:
+    ##     - path: "/extra-service"
+    ##       serviceName: "extra-service"
+    ##       servicePort: "use-annotation"
+    ##
+    succeedingPaths: []
 
 ###################################
 # Kubernetes - RBAC


### PR DESCRIPTION
#### What this PR does / why we need it:
This change will allow you to optionally specify a label for the web Ingress resource. This is a useful feature for ingress controllers such as traefik that allow you to filter Ingresses based on arbitrary labels.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
