### PR TITLE
[stable/airflow] Add namespace and correct service name in NOTES.txt

### DIFF
--- a/stable/airflow/templates/NOTES.txt
+++ b/stable/airflow/templates/NOTES.txt
@@ -18,8 +18,8 @@ Ingress URL to Airflow and Flower:
    echo http://$NODE_IP:$NODE_PORT/
 {{- else if contains "LoadBalancer" .Values.web.service.type }}
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-         You can watch the status of the service by running 'kubectl get svc -w {{ include "airflow.fullname" . }}'
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "airflow.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+         You can watch the status of the service by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "airflow.fullname" . }}-web'
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "airflow.fullname" . }}-web -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
    echo http://$SERVICE_IP:{{ .Values.web.service.externalPort }}/
 {{- else if contains "ClusterIP" .Values.web.service.type }}
    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component=web,app={{ include "airflow.labels.app" . }}" -o jsonpath="{.items[0].metadata.name}")


### PR DESCRIPTION
Add namespace and correct service name in NOTES.txt

Signed-off-by: Ramses Rodriguez Martinez ramses.harpago@gmail.com

#### What this PR does / why we need it:
This PR improves the NOTES.txt template shown after a deployment to include the correct service name airflow-web and to take into account the service namespace.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
