### PR TITLE
[incubator/cassandra] Optionally override seeders list

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.15.2
+version: 0.15.3
 appVersion: 3.11.6
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -109,7 +109,9 @@ spec:
         {{- $seed_size := default 1 .Values.config.seed_size | int -}}
         {{- $global := . }}
         - name: CASSANDRA_SEEDS
-          {{- if .Values.hostNetwork }}
+          {{- if .Values.config.seeds }}
+          value: {{ .Values.config.seeds | quote }}
+          {{- else if .Values.hostNetwork }}
           value: {{ required "You must fill \".Values.config.seeds\" with list of Cassandra seeds when hostNetwork is set to true" .Values.config.seeds | quote }}
           {{- else }}
           value: "{{- range $i, $e := until $seed_size }}{{ template "cassandra.fullname" $global }}-{{ $i }}.{{ template "cassandra.fullname" $global }}.{{ $global.Release.Namespace }}.svc.{{ $global.Values.config.cluster_domain }}{{- if (lt ( add1 $i ) $seed_size ) }},{{- end }}{{- end }}"


### PR DESCRIPTION
Signed-off-by: Sergio Rua <sergio.rua@digitalis.io>

# Optional Seeds

Currently you can only provide seeds list when using host network. To be able to test multiple set ups locally I'd like to be able to override the seeds list.

This provides such a feature.

Thanks

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
