### PR TITLE
Updating the README to the new repo locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For issues and support for Helm and Charts see [Support Channels](CONTRIBUTING.m
 
 ## How Do I Install These Charts?
 
-Just `helm install stable/<chart>`. This is the default repository for Helm which is located at https://kubernetes-charts.storage.googleapis.com/ and is installed by default.
+Just `helm install stable/<chart>`. This is the default repository for Helm v2 which is located at https://charts.helm.sh/stable/ and was installed by default prior to Helm v3.
 
 For more information on using Helm, refer to the [Helm documentation](https://github.com/kubernetes/helm#docs).
 
@@ -40,7 +40,7 @@ For more information on using Helm, refer to the [Helm documentation](https://gi
 To add the Helm Stable Charts for your local client, run `helm repo add`:
 
 ```
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm repo add stable https://charts.helm.sh/stable
 "stable" has been added to your repositories
 ```
 
@@ -49,7 +49,7 @@ $ helm repo add stable https://kubernetes-charts.storage.googleapis.com
 To add the Incubator charts for your local client, run `helm repo add`:
 
 ```
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+$ helm repo add incubator https://charts.helm.sh/incubator
 "incubator" has been added to your repositories
 ```
 
@@ -63,7 +63,7 @@ Before contributing a Chart, become familiar with the format. Note that the proj
 
 ## Repository Structure
 
-This GitHub repository contains the source for the packaged and versioned charts released in the [`gs://kubernetes-charts` Google Storage bucket](https://console.cloud.google.com/storage/browser/kubernetes-charts/) (the Chart Repository).
+This GitHub repository contains the source for the packaged and versioned charts released using [GitHub pages](https://github.com/helm/charts/tree/gh-pages/stable) (the Chart Repository).
 
 The Charts in the `stable/` directory in the master branch of this repository match the latest packaged Chart in the Chart Repository, though there may be previous versions of a Chart available in that Chart Repository.
 
@@ -76,7 +76,7 @@ The Charts in this repository are organized into two folders:
 
 Stable Charts meet the criteria in the [technical requirements](CONTRIBUTING.md#technical-requirements).
 
-Incubator Charts are those that do not meet these criteria. Having the incubator folder allows charts to be shared and improved on until they are ready to be moved into the stable folder. The charts in the `incubator/` directory can be found in the [`gs://kubernetes-charts-incubator` Google Storage Bucket](https://console.cloud.google.com/storage/browser/kubernetes-charts-incubator).
+Incubator Charts are those that do not meet these criteria. Having the incubator folder allows charts to be shared and improved on until they are ready to be moved into the stable folder. The charts in the `incubator/` directory can be found on the [`gh-pages` branch of the repository](https://github.com/helm/charts/tree/gh-pages/incubator).
 
 In order to get a Chart from incubator to stable, Chart maintainers should open a pull request that moves the chart folder.
 


### PR DESCRIPTION
This updates the README at the top level with the new GH Pages based location for the Helm repos