### PR TITLE
[incubator/sparkoperator] fix invalid webhook init job

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.8.3
+version: 0.8.4
 appVersion: v1beta2-1.2.0-3.0.0
 keywords:
   - spark

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  metadata:
-    name: {{ include "sparkoperator.fullname" . }}-webhook-init
-    {{- if .Values.istio.enabled }}
-    annotations:
-      "sidecar.istio.io/inject": "false"
-    {{- end }}
   template:
+    metadata:
+      name: {{ include "sparkoperator.fullname" . }}-webhook-init
+      {{- if .Values.istio.enabled }}
+      annotations:
+        "sidecar.istio.io/inject": "false"
+      {{- end }}
     spec:
       serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
       restartPolicy: OnFailure


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Prior to these changes helm validation for webhook-init-job of
incubator/sparkoperator failed in helm3 with the following error:

    Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Job.spec): unknown field "metadata" in io.k8s.api.batch.v1.JobSpec

Issue was introduced by https://github.com/helm/charts/pull/23876 by
accident, as other jobs in this chart (incubator/sparkoperator) were not
affected.

#### Which issue this PR fixes

Prior to these changes helm validation for webhook-init-job of
incubator/sparkoperator failed in helm3 with the following error:

    Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Job.spec): unknown field "metadata" in io.k8s.api.batch.v1.JobSpec

Issue was introduced by https://github.com/helm/charts/pull/23876 by
accident, as other jobs in this chart (incubator/sparkoperator) were not
affected.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md (not needed)
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
