### PR TITLE
[stable/ingressmonitorcontroller] Support image pull secrets

### DIFF
--- a/stable/ingressmonitorcontroller/Chart.yaml
+++ b/stable/ingressmonitorcontroller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingressmonitorcontroller
-version: 1.0.48
+version: 1.0.49
 appVersion: 1.0.47
 description: IngressMonitorController chart that runs on kubernetes
 keywords:

--- a/stable/ingressmonitorcontroller/README.md
+++ b/stable/ingressmonitorcontroller/README.md
@@ -42,6 +42,7 @@ The following quickstart let's you set up Ingress Monitor Controller to register
 | image.name          | Image of ingressMonitorController                                                      | `stakater/ingressmonitorcontroller`                        | `stakater/ingressmonitorcontroller`
 | image.tag          | Version of ingressMonitorController Image                                                      | `1.0.47`                        | `1.0.47`
 | image.pullPolicy          | Pull policy for image                                                      | `IfNotPresent`                        | `IfNotPresent`
+| image.pullSecrets       | Image pull secrets                                                        | `[]`                                 | `nil`                                
 | providers.name          | Name of the provider                                                      | `UptimeRobot`                        | `UptimeRobot`                        |
 | providers.apiKey        | ApiKey of the provider                                                    | `u956-afus321g565fghr519`            | `your-api-key`                       |
 | providers.apiURL        | Base url of the ApiProvider                                               | `https://api.uptimerobot.com/v2/` | `https://api.uptimerobot.com/v2/` |

--- a/stable/ingressmonitorcontroller/templates/deployment.yaml
+++ b/stable/ingressmonitorcontroller/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
 {{ toYaml .Values.ingressMonitorController.matchLabels | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.ingressMonitorController.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.ingressMonitorController.image.pullSecrets | indent 8 }}
+      {{- end }}
       containers:
       - env:
       {{- if .Values.ingressMonitorController.watchNamespace }}

--- a/stable/ingressmonitorcontroller/values.yaml
+++ b/stable/ingressmonitorcontroller/values.yaml
@@ -24,6 +24,10 @@ ingressMonitorController:
     name: stakater/ingressmonitorcontroller
     tag: "1.0.47"
     pullPolicy: IfNotPresent
+    ## It is possible to specify docker registry credentials
+    ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    # pullSecrets:
+      # - name: regsecret
   providers:
   - name: UptimeRobot
     apiKey: your-api-key


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Allows the user to specify image pull secrets for the Ingress Monitor Controller Deployment

#### Special notes for your reviewer:
Usecase: avoid the newly introduced Docker Hub download rate limits by using a pro account
https://docs.docker.com/docker-hub/download-rate-limit/

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
