### PR TITLE
[stable/coredns] Properly indent pod annotations

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.13.5
+version: 1.13.6
 appVersion: 1.7.1
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         {{- end }}
-        {{- if .Values.podAnnotations }}
-        {{ toYaml .Values.podAnnotations }}
-        {{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Currently, only the first podAnnotation is properly indented.  Attempting to add more than one pod annotation results in a yaml parsing error during deploy.  This PR uses the indent function to properly indent pod annotations.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
