### PR TITLE
[stable/prometheus-operator] Update dependencies repository URL

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.2
+version: 9.3.3
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.8.10
+  repository: https://charts.helm.sh/stable
+  version: 2.8.*
 - name: prometheus-node-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.10.0
+  repository: https://charts.helm.sh/stable
+  version: 1.10.*
 - name: grafana
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.0
-digest: sha256:4cafebfa80daacbd651defea2a7cad3074e8022114d27d76a3baa1861998981b
-generated: "2020-06-22T12:36:10.4861206Z"
+  repository: https://charts.helm.sh/stable
+  version: 5.3.*
+digest: sha256:881f9a664c196e025aeb46a538e46724573cb21dcc5e1ea9147a791d6690238f
+generated: "2020-11-02T14:18:52.090826206+02:00"

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -2,15 +2,15 @@ dependencies:
 
   - name: kube-state-metrics
     version: "2.8.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
     version: "1.10.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: nodeExporter.enabled
 
   - name: grafana
     version: "5.3.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: grafana.enabled


### PR DESCRIPTION

this google cloud storage bucket is expected to be de-listed on November 13th. https://charts.helm.sh has been set up as a mirror repository, so all charts currently referencing the old google cloud storage bucket must be updated to the new repository URLs.

https://helm.sh/blog/new-location-stable-incubator-charts/