### PR TITLE
[incubator/kafka] Update liveness probe to be compatible with Kafka 2.6.0

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.21.2
+version: 0.21.3
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -92,7 +92,7 @@ spec:
             command:
               - sh
               - -ec
-              - /usr/bin/jps | /bin/grep -q SupportedKafka
+              - /usr/bin/jps | /bin/grep -q Kafka
           {{- if not .Values.livenessProbe }}
           initialDelaySeconds: 30
           timeoutSeconds: 5


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Since Kafka 2.6.0 integrated in the Docker image `confluentinc/cp-kafka:6.0.0`, the command `sh -ec /usr/bin/jps`
 now returns `Kafka` instead of `SupportedKafka` making the liveness probe fail.

This change is compatible with both pre and post `6.0.0` versions.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
