### PR TITLE
[stable/superset] Add deployment strategy option

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.11
-appVersion: "0.36.0"
+version: 1.1.12
+appVersion: "0.37.2"
 keywords:
 - bi
 home: https://github.com/apache/incubator-superset

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -42,13 +42,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | Parameter                  | Description                                     | Default                                                      |
 | -------------------------- | ----------------------------------------------- | ------------------------------------------------------------ |
 | `image.repository`         | `superset` image repository                     | `amancevice/superset`                                        |
-| `image.tag`                | `superset` image tag                            | `0.35.2`                                                     |
+| `image.tag`                | `superset` image tag                            | `0.37.2`                                                     |
 | `image.pullPolicy`         | Image pull policy                               | `IfNotPresent`                                               |
 | `image.pullSecrets`        | Secrets for private registry                    | `[]`                                                         |
 | `configFile`               | Content of [`superset_config.py`](https://superset.incubator.apache.org/installation.html) | See values.yaml](./values.yaml) |
 | `extraConfigFiles`         | Content of additional configuration files. Let the dictionary key name represent the name of the file and its value the files content. | `{}` |
 | `initFile`                 | Content of init shell script                    | See [values.yaml](./values.yaml)                             |
 | `replicas`                 | Number of replicas of superset                  | `1`                                                          |
+| `deploymentStrategy`       | Deployment strategy for superset                | RollingUpdate                                                |
 | `extraEnv`                 | Extra environment variables passed to pods      | `{}`                                                         |
 | `extraArguments`           | Extra arguments passed to init_superset.sh      | `[]`                                                         |
 | `extraEnvFromSecret`       | The name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |

--- a/stable/superset/templates/deployment.yaml
+++ b/stable/superset/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
   selector:
     matchLabels:
       app: {{ include "superset.name" . }}

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -2,11 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-
+deploymentStrategy: RollingUpdate
 ## Set default image, imageTag, and imagePullPolicy.
 image:
   repository: "amancevice/superset"
-  tag: "0.36.0"
+  tag: "0.37.2"
   pullPolicy: "IfNotPresent"
   pullSecrets: []
 


### PR DESCRIPTION
Is this a new chart?
No

What this PR does / why we need it:
Adds the following functionality:

Gives an option to choose deployment strategy when deploying superset. When we have pvc mounted, we can only have Recreate Strategy. So having an option in helm chart will make it easy. 

Which issue this PR fixes
None