### PR TITLE
[stable/metabase] Allow MAX_SESSION_AGE and MB_SESSION_COOKIES to be set from values.yaml

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.12.1
+version: 0.13.0
 appVersion: v0.36.3
 maintainers:
 - name: pmint93

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -103,6 +103,8 @@ The following table lists the configurable parameters of the Metabase chart and 
 | jetty.maxQueued                  | Jetty max queue size                                        | null              |
 | jetty.maxIdleTime                | Jetty max idle time                                         | null              |
 | siteUrl                          | Base URL, useful for serving behind a reverse proxy         | null              |
+| session.maxSessionAge            | Session expiration defined in minutes                       | 20160             |
+| session.sessionCookies           | When browser is closed, user login session will expire      | null              |
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](http://www.metabase.com/docs/v0.36.3/).
 

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
           {{- end }}
           {{- if .Values.session.maxSessionAge }}
           - name: MAX_SESSION_AGE
-            value: {{ .Values.session.maxSessionAge }}
+            value: {{ .Values.session.maxSessionAge | quote }}
           {{- end }}
           {{- if .Values.session.sessionCookies }}
           - name: MB_SESSION_COOKIES

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -118,6 +118,14 @@ spec:
           - name: MB_SITE_URL
             value: {{ .Values.siteUrl | quote }}
           {{- end }}
+          {{- if .Values.session.maxSessionAge }}
+          - name: MAX_SESSION_AGE
+            value: {{ .Values.session.maxSessionAge }}
+          {{- end }}
+          {{- if .Values.session.sessionCookies }}
+          - name: MB_SESSION_COOKIES
+            value: {{ .Values.session.sessionCookies | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -64,9 +64,9 @@ emojiLogging: true
 # pluginsDirectory:
 # siteUrl:
 
-# session:
-#   maxSessionAge:
-#   sessionCookies:
+session: {}
+  # maxSessionAge:
+  # sessionCookies:
 
 livenessProbe:
   initialDelaySeconds: 120

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -64,6 +64,10 @@ emojiLogging: true
 # pluginsDirectory:
 # siteUrl:
 
+# session:
+#   maxSessionAge:
+#   sessionCookies:
+
 livenessProbe:
   initialDelaySeconds: 120
   timeoutSeconds: 30


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

Allow MAX_SESSION_AGE and MB_SESSION_COOKIES to be set from values.yaml

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
