### PR TITLE
[stable/traefik] Update cloudflare environment variables

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.87.2
+version: 1.87.3
 appVersion: 1.7.24
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -269,8 +269,8 @@ acme:
       AZURE_TENANT_ID: ""
       AZURE_RESOURCE_GROUP: ""
     cloudflare:
-      CLOUDFLARE_EMAIL: ""
-      CLOUDFLARE_API_KEY: ""
+      CF_API_EMAIL: ""
+      CF_API_KEY: ""
     digitalocean:
       DO_AUTH_TOKEN: ""
     dnsimple:


### PR DESCRIPTION
## Context

Cloudflare DNS provider could not be hooked up correctly because of upstream changes with environment variables

Version 1.7 has changed the Cloudflare DNS provider environment variables from `CLOUDFLARE_*` to `CF_API_*`

Ref: https://doc.traefik.io/traefik/v1.7/configuration/acme/

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

cc @emilevauge @dtomcej @timoreimann @vdemeester @nmengin @mmatur @ldez @Juliens @jbdoumenjou @geraldcroes @SantoDE @errm
