### PR TITLE
[stable/nfs-server-provisioner] add deprecation warning

### DIFF
--- a/stable/nfs-server-provisioner/README.md
+++ b/stable/nfs-server-provisioner/README.md
@@ -1,3 +1,12 @@
+# ⚠️  DEPRECATED
+
+*As part of the [deprecation timeline](https://github.com/helm/charts/#deprecation-timeline).*
+
+This chart is deprecated as we have moved to the upstream repo [NFS Ganesha server and external provisioner](https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner)  
+the chart source can be found here:
+
+https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/tree/master/deploy/helm
+
 # NFS Server Provisioner
 
 [NFS Server Provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs)


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

Add deprecation warning to notify users about the new chart repository

#### Which issue this PR fixes

#### Special notes for your reviewer:

pull request: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/pull/13

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
