### PR TITLE
Patroni helm3 migration compatibility

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.16.0
+version: 0.16.1
 appVersion: 1.5-p5
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the patroni chart and t
 | `rbac.create`                     | Create required role and rolebindings       | `true`                                              |
 | `serviceAccount.create`           | If true, create a new service account	      | `true`                                              |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `nil` |
+| `helm3-migration-compatibility`   | Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to "Tiller", as this field is immutable and must be preserved in a helm2-to-helm3 upgrade. | `false` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/patroni/ci/helm3-migration-compatibility-values.yaml
+++ b/incubator/patroni/ci/helm3-migration-compatibility-values.yaml
@@ -1,0 +1,1 @@
+helm3-migration-compatibility: true

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -191,7 +191,7 @@ spec:
         labels:
           app: {{ template "patroni.fullname" . }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
+          heritage: {{ if index .Values "helm3-migration-compatibility" -}} Tiller {{- else }}{{ .Release.Service }}{{ end }}
       spec:
         accessModes:
 {{ toYaml .Values.persistentVolume.accessModes | indent 8 }}

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -125,3 +125,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to
+# "Tiller", as this field is immutable and must be preserved in a
+# helm2-to-helm3 upgrade.
+helm3-migration-compatibility: false


### PR DESCRIPTION
#### What this PR does / why we need it:
When upgrading from a helm2 release using helm [2to3](https://github.com/helm/helm-2to3), helm3 upgrades fail because [`.Release.Service` changed](https://github.com/helm/helm/issues/7211), causing helm to attempt to modify the (immutable) `heritage` label on the Statefulset's VolumeClaimTemplate. This provides a flag to set it back to "Tiller" to allow for upgrades.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
