### PR TITLE
stable/fluentd include spec.serviceName if either autoscaling.enabled or useStatefulSet

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.5.1
+version: 2.5.2
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
-{{- if .Values.autoscaling.enabled }}
+{{- if $statefulSet }}
   serviceName: {{ template "fluentd.name" . }}
 {{- end }}
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it:
specifying that a statefulset is being used should preclude the need to specify that auto-scaling is enabled 

#### Which issue this PR fixes
fixes #23893 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
