### PR TITLE
[stable/instana-agent] Chart version 1.0.33

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: instana-agent
 sources:
 - https://github.com/instana/instana-agent-docker
-version: 1.0.32
+version: 1.0.33

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.agent.pod.priorityClassName }}
       priorityClassName: {{ .Values.agent.pod.priorityClassName | quote }}
       {{- end }}
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: instana-agent
           image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag }}"


### PR DESCRIPTION
#### What this PR does / why we need it:

Use `dnsPolicy: ClusterFirstWithHostNet` as this should be the default for pods with `hostNetwork: true` according to https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

#### Which issue this PR fixes

https://github.com/helm/charts/issues/23910

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
