### PR TITLE
[stable/airflow] Allow for separate custom readiness path

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.13.1
+version: 7.13.2
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -4,6 +4,7 @@
 
 __The following values have been ADDED:__
 * `flower.oauthDomains`
+* `ingress.web.readinessPath`
 
 ## `v7.11.X` → `v7.12.0`
 

--- a/stable/airflow/templates/webserver/webserver-deployment.yaml
+++ b/stable/airflow/templates/webserver/webserver-deployment.yaml
@@ -240,7 +240,11 @@ spec:
           readinessProbe:
             httpGet:
               scheme: {{ .Values.web.readinessProbe.scheme }}
+              {{- if .Values.ingress.web.readinessPath }}
+              path: "{{ .Values.ingress.web.readinessPath }}"
+              {{- else }}
               path: "{{ .Values.ingress.web.path }}/health"
+              {{- end }}
               port: web
             initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1107,12 +1107,19 @@ ingress:
     ##
     host: ""
 
-    ## the livenessPath for the web Ingress
+    ## the livenessPath for the Deployment
     ##
     ## NOTE:
     ## - if set to "", defaults to: `{ingress.web.path}/health`
     ##
     livenessPath: ""
+
+    ## the readinessPath for the Deployment
+    ##
+    ## NOTE:
+    ## - if set to "", defaults to: `{ingress.web.path}/health`
+    ##
+    readinessPath: ""
 
     ## configs for web Ingress TLS
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Allow for a custom readiness probe path for the Airflow ingress.

When using the `nginx-ingress` we want to make sure that `https://internal/airflow` and `https://internal/airflow/` (notice trialing slash) work. 

To do this we append `(/|$)(.*)` to our paths for the ingresses in K8s. 

While the `livenessProbe` allows for a separate `livenessPath`, the `readinessProbe` has no such functionality, meaning when we set `ingress.web.path` to something like `/airflow(/|$)(.*)` the following probe gets generated:
```
           readinessProbe:
             httpGet:
               scheme: HTTP
               path: "/airflow(/|$)(.*)/health"
               port: web
```

This causes the probe to fail.

This PR adds a separate `readinessPath`, just like the `livenessPath`, fixing this problem.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
