### PR TITLE
[stable/lamp] Adding quote to git sync wait

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 1.1.3
+version: 1.1.4
 appVersion: 7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -607,7 +607,7 @@ spec:
         - name: GIT_SYNC_REV
           value: {{ .Values.git.revision }}
         - name: GIT_SYNC_WAIT
-          value: {{ .Values.git.wait }}
+          value: {{ quote .Values.git.wait }}
         - name: GIT_SYNC_DEST
           value: /git
         volumeMounts:


### PR DESCRIPTION
I'm using helm 3 version `version.BuildInfo{Version:"v3.3.4", GitCommit:"a61ce5633af99708171414353ed49547cf05013d", GitTreeState:"clean", GoVersion:"go1.14.9"}` and I can't create this chart with git enabled. The following error is thrown:
```
Error: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 3, error found in #10 byte of ...|,"value":30},{"name"|..., bigger context ...|e":"FETCH_HEAD"},{"name":"GIT_SYNC_WAIT","value":30},{"name":"GIT_SYNC_DEST","value":"/git"}],"image|...
```

This change quotes the timeout and allows chart creation.