### PR TITLE
[stable/kuberhealthy] Deprecate chart

### DIFF
--- a/stable/kuberhealthy/Chart.yaml
+++ b/stable/kuberhealthy/Chart.yaml
@@ -1,16 +1,10 @@
 apiVersion: v1
 appVersion: "v1.0.2"
 home: https://comcast.github.io/kuberhealthy/
-description: The official Helm chart for Kuberhealthy.
+description: DEPRECATED. Please use https://comcast.github.io/kuberhealthy/ instead.
 name: kuberhealthy
-version: 1.2.6
-maintainers:
-  - name: integrii
-    email: eric.greer@comcast.com
-  - name: lolimjake
-    email: jacob.martin@comcast.com
-  - name: ihoegen
-    email: ianhoegen@gmail.com
+deprecated: true
+version: 1.2.7
 keywords:
 - kuberhealthy
 - kubernetes

--- a/stable/kuberhealthy/README.md
+++ b/stable/kuberhealthy/README.md
@@ -1,3 +1,5 @@
+*** DEPRECATED, please use https://comcast.github.io/kuberhealthy/ instead
+
 <center><img src="https://github.com/Comcast/kuberhealthy/blob/master/images/kuberhealthy.png?raw=true"></center><br />
 
 Easy synthetic testing for [Kubernetes](https://kubernetes.io) clusters.  Supplements other solutions like [Prometheus](https://prometheus.io/) nicely.


### PR DESCRIPTION
Signed-off-by: David Karlsen <david@davidkarlsen.com>
Deprecate chart in favour of upstream repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/helm/charts/23919)
<!-- Reviewable:end -->
