### PR TITLE
[incubator/druid] provide additional config in secret 

### DIFF
--- a/incubator/druid/Chart.yaml
+++ b/incubator/druid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.19.0
 description: Apache Druid is a high performance real-time analytics database.
 name: druid
-version: 0.2.13
+version: 0.2.14
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
 maintainers:

--- a/incubator/druid/README.md
+++ b/incubator/druid/README.md
@@ -68,6 +68,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `image.pullSecrets`                      | image pull secrest for private repositoty               | `[]`                                       |
 | `configMap.enabled`                       | enable druid configuration as configmap                   | `true`                                     |
 | `configVars`                              | druid configuration variables for all components         | ``                                         |
+| `configSecret.enabled`                   | enable additional druid configuration as secret         | `false`                                |
+| `configSecret.name`                      | secret name used for additional sensitive configuration | `druid`                                    |
 | `gCloudStorage.enabled`                  | look for secret to set google cloud credentials         | `false`                                    |
 | `gCloudStorage.secretName`               | secretName to be mounted as google cloud credentials    | `false`                                    |
 | `broker.enabled`                         | enable broker                                           | `true`                                     |

--- a/incubator/druid/templates/broker/deployment.yaml
+++ b/incubator/druid/templates/broker/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ template "druid.name" . }}
+            {{- if .Values.configSecret.enabled }}
+            - secretRef:
+                name: {{ .Values.configSecret.name }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}

--- a/incubator/druid/templates/coordinator/deployment.yaml
+++ b/incubator/druid/templates/coordinator/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ template "druid.name" . }}
+            {{- if .Values.configSecret.enabled }}
+            - secretRef:
+                name: {{ .Values.configSecret.name }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.coordinator.port }}

--- a/incubator/druid/templates/historical/statefulset.yaml
+++ b/incubator/druid/templates/historical/statefulset.yaml
@@ -83,6 +83,10 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ template "druid.name" . }}
+          {{- if .Values.configSecret.enabled }}
+          - secretRef:
+              name: {{ .Values.configSecret.name }}
+          {{- end }}
         resources:
 {{ toYaml .Values.historical.resources | indent 12 }}
         livenessProbe:

--- a/incubator/druid/templates/middleManager/statefulset.yaml
+++ b/incubator/druid/templates/middleManager/statefulset.yaml
@@ -83,6 +83,10 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ template "druid.name" . }} 
+          {{- if .Values.configSecret.enabled }}
+          - secretRef:
+              name: {{ .Values.configSecret.name }}
+          {{- end }}
         resources:
 {{ toYaml .Values.middleManager.resources | indent 12 }}
         livenessProbe:

--- a/incubator/druid/templates/overlord/deployment.yaml
+++ b/incubator/druid/templates/overlord/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ template "druid.name" . }} 
+            {{- if .Values.configSecret.enabled }}
+            - secretRef:
+                name: {{ .Values.configSecret.name }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.overlord.port }}

--- a/incubator/druid/templates/router/deployment.yaml
+++ b/incubator/druid/templates/router/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ template "druid.name" . }} 
+            {{- if .Values.configSecret.enabled }}
+            - secretRef:
+                name: {{ .Values.configSecret.name }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.router.port }}

--- a/incubator/druid/values.yaml
+++ b/incubator/druid/values.yaml
@@ -33,6 +33,13 @@ configVars:
   druid_emitter_logging_logLevel: debug
   druid_emitter_http_recipientBaseUrl: http://druid_exporter_url:druid_exporter_port/druid
 
+## Existing secret holding passwords (aws, azure,...)
+configSecret:
+  ## If true, env variables will be added from predefined secret
+  ##
+  enabled: false
+  name: "druid"
+
 gCloudStorage:
   enabled: false
   secretName: google-cloud-key


### PR DESCRIPTION

#### What this PR does / why we need it:
Putting sensitive passwords in values.yaml file or in ConfigMap is a bad practice. This change introduces pulling sensitive configuration from existing, pre-defined Secret.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)