### PR TITLE
[stable/airflow] create flower oauthDomains config

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.12.1
+version: 7.13.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -52,6 +52,7 @@ kubectl exec \
 
 Chart version numbers: [Chart.yaml](Chart.yaml) or [Helm Hub](https://hub.helm.sh/charts/stable/airflow)
 
+- [v7.12.X → v7.13.0](UPGRADE.md#v712x--v7130)
 - [v7.11.X → v7.12.0](UPGRADE.md#v711x--v7120)
 - [v7.10.X → v7.11.0](UPGRADE.md#v710x--v7110)
 - [v7.9.X → v7.10.0](UPGRADE.md#v79x--v7100)
@@ -753,6 +754,7 @@ __Airflow Flower Values:__
 | `flower.podAnnotations` | Pod annotations for the flower Deployment | `{}` |
 | `flower.safeToEvict` | if we should tell Kubernetes Autoscaler that its safe to evict these Pods | `true` |
 | `flower.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the flower Deployment | `<see values.yaml>` |
+| `flower.oauthDomains` | the value of the flower `--auth` argument | `""` |
 | `flower.basicAuthSecret` | the name of a pre-created secret containing the basic authentication value for flower | `""` |
 | `flower.basicAuthSecretKey` | the key within `flower.basicAuthSecret` containing the basic authentication string | `""` |
 | `flower.urlPrefix` | sets `AIRFLOW__CELERY__FLOWER_URL_PREFIX` | `""` |

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrading Steps
 
+## `v7.12.X` → `v7.13.0`
+
+__The following values have been ADDED:__
+* `flower.oauthDomains`
+
 ## `v7.11.X` → `v7.12.0`
 
 __The following values have been ADDED:__

--- a/stable/airflow/templates/flower/flower-deployment.yaml
+++ b/stable/airflow/templates/flower/flower-deployment.yaml
@@ -109,7 +109,12 @@ spec:
                && mkdir -p /home/airflow/.local/bin \
                && export PATH="/home/airflow/.local/bin:$PATH" \
                && echo "*** running flower..." \
+              {{- if .Values.flower.oauthDomains }}
+               && exec airflow flower --auth={{ .Values.flower.oauthDomains | quote }}
+              {{- else }}
                && exec airflow flower
+              {{- end }}
+
           livenessProbe:
             {{- if and (.Values.flower.basicAuthSecret) (not .Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH) }}
             exec:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -758,6 +758,13 @@ flower:
     ##
     minAvailable: ""
 
+  ## the value of the flower `--auth` argument
+  ##
+  ## NOTE:
+  ##  - see flower docs: https://flower.readthedocs.io/en/latest/auth.html#google-oauth-2-0
+  ##
+  oauthDomains: ""
+
   ## the name of a pre-created secret containing the basic authentication value for flower
   ##
   ## NOTE:


### PR DESCRIPTION
 ## What this PR does / why we need it:
enables google oauth for the stable/airflow chart (flower component)
#### Which issue this PR fixes
  - fixes #23918

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@thesuperzapper 