### PR TITLE
[stable/hlf-peer] Update Peer chart for hyperledger 2.x

### DIFF
--- a/stable/hlf-peer/Chart.yaml
+++ b/stable/hlf-peer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-peer
-version: 1.6.1
-appVersion: 1.4.3
+version: 2.0.0
+appVersion: 2.2.1
 keywords:
   - blockchain
   - hyperledger

--- a/stable/hlf-peer/README.md
+++ b/stable/hlf-peer/README.md
@@ -70,7 +70,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 The following table lists the configurable parameters of the Hyperledger Fabric Peer chart and default values.
-            
+
 | Parameter                           | Description                                                    | Default                   |
 | ---------------------------------   | -------------------------------------------------              | ------------------------- |
 | `image.repository`                  | `hlf-peer` image repository                                    | `hyperledger/fabric-peer` |
@@ -97,9 +97,9 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `ingress.path`                      | Ingress path                                                   | `/`                       |
 | `ingress.hosts`                     | Ingress hostnames                                              | `[]`                      |
 | `ingress.tls`                       | Ingress TLS configuration                                      | `[]`                      |
-| `dockerSocketPath`                  | Docker Socket path                                             | `/var/run/docker.sock`    |
-| `dockerConfig`                      | Docker Config file base 64 encoded                             | `null`                    |
-| `dockerConfigMountPath`             | Docker Config file mount path                                  | `/root/.docker`           |
+| `docker.socketPath`                 | Docker Socket path                                             | `/var/run/docker.sock`    |
+| `docker.config`                     | Docker Config file base 64 encoded                             | `null`                    |
+| `docker.configMountPath`            | Docker Config file mount path                                  | `/root/.docker`           |
 | `peer.databaseType`                 | Database type to use (`goleveldb` or `CouchDB`)                | `goleveldb`               |
 | `peer.couchdbInstance`              | CouchDB chart name to use `cdb-peer1`                          | `cdb-peer1`               |
 | `peer.mspID`                        | ID of MSP the Peer belongs to                                  | `Org1MSP`                 |
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `peer.metrics.statsd.address`       | Address of the StatsD server                                   | `127.0.0.1:8125`          |
 | `peer.metrics.statsd.writeInterval` | Intervall at whitch counters and gauges are pushed             | `10s`                     |
 | `peer.metrics.statsd.prefix`        | Prefix prepended to all the exported metrics                   | ``                        |
+| `peer.docker.enabled`               | Do we enable Docker                                            | `true`                    |
 | `secrets.peer.cred`                 | Credentials: 'CA_USERNAME' and 'CA_PASSWORD'                   | ``                        |
 | `secrets.peer.cert`                 | Certificate: as 'cert.pem'                                     | ``                        |
 | `secrets.peer.key`                  | Private key: as 'key.pem'                                      | ``                        |
@@ -136,7 +137,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `nodeSelector`                      | Node labels for pod assignment                                 | `{}`                      |
 | `tolerations`                       | Toleration labels for pod assignment                           | `[]`                      |
 | `affinity`                          | Affinity settings for pod assignment                           | `{}`                      |
-  
+
 ## Persistence
 
 The volume stores the Fabric Peer data and configurations at the `/var/hyperledger` path of the container.

--- a/stable/hlf-peer/templates/configmap--peer.yaml
+++ b/stable/hlf-peer/templates/configmap--peer.yaml
@@ -68,7 +68,9 @@ data:
   CORE_PEER_TLS_CLIENTROOTCAS_FILES: "/var/hyperledger/tls/client/cert/*"
   CORE_PEER_TLS_CLIENTCERT_FILE: "/var/hyperledger/tls/client/pair/tls.crt"
   CORE_PEER_TLS_CLIENTKEY_FILE: "/var/hyperledger/tls/client/pair/tls.key"
+  {{- if .Values.peer.docker.enabled }}
   CORE_VM_ENDPOINT: unix:///host/var/run/docker.sock
+  {{- end}}
   CORE_LEDGER_STATE_STATEDATABASE: {{ .Values.peer.databaseType | quote }}
   # Containers in the same pod share the host
   {{- if eq .Values.peer.databaseType "CouchDB" }}

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -27,16 +27,18 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+        {{- if .Values.peer.docker.enabled }}
         - name: dockersocket
           hostPath:
-            path: {{ .Values.dockerSocketPath }}
-        {{- if .Values.dockerConfig }}
+            path: {{ .Values.docker.socketPath }}
+        {{- if .Values.docker.config }}
         - name: docker-config
           secret:
             secretName: {{ include "hlf-peer.fullname" . }}-dockerconfigjson
             items:
               - key: .dockerconfigjson
                 path: config.json
+        {{- end }}
         {{- end }}
         {{- if .Values.secrets.peer.cert }}
         - name: id-cert
@@ -131,7 +133,7 @@ spec:
               - /var/hyperledger
             initialDelaySeconds: 15
           command:
-            - bash
+            - sh
             - -c
             - |
               # To avoid having separate secrets for CouchDB and HLF
@@ -174,12 +176,14 @@ spec:
           volumeMounts:
             - mountPath: /var/hyperledger
               name: data
+            {{- if .Values.peer.docker.enabled }}
             - mountPath: /host/var/run/docker.sock
               name: dockersocket
-            {{- if .Values.dockerConfig }}
+            {{- if .Values.docker.config }}
             - name: docker-config
-              mountPath: {{ .Values.dockerConfigMountPath }}
-            {{ end }}
+              mountPath: {{ .Values.docker.configMountPath }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.secrets.peer.cert }}
             - mountPath: /var/hyperledger/msp/signcerts
               name: id-cert

--- a/stable/hlf-peer/values.yaml
+++ b/stable/hlf-peer/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: hyperledger/fabric-peer
-  tag: 1.4.3
+  tag: 2.2.1
   pullPolicy: IfNotPresent
 
 service:
@@ -14,12 +14,13 @@ service:
   portEvent: 7053
   portMetrics: 9443
 
-# Path of the docker socket on the host
-dockerSocketPath: /var/run/docker.sock
-# Docker config to be used to pull the images (base64'd)
-dockerConfig: null
-# Docker config mount path
-dockerConfigMountPath: /root/.docker
+docker:
+  # Path of the docker socket on the host
+  socketPath: /var/run/docker.sock
+  # Docker config to be used to pull the images (base64'd)
+  config: null
+  # Docker config mount path
+  configMountPath: /root/.docker
 
 ingress:
   enabled: false
@@ -97,6 +98,10 @@ peer:
       address: "127.0.0.1:8125"
       writeInterval: "10s"
       prefix: ""
+
+  docker:
+    enabled: true
+
 # Secrets references, empty by default, fill in with your secrets (particularly adminCert) or add Peer Admin certificate manually after launching chart.
 secrets:
   ## These secrets should contain the Orderer crypto materials and credentials
@@ -115,7 +120,7 @@ secrets:
     # tls: hlf--peer1-tls
     ## TLS root CA certificate saved under key 'cert.pem'
     # tlsRootCert: hlf--peer-tlsrootcert
-    ## TLS client root CA certificates saved under any names (as there may be multiple)
+    ## TLS secret, saved under keys 'tls.crt' and 'tls.key' (to conform with K8S nomenclature)
     # tlsClient: hlf--peer1-tls
     ## TLS client root CA certificates saved under any names (as there may be multiple)
     # tlsClientRootCerts: hlf--ord-tlsrootcert


### PR DESCRIPTION
Update Peer chart for hyperledger 2.x and make docker socket optional.

Signed-off-by: Kelvin Moutet <kelvin.moutet@owkin.com>

#### What this PR does / why we need it:

Update Peer image to use hyperledger 2.x image. The new image uses alpine as base, so we need to switch from batch to sh.
Moreover, make docker socket optional as we can use external chaincode with the new chaincode lifecycle
https://hyperledger-fabric.readthedocs.io/en/release-2.2/enable_cc_lifecycle.html

#### Special notes for your reviewer:
N/A
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
