### PR TITLE
Redis helm3 migration compatibility

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.5.7
+version: 10.5.8
 appVersion: 5.0.7
 # The redis chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
 deprecated: true

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -266,6 +266,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `sysctlImage.mountHostSys`                    | Mount the host `/sys` folder to `/host-sys`                                                                                                         | `false`                                                 |
 | `sysctlImage.resources`                       | sysctlImage Init container CPU/Memory resource requests/limits                                                                                      | {}                                                      |
 | `podSecurityPolicy.create`                    | Specifies whether a PodSecurityPolicy should be created                                                                                             | `false`                                                 |
+| `helm3-migration-compatibility`               | Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to "Tiller", as this field is immutable and must be preserved in a helm2-to-helm3 upgrade. | `false`                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/redis/ci/helm3-migration-compatibility-values.yaml
+++ b/stable/redis/ci/helm3-migration-compatibility-values.yaml
@@ -1,0 +1,1 @@
+helm3-migration-compatibility: true

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -386,7 +386,7 @@ spec:
         labels:
           app: {{ template "redis.name" . }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
+          heritage: {{ if index .Values "helm3-migration-compatibility" -}} Tiller {{- else }}{{ .Release.Service }}{{ end }}
           component: master
       spec:
         accessModes:

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -403,7 +403,7 @@ spec:
         labels:
           app: {{ template "redis.name" . }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
+          heritage: {{ if index .Values "helm3-migration-compatibility" -}} Tiller {{- else }}{{ .Release.Service }}{{ end }}
           component: slave
       spec:
         accessModes:

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -629,3 +629,8 @@ podSecurityPolicy:
   ## Specifies whether a PodSecurityPolicy should be created
   ##
   create: false
+
+# Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to
+# "Tiller", as this field is immutable and must be preserved in a
+# helm2-to-helm3 upgrade.
+helm3-migration-compatibility: false


### PR DESCRIPTION
#### What this PR does / why we need it:
When upgrading from a helm2 release using helm [2to3](https://github.com/helm/helm-2to3), helm3 upgrades fail because [`.Release.Service` changed](https://github.com/helm/helm/issues/7211), causing helm to attempt to modify the (immutable) `heritage` label on the Statefulset's VolumeClaimTemplate. This provides a flag to set it back to "Tiller" to allow for upgrades.

#### Which issue this PR fixes
  - fixes #20921

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)