### PR TITLE
[stable/spark-history-server] Add support for default account and Workload Identity when accessing GCS backend

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark-history-server
-version: 1.3.0
+version: 1.4.0
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/README.md
+++ b/stable/spark-history-server/README.md
@@ -16,6 +16,8 @@
 
   If using GCS as storage, follow the preparatory steps below:
 
+  Note: Use the `gcs.enableIAM` flag if running on GKE with Workload Idenity or if the node's service account already has the required permissions. Otherwise follow the steps below.
+
   Set up `gsutil` and `gcloud` on your local laptop and associate them with your Google Cloud Platform (GCP) project, create a bucket, create an IAM service account `sparkonk8s`, generate a JSON key file `sparkonk8s.json`, to grant `sparkonk8s` admin permission to bucket `gs://spark-history-server`.
 
   ```bash

--- a/stable/spark-history-server/templates/deployment.yaml
+++ b/stable/spark-history-server/templates/deployment.yaml
@@ -48,8 +48,11 @@ spec:
             -Dspark.history.fs.logDirectory=file:/data/$eventsDir";
           elif [ "$enableGCS" == "true" ]; then
             export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
-            -Dspark.hadoop.google.cloud.auth.service.account.json.keyfile=/etc/secrets/$key \
             -Dspark.history.fs.logDirectory=$logDirectory";
+            if [ "$enableIAM" == "false" ]; then
+              export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
+              -Dspark.hadoop.google.cloud.auth.service.account.json.keyfile=/etc/secrets/$key";
+            fi;
           elif [ "$enableS3" == "true" ]; then
             export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
               -Dspark.history.fs.logDirectory=$logDirectory \
@@ -101,9 +104,11 @@ spec:
         - name: data
           mountPath: /data
         {{- else if .Values.gcs.enableGCS }}
+        {{- if (not .Values.gcs.enableIAM) }}
         volumeMounts:
         - name: secrets-volume
           mountPath: /etc/secrets
+        {{- end }}
         {{- else if .Values.s3.enableS3 }}
         {{- if (not .Values.s3.enableIAM) }}
         volumeMounts:
@@ -129,10 +134,12 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.pvc.existingClaimName }}
       {{- else if .Values.gcs.enableGCS }}
+      {{- if (not .Values.gcs.enableIAM) }}
       volumes:
       - name: secrets-volume
         secret:
           secretName: {{ .Values.gcs.secret }}
+      {{- end }}
       {{- else if .Values.s3.enableS3 }}
       {{- if (not .Values.s3.enableIAM) }}
       volumes:

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -79,6 +79,7 @@ nfs:
 
 gcs:
   enableGCS: false
+  enableIAM: false
   secret: history-secrets
   key: sparkonk8s.json
   logDirectory: gs://spark-hs/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR adds support for using `default application credentials` or `workload identity` when using GCS as backend. Google also recommends using `Workload Identity` instead of service account tokens if running on GKE.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Hey @yuchaoran2011 , Please take a look.
