### PR TITLE
[stable/seq] Add default nodeSelector targeting Linux OS for Seq

### DIFF
--- a/stable/seq/values.yaml
+++ b/stable/seq/values.yaml
@@ -80,7 +80,8 @@ cache:
   # 70% (`0.7`) is a good starting point for machines with up to ~8GB of RAM.
   targetSize: 0.7
 
-nodeSelector: {}
+nodeSelector: 
+  kubernetes.io/os: linux
 
 tolerations: []
 


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It increases the success of Seq getting properly installed and running within hybrid Kubernetes environments (having both windows and linux worker nodes)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #23929

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
