### PR TITLE
[stable/airflow] add option to run airflow upgradedb in init-container

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 7.13.2
+version: 7.13.3
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -414,6 +414,10 @@ If the value `scheduler.initdb` is set to `true` (this is the default), the airf
 If the value `scheduler.preinitdb` is set to `true`, then we ALSO RUN `airflow initdb` in an init-container (retrying 5 times).
 This is unusually NOT necessary unless your synced DAGs include custom database hooks that prevent `airflow initdb` from running.
 
+If the value `scheduler.upgradedb` is set to `true`, `airflow upgradedb` will be run in an init-container. This creates all tables
+needed by airflow without a lot of default connection, charts, etc. which might be prefered over `initdb` for production environments.
+`upgrade` keeps track of migrations already applies, so it’s safe to run as often as you need.
+
 ## Docs (Database) - Passwords
 
 PostgreSQL is the default database in this chart, because we use insecure username/password combinations by default, you should create secure credentials before installing the Helm chart.

--- a/stable/airflow/templates/config/configmap-scripts.yaml
+++ b/stable/airflow/templates/config/configmap-scripts.yaml
@@ -58,3 +58,23 @@ data:
 
     echo "*** Initdb failed after ${COUNT} retries; failed."
     exit 1
+  upgrade-db.sh: |
+    #!/bin/bash
+    echo "*** Waiting 10s for database"
+    sleep 10
+
+    COUNT=0
+    while [ "${COUNT}" -lt 5 ]; do
+      echo "*** upgrading airflow db"
+      if airflow upgradedb || airflow db upgrade; then
+        echo "*** upgradedb succeeded"
+        exit 0
+      else
+        ((COUNT++))
+        echo "*** upgradedb failed: waiting 5s before retry #${COUNT}"
+        sleep 5
+      fi
+    done
+
+    echo "*** upgradedb failed after ${COUNT} retries; failed."
+    exit 1

--- a/stable/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/stable/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -78,7 +78,7 @@ spec:
         {{- toYaml .Values.scheduler.securityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
-      {{- if or (.Values.dags.initContainer.enabled) (.Values.scheduler.preinitdb) (.Values.scheduler.extraInitContainers) }}
+      {{- if or (.Values.dags.initContainer.enabled) (.Values.scheduler.preinitdb) (.Values.scheduler.extraInitContainers) (.Values.scheduler.upgradedb) }}
       initContainers:
         {{- if .Values.scheduler.preinitdb }}
         - name: {{ .Chart.Name }}-preinitdb
@@ -91,6 +91,28 @@ spec:
             - "/bin/bash"
             - "-c"
             - "/home/airflow/scripts/preinit-db.sh"
+          envFrom:
+            - configMapRef:
+                name: "{{ include "airflow.fullname" . }}-env"
+          env:
+            {{- include "airflow.mapenvsecrets" . | indent 12 }}
+          resources:
+            {{- toYaml .Values.scheduler.resources | nindent 12 }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /home/airflow/scripts
+        {{- end }}
+        {{- if .Values.scheduler.upgradedb }}
+        - name: {{ .Chart.Name }}-upgradedb
+          image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
+          imagePullPolicy: {{ .Values.airflow.image.pullPolicy}}
+          command:
+            - "/usr/bin/dumb-init"
+            - "--"
+          args:
+            - "/bin/bash"
+            - "-c"
+            - "/home/airflow/scripts/upgrade-db.sh"
           envFrom:
             - configMapRef:
                 name: "{{ include "airflow.fullname" . }}-env"

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -317,7 +317,7 @@ scheduler:
 
   ##  if we run `airflow upgradedb` (prior airflow 2.0) or `airflow db upgrade` (> airflow 2.0)
   ##
-  ## Note: 
+  ## Note:
   ## - create all the tables required for operation
   ## - needs an empty DB and anairflow’s user with permission to CREATE/ALTER it
   ## - upgrade keeps track of migrations already applies, so it’s safe to run as often as you need

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -315,6 +315,15 @@ scheduler:
   ##
   initdb: true
 
+  ##  if we run `airflow upgradedb` (prior airflow 2.0) or `airflow db upgrade` (> airflow 2.0)
+  ##
+  ## Note: 
+  ## - create all the tables required for operation
+  ## - needs an empty DB and anairflow’s user with permission to CREATE/ALTER it
+  ## - upgrade keeps track of migrations already applies, so it’s safe to run as often as you need
+  ## - Do not use airflow initdb as it can create a lot of default connection, charts, etc.
+  upgradedb: false
+
   ## if we run `airflow initdb` inside a special initContainer
   ##
   ## NOTE:


### PR DESCRIPTION
Signed-off-by: Benny Gaechter <benny.gaechter@gmail.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Enables the use of `airflow upgradedb` as an init-container which allows airflow state database upgrades and is the prefered method of creating the airflow state database in production environments.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
