### PR TITLE
[incubator/rundeck] Fixing aws-config volume mount paths.

### DIFF
--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 0.3.4
-appVersion: 3.2.7
+version: 0.3.5
+appVersion: 3.3.4
 keywords:
 - rundeck
 - jobs

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -18,7 +18,7 @@ deployment.replicaCount | How many replicas to run. Rundeck can really only work
 deployment.annotations | You can pass annotations inside deployment.spec.template.metadata.annotations. Useful for KIAM/Kube2IAM and others for example. | {}
 deployment.strategy | Sets the K8s rollout strategy for the Rundeck deployment | { type: RollingUpdate }
 image.repository | Name of the image to run, without the tag. | [rundeck/rundeck](https://github.com/rundeck/rundeck)
-image.tag | The image tag to use. | 3.2.7
+image.tag | The image tag to use. | 3.3.4
 image.pullPolicy | The kubernetes image pull policy. | IfNotPresent
 image.pullSecrets | The kubernetes secret to pull the image from a private registry. | None
 service.type | The kubernetes service type to use. | ClusterIP
@@ -29,7 +29,7 @@ rundeck.adminUser | The config to set up the admin user that should be placed at
 rundeck.env | The rundeck environment variables that you would want to set | Default variables provided in docker file
 rundeck.envSecret | Name of secret containing environment variables to add to the Rundeck deployment | ""
 rundeck.sshSecrets | A reference to the Kubernetes Secret that contains the ssh keys. | ""
-rundeck.awsConfigSecret | Name of secret to mount under the `~/.aws/` directory. Useful when AWS IRSA is not an option. | ""
+rundeck.awsConfigCredentialsSecret | Name of secret to mount under the `~/.aws/` directory. Useful when AWS IRSA is not an option. | ""
 rundeck.kubeConfigSecret | Name of secret to mount under the `~/.kube/` directory. Useful when Rundeck needs configuration for multiple K8s clusters. | ""
 rundeck.extraConfigSecret | Name of secret containing additional files to mount at `~/extra/`. Can be useful for working with RUNDECK_TOKENS_FILE configuration | ""
 nginxConfOverride | An optional multi-line value that can replace the default nginx.conf. | ""

--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -89,9 +89,10 @@ spec:
             mountPath: /home/rundeck/.ssh
             readOnly: true
         {{- end }}
-        {{- if .Values.rundeck.awsConfigSecret }}
-          - name: aws-config
-            mountPath: /home/rundeck/.aws/
+        {{- if .Values.rundeck.awsConfigCredentialsSecret }}
+          - name: aws-config-credentials
+            mountPath: /home/rundeck/.aws/credentials
+            subPath: credentials
         {{- end }}
         {{- if .Values.rundeck.kubeConfigSecret }}
           - name: kube-config
@@ -149,10 +150,10 @@ spec:
           secret:
             secretName: {{ .Values.rundeck.sshSecrets }}
         {{- end }}
-        {{- if .Values.rundeck.awsCredentialsSecret }}
-        - name: aws-credentials
+        {{- if .Values.rundeck.awsConfigCredentialsSecret }}
+        - name: aws-config-credentials
           secret:
-            secretName: {{ .Values.rundeck.awsCredentialsSecret}}
+            secretName: {{ .Values.rundeck.awsConfigCredentialsSecret}}
         {{- end }}
         {{- if .Values.rundeck.kubeConfigSecret }}
         - name: kube-config

--- a/incubator/rundeck/values.yaml
+++ b/incubator/rundeck/values.yaml
@@ -36,7 +36,7 @@ rundeck:
   # sshSecrets: "ssh-secret"
 
   # Name of secret containing to mount under ~/.aws/
-  # awsConfigSecret: "aws-secret"
+  # awsConfigCredentialsSecret: "aws-secret"
 
   # Name of secret to mount under ~/.kube/
   # kubeConfigSecret: "kube-secret"


### PR DESCRIPTION
Signed-off-by: Tagore Korrapati <tkorrapati@appneta.com>

This PR Fixes the issue that _ awsConfigSecret_ volume and volume mount has been named wrong

#### Special notes for your reviewer:
Intentionally mounting it in subpath _credentials_ so that other files in .aws dir are not overwritten. 
@dwardu89 @fabioviana 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
