### PR TITLE
[stable/vsphere-cpi] Fix failing installation when mapping values are specified

### DIFF
--- a/stable/vsphere-cpi/Chart.yaml
+++ b/stable/vsphere-cpi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.1
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: vsphere-cpi
-version: 0.2.0
+version: 0.2.1
 keywords:
   - vsphere
   - vmware

--- a/stable/vsphere-cpi/templates/daemonset.yaml
+++ b/stable/vsphere-cpi/templates/daemonset.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
     {{- if .Values.daemonset.annotations }}
-    {{- toYaml .Values.daemonset.annotations | indent 4 }}
+    {{- toYaml .Values.daemonset.annotations | nindent 4 }}
     {{- end }}
 spec:
   selector:
@@ -26,7 +26,7 @@ spec:
     metadata:
       {{- if .Values.daemonset.podAnnotations }}
       annotations:
-      {{- toYaml .Values.daemonset.podAnnotations | indent 8 }}
+      {{- toYaml .Values.daemonset.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "cpi.name" . }}
@@ -35,13 +35,13 @@ spec:
         release: {{ .Release.Name }}
         vsphere-cpi-infra: daemonset
         {{- if .Values.daemonset.podLabels }}
-        {{- toYaml .Values.daemonset.podLabels | indent 8 }}
+        {{- toYaml .Values.daemonset.podLabels | nindent 8 }}
         {{- end }}
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       {{- if .Values.daemonset.nodeSelector }}
-      {{- toYaml .Values.daemonset.nodeSelector | indent 8 }}
+      {{- toYaml .Values.daemonset.nodeSelector | nindent 8 }}
       {{- end }}
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
@@ -53,7 +53,7 @@ spec:
         effect: NoSchedule
         operator: Exists
       {{- if .Values.daemonset.tolerations }}
-      {{- toYaml .Values.daemonset.tolerations | indent 8 }}
+      {{- toYaml .Values.daemonset.tolerations | nindent 6 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -93,7 +93,7 @@ spec:
             readOnly: true
         {{- if .Values.daemonset.resources }}
         resources:
-          {{- toYaml .Values.daemonset.resources | indent 10 }}
+          {{- toYaml .Values.daemonset.resources | nindent 10 }}
         {{- end }}
       volumes:
         - name: vsphere-config-volume


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

NO

#### What this PR does / why we need it:
Fixes a bug that causes an installation error

#### Which issue this PR fixes

When the Helm chart is deployed while specifying mapping values such as `daemonset.tolerations` or `daemonset.annotations` the installation fails with errors like this:

> Error: YAML parse error on keepalived-ingress-vip/templates/deployment.yaml: error converting YAML to JSON: yaml: line 42: mapping values are not allowed in this context

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
