### PR TITLE
Remove ezimanyi as owner of spinnaker chart

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.3
+version: 2.2.4
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -11,8 +11,6 @@ icon: https://pbs.twimg.com/profile_images/669205226994319362/O7OjwPrh_400x400.p
 maintainers:
 - name: viglesiasce
   email: viglesias@google.com
-- name: ezimanyi
-  email: ezimanyi@google.com
 - name: dwardu89
   email: hello@dwardu.com
 - name: paulczar

--- a/stable/spinnaker/OWNERS
+++ b/stable/spinnaker/OWNERS
@@ -1,10 +1,8 @@
 approvers:
 - viglesiasce
-- ezimanyi
 - dwardu89
 - paulczar
 reviewers:
 - viglesiasce
-- ezimanyi
 - dwardu89
 - paulczar


### PR DESCRIPTION
Lars added me to replace him when he stopped working on Spinnaker, but I've mostly been focused on other aspects of the Spinnaker project and haven't had the time to devote to looking at PRs in this chart repo. Removing myself as I'm not close enough to this chart to be an owner/approver.