### PR TITLE
[stable/openebs] Fixes dead link to artifact hub in readme

### DIFF
--- a/stable/openebs/Chart.yaml
+++ b/stable/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.11.1
+version: 1.11.2
 name: openebs
 appVersion: 1.11.0
 # The chart is deprecated and moved. See README.md

--- a/stable/openebs/README.md
+++ b/stable/openebs/README.md
@@ -3,7 +3,7 @@ OpenEBS
 
 ## NOTICE: This chart has moved!
 
-Due to the [deprecation and obsoletion plan](https://github.com/helm/charts#status-of-the-project) of the Helm charts repository this chart has been moved to a new repository. The source for the OpenEBS Charts is moved to [OpenEBS Charts GitHub project](https://github.com/openebs/charts). The chart is hosted at https://hub.helm.sh/charts?q=openebs.
+Due to the [deprecation and obsoletion plan](https://github.com/helm/charts#status-of-the-project) of the Helm charts repository this chart has been moved to a new repository. The source for the OpenEBS Charts is moved to [OpenEBS Charts GitHub project](https://github.com/openebs/charts). The chart can be found using [artifacthub.io](https://artifacthub.io/packages/search?ts_query_web=openebs).
 
 
 


### PR DESCRIPTION
https://github.com/helm/charts/blob/master/stable/openebs/README.md references dead link: https://hub.helm.sh/charts?q=openebs

![image](https://user-images.githubusercontent.com/18498995/96252000-2d5ea880-0fa9-11eb-87ef-7bb91df12613.png)
