### PR TITLE
[stable/hlf-ord] Update Orderer chart for hyperledger 2.x 

### DIFF
--- a/stable/hlf-ord/Chart.yaml
+++ b/stable/hlf-ord/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ord
-version: 1.4.1
-appVersion: 1.4.3
+version: 2.0.0
+appVersion: 2.2.1
 keywords:
   - blockchain
   - hyperledger

--- a/stable/hlf-ord/README.md
+++ b/stable/hlf-ord/README.md
@@ -10,11 +10,11 @@ $ helm install stable/hlf-ord
 
 ## Introduction
 
-The Hyperledger Fabric Orderer can be installed as either a `solo` orderer (for development), or a `kafka` orderer (for crash fault tolerant consensus).
+The Hyperledger Fabric Orderer can be installed as either a `solo` orderer (for development), a `kafka` orderer (for crash fault tolerant consensus) or a `etcdraft` orderer (etcd to maintain the state and raft wich is Leader/Follower type consensus algorithm).
 
 This Orderer can receive transaction endorsements and package them into blocks to be distributed to the nodes of the Hyperledger Fabric network.
 
-Learn more about deploying a production ready consensus framework based on Apache [Kafka](https://hyperledger-fabric.readthedocs.io/en/release-1.1/kafka.html?highlight=orderer). Minimally, you will need to set these options:
+Learn more about deploying a production ready consensus framework based on Apache [Kafka](https://hyperledger-fabric.readthedocs.io/en/release-2.2/kafka.html?highlight=orderer). Minimally, you will need to set these options:
 
 ```
   "default.replication.factor": 4  # given a 4 node Kafka cluster
@@ -24,6 +24,10 @@ Learn more about deploying a production ready consensus framework based on Apach
   "replica.fetch.max.bytes": "103809024"  # 99 * 1024 * 1024 B
   "log.retention.ms": -1  # Since we need to keep logs indefinitely for the HL Fabric Orderer
 ```
+
+Learn more about deploying a production consensus framework based on [etcd and raft](https://hyperledger-fabric.readthedocs.io/en/release-2.2/raft_configuration.html)
+
+You can also check this to migrate from kafka to raft : https://hyperledger-fabric.readthedocs.io/en/release-2.2/kafka_raft_migration.html
 
 ## Prerequisites
 
@@ -98,7 +102,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `persistence.annotations`          | Persistent Volume annotations                                 | `{}`                                                       |
 | `persistence.size`                 | Size of data volume (adjust for production!)                  | `1Gi`                                                      |
 | `persistence.storageClass`         | Storage class of backing PVC                                  | `default`                                                  |
-| `ord.type`                         | Type of Orderer (`solo` or `kafka`)                           | `solo`                                                     |
+| `ord.type`                         | Type of Orderer (`solo`, `etcdraft` or `kafka`)               | `solo`                                                     |
 | `ord.mspID`                        | ID of MSP the Orderer belongs to                              | `OrdererMSP`                                               |
 | `ord.tls.server.enabled`           | Do we enable server-side TLS?                                 | `false`                                                    |
 | `ord.tls.client.enabled`           | Do we enable client-side TLS?                                 | `false`                                                    |
@@ -114,6 +118,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `secrets.ord.intCaCert`            | Int. CA Cert: as 'intermediatecacert.pem'                     | ``                                                         |
 | `secrets.ord.tls`                  | TLS secret: as 'tls.crt' and 'tls.key'                        | ``                                                         |
 | `secrets.ord.tlsRootCert`          | TLS root CA certificate: as 'cert.pem'                        | ``                                                         |
+| `secrets.ord.tlsClient`            | TLS client secret: as 'tls.crt' and 'tls.key'                 | ``                                                         |
 | `secrets.ord.tlsClientRootCert`    | TLS client root CA certificate: as 'cert.pem'                 | ``                                                         |
 | `secrets.genesis`                  | Secret containing Genesis Block for orderer                   | ``                                                         |
 | `secrets.adminCert`                | Secret containing Orderer Org admin certificate               | ``                                                         |

--- a/stable/hlf-ord/templates/configmap--ord.yaml
+++ b/stable/hlf-ord/templates/configmap--ord.yaml
@@ -30,6 +30,8 @@ data:
   ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED: {{ .Values.ord.tls.client.enabled | quote }}
   # This is fixed prior to starting the orderer
   ORDERER_GENERAL_TLS_CLIENTROOTCAS: "/var/hyperledger/tls/client/cert/*"
+  ORDERER_GENERAL_TLS_CLIENTCERT_FILE: "/var/hyperledger/tls/client/pair/tls.crt"
+  ORDERER_GENERAL_TLS_CLIENTKEY_FILE: "/var/hyperledger/tls/client/pair/tls.key"
   GODEBUG: "netdns=go"
   ADMIN_MSP_PATH: /var/hyperledger/admin_msp
   ##############

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
           secret:
             secretName: {{ .Values.secrets.ord.tlsRootCert }}
         {{- end }}
+        {{- if .Values.secrets.ord.tlsClient }}
+        - name: tls-client
+          secret:
+            secretName: {{ .Values.secrets.ord.tlsClient }}
+        {{- end }}
         {{- if .Values.secrets.ord.tlsClientRootCert }}
         - name: tls-clientrootcert
           secret:
@@ -105,7 +110,7 @@ spec:
               - /var/hyperledger
             initialDelaySeconds: 15
           command:
-            - bash
+            - sh
             - -c
             - |
 
@@ -172,6 +177,10 @@ spec:
             {{- if .Values.secrets.ord.tls }}
             - mountPath: /var/hyperledger/tls/server/pair
               name: tls
+            {{- end }}
+            {{- if .Values.secrets.ord.tlsClient }}
+            - mountPath: /var/hyperledger/tls/client/pair
+              name: tls-client
             {{- end }}
             {{- if .Values.secrets.ord.tlsRootCert }}
             - mountPath: /var/hyperledger/tls/server/cert

--- a/stable/hlf-ord/values.yaml
+++ b/stable/hlf-ord/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: hyperledger/fabric-orderer
-  tag: 1.4.3
+  tag: 2.2.1
   pullPolicy: IfNotPresent
 
 service:
@@ -81,6 +81,8 @@ secrets:
     # tls: hlf--ord1-tls
     ## TLS root CA certificate saved under key 'cert.pem'
     # tlsRootCert: hlf--ord-tlsrootcert
+    ## TLS client secret, saved under keys 'tls.crt' and 'tls.key' (to conform with K8S nomenclature)
+    # tlsClient: hlf--ord1-tls
     ## TLS client root CA certificates saved under any names (as there may be multiple)
     # tlsClientRootCerts: hlf--peer-tlsrootcert
   ## This should contain "genesis" block derived from a configtx.yaml


### PR DESCRIPTION
Update Orderer chart for hyperledger 2.x and add etcdraft orderer type.

Signed-off-by: Kelvin Moutet <kelvin.moutet@owkin.com>

#### What this PR does / why we need it:
Update Orderer image to use hyperledger 2.x image. The new image uses alpine as base, so we need to switch from batch to sh.
Moreover, the addition of `etcdraft` as orderer type is recommended and only needs the option `etcdraft`, client tls certificates and the use of this [configuration update](https://hyperledger-fabric.readthedocs.io/en/release-2.2/raft_configuration.html#configuration) for `configtx.yaml`.

#### Special notes for your reviewer:
N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
