### PR TITLE
GH Actions to automate gh-pages

### DIFF
--- a/.github/workflows/sync-readmes.yaml
+++ b/.github/workflows/sync-readmes.yaml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'stable/README.md'
+      - 'incubator/README.md'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          mkdir -p ${{ runner.temp }}/stable ${{ runner.temp }}/incubator
+          cp -f stable/README.md ${{ runner.temp }}/stable/README.md
+          cp -f incubator/README.md ${{ runner.temp }}/incubator/README.md
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - run: |
+          cp -f ${{ runner.temp }}/stable/README.md stable
+          cp -f ${{ runner.temp }}/incubator/README.md incubator
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add stable/README.md incubator/README.md
+          git commit --signoff -m "Sync READMEs from master [ci skip]"
+          git push

--- a/.github/workflows/sync-repos.yaml
+++ b/.github/workflows/sync-repos.yaml
@@ -53,8 +53,7 @@ jobs:
           echo "dirs: ${{ needs.changes.outputs.stable_dirs }}"
           mkdir -p ${{ runner.temp }}/stable/packages
           for dir in ${{ needs.changes.outputs.stable_dirs }}; do
-              if helm dependency build "$dir"; then
-                  helm package --destination ${{ runner.temp }}/stable/packages "$dir"
+              if helm package --dependency-update --destination ${{ runner.temp }}/stable/packages "$dir"; then
                   echo "✅ built dependencies and packaged $dir"
               else
                   echo "❌ unable to build dependencies for $dir"
@@ -71,8 +70,7 @@ jobs:
         run: |
           mkdir -p ${{ runner.temp }}/incubator/packages
           for dir in ${{ needs.changes.outputs.incubator_dirs }}; do
-              if helm dependency build "$dir"; then
-                  helm package --destination ${{ runner.temp }}/incubator/packages "$dir"
+              if helm package --dependency-update --destination ${{ runner.temp }}/incubator/packages "$dir"; then
                   echo "✅ built dependencies and packaged $dir"
               else
                   echo "❌ unable to build dependencies for $dir"

--- a/.github/workflows/sync-repos.yaml
+++ b/.github/workflows/sync-repos.yaml
@@ -1,0 +1,140 @@
+on:
+  push:
+    branches:
+      - master
+    # Only bother running workflow if files in one of these subfolder have
+    # changed since most recent commit to master.
+    paths:
+      - 'stable/*/**'
+      - 'incubator/*/**'
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      stable: ${{ steps.filter.outputs.stable }}
+      incubator: ${{ steps.filter.outputs.incubator }}
+      stable_dirs: ${{ steps.dirs.outputs.stable_dirs }}
+      incubator_dirs: ${{ steps.dirs.outputs.incubator_dirs }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2.5.0
+        id: filter
+        with:
+          list-files: shell
+          filters: |
+            stable:
+              - added|modified: 'stable/*/**'
+            incubator:
+              - added|modified: 'incubator/*/**'
+      # Exports space-separated lists of changed chart dirs
+      #   "xargs -n1" converts to newlines
+      #   "cut -d/ -f 1-2" gets the first two dirs (example: stable/wordpress)
+      #   "sort -u" gets sorted unique dirs
+      #   "xargs" converts back to space-separated string
+      - id: dirs
+        run: |
+          echo "stable files: ${{ steps.filter.outputs.stable_files }}"
+          echo "incubator files: ${{ steps.filter.outputs.stable_files }}"
+          stable_dirs=$(echo ${{ steps.filter.outputs.stable_files }} | xargs -n1 | cut -d/ -f 1-2 | sort -u | xargs)
+          echo "::set-output name=stable_dirs::$stable_dirs"
+          echo "stable dirs: $stable_dirs"
+          incubator_dirs=$(echo ${{ steps.filter.outputs.incubator_files }} | xargs -n1 | cut -d/ -f 1-2 | sort -u | xargs)
+          echo "::set-output name=incubator_dirs::$incubator_dirs"
+          echo "incubator dirs: $incubator_dirs"
+
+  package:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: package stable
+        if: ${{ needs.changes.outputs.stable == 'true' }}
+        run: |
+          echo "dirs: ${{ needs.changes.outputs.stable_dirs }}"
+          mkdir -p ${{ runner.temp }}/stable/packages
+          for dir in ${{ needs.changes.outputs.stable_dirs }}; do
+              if helm dependency build "$dir"; then
+                  helm package --destination ${{ runner.temp }}/stable/packages "$dir"
+                  echo "✅ built dependencies and packaged $dir"
+              else
+                  echo "❌ unable to build dependencies for $dir"
+                  exit 1
+              fi
+          done
+      - uses: actions/upload-artifact@v2
+        if: ${{ needs.changes.outputs.stable == 'true' }}
+        with:
+          name: stable-packages
+          path: ${{ runner.temp }}/stable/packages/
+      - name: package incubator
+        if: ${{ needs.changes.outputs.incubator == 'true' }}
+        run: |
+          mkdir -p ${{ runner.temp }}/incubator/packages
+          for dir in ${{ needs.changes.outputs.incubator_dirs }}; do
+              if helm dependency build "$dir"; then
+                  helm package --destination ${{ runner.temp }}/incubator/packages "$dir"
+                  echo "✅ built dependencies and packaged $dir"
+              else
+                  echo "❌ unable to build dependencies for $dir"
+                  exit 1
+              fi
+          done
+      - uses: actions/upload-artifact@v2
+        if: ${{ needs.changes.outputs.incubator == 'true' }}
+        with:
+          name: incubator-packages
+          path: ${{ runner.temp }}/incubator/packages/
+
+  index-release:
+    needs:
+      - changes
+      - package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - uses: actions/download-artifact@v2
+        if: ${{ needs.changes.outputs.stable == 'true' }}
+        with:
+          name: stable-packages
+          path: ${{ runner.temp }}/stable/packages
+      - name: sync stable
+        if: ${{ needs.changes.outputs.stable == 'true' }}
+        run: |
+          if helm repo index --url https://charts.helm.sh/stable --merge stable/index.yaml ${{ runner.temp }}/stable; then
+              mv -f ${{ runner.temp }}/stable/index.yaml stable/index.yaml
+              git add stable/index.yaml
+          else
+              echo "❌ unable to update index"
+              exit 1
+          fi
+          mkdir -p stable/packages
+          cp -f ${{ runner.temp }}/stable/packages/*.tgz stable/packages
+          git add stable/packages/*.tgz
+          git commit --signoff -m "Sync stable [ci skip]"
+          git push
+      - uses: actions/download-artifact@v2
+        if: ${{ needs.changes.outputs.incubator == 'true' }}
+        with:
+          name: incubator-packages
+          path: ${{ runner.temp }}/incubator/packages
+      - name: sync incubator
+        if: ${{ needs.changes.outputs.incubator == 'true' }}
+        run: |
+          if helm repo index --url https://charts.helm.sh/stable/incubator --merge incubator/index.yaml ${{ runner.temp }}/incubator; then
+              mv -f ${{ runner.temp }}/incubator/index.yaml incubator/index.yaml
+              git add incubator/index.yaml
+          else
+              echo "❌ unable to update index"
+              exit 1
+          fi
+          mkdir -p incubator/packages
+          cp -f ${{ runner.temp }}/incubator/packages/*.tgz incubator/packages
+          git add incubator/packages/*.tgz
+          git commit --signoff -m "Sync incubator [ci skip]"
+          git push

--- a/incubator/README.md
+++ b/incubator/README.md
@@ -1,0 +1,29 @@
+# Helm Incubator
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add incubator https://charts.helm.sh/incubator
+```
+
+You can then run `helm search repo incubator` to see the charts, or browse on CNCF [Artifact Hub](https://artifacthub.io/packages/search?page=1&repo=helm-incubator).
+
+## Contributing
+
+<!-- Keep full URL links to repo files because this README syncs from master to gh-pages.  -->
+⚠️ Note the [status of the project](https://github.com/helm/charts/blob/master/README.md#status-of-the-project), [deprecation timeline](https://github.com/helm/charts/blob/master/README.md#deprecation-timeline), and the ongoing effort to [relocate charts to new repos](https://github.com/helm/charts/issues/21103).
+
+<!-- Keep full URL links to repo files because this README syncs from master to gh-pages.  -->
+We'd love to have you contribute! Please refer to our [contribution guidelines](https://github.com/helm/charts/blob/master/CONTRIBUTING.md) for details.
+
+## License
+
+<!-- Keep full URL links to repo files because this README syncs from master to gh-pages.  -->
+[Apache 2.0 License](https://github.com/helm/charts/blob/master/LICENSE).

--- a/stable/README.md
+++ b/stable/README.md
@@ -1,0 +1,29 @@
+# Helm Stable
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add stable https://charts.helm.sh/stable
+```
+
+You can then run `helm search repo stable` to see the charts, or browse on CNCF [Artifact Hub](https://artifacthub.io/packages/search?page=1&repo=helm-stable).
+
+## Contributing
+
+<!-- Keep full URL links to repo files because this README syncs from master to gh-pages.  -->
+⚠️ Note the [status of the project](https://github.com/helm/charts/blob/master/README.md#status-of-the-project), [deprecation timeline](https://github.com/helm/charts/blob/master/README.md#deprecation-timeline), and the ongoing effort to [relocate charts to new repos](https://github.com/helm/charts/issues/21103).
+
+<!-- Keep full URL links to repo files because this README syncs from master to gh-pages.  -->
+We'd love to have you contribute! Please refer to our [contribution guidelines](https://github.com/helm/charts/blob/master/CONTRIBUTING.md) for details.
+
+## License
+
+<!-- Keep full URL links to repo files because this README syncs from master to gh-pages.  -->
+[Apache 2.0 License](https://github.com/helm/charts/blob/master/LICENSE).


### PR DESCRIPTION
Relates to https://github.com/helm/charts/issues/23850 (explanatory blog post forthcoming).

- Charts are auto-synced to gh-pages hosted chart repos.
- Chart repo READMEs are auto-synced to gh-pages on any changes to these files in master. This will allow changes to gh-pages READMEs using the normal PR process (including access) on master.

See https://github.com/scottrigby/chart-repo-gh-pages for a vanilla working example.

Notes:
- There have been some packages published between when https://github.com/helm/charts/pull/23913 and https://github.com/helm/charts/pull/23911 were merged and now. Filling in the package history gap will be.a follow-up PR once this one is merged.
- This PR doesn't remove `test/repo-sync.sh`, since for now we want to continue publishing both to GCR and gh-pages. @viglesiasce this is where our timeline/plan comes in. Can be addressed in follow-up PRs.
- Some of these `run` steps could be moved into local actions, but it didn't seem as though it would help much here, and I hope the shell is clear all in one place.
