### PR TITLE
[incubator/solr] Allow enable/disable zookeeper requirement installation.

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.5.3"
+version: "1.5.4"
 appVersion: "8.4.0"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/README.md
+++ b/incubator/solr/README.md
@@ -64,6 +64,9 @@ The following table shows the configuration options for the Solr helm chart:
 | `tls.certSecret.certPath`                     | The key in the Kubernetes secret that contains the TLS certificate | `tls.crt`                                                             |
 | `service.type`                                | The type of service for the solr client service | `ClusterIP`                                                           |
 | `service.annotations`                         | Annotations to apply to the solr client service | `{}` |
+| `zookeeper.enabled`                           | If true, deploy Zookeeper | `true`
+| `zookeeper.url`                               | If the Zookeeper Chart is disabled a URL and port are required to connect | `nil`
+| `zookeeper.port`                              | If the Zookeeper Chart is disabled a URL and port are required to connect. If Zookeeper chart is enabled leave the default value | `2181`
 | `exporter.enabled`                            | Whether to enable the Solr Prometheus exporter | `false`                                                               |
 | `exporter.image.pullSecrets`                  | Specify docker-registry secret names as an array      | `[]` (does not add image pull secrets to deployed pods)      |
 | `exporter.configFile`                         | The path in the docker image that the exporter loads the config from | `/opt/solr/contrib/prometheus-exporter/conf/solr-exporter-config.xml` |

--- a/incubator/solr/requirements.lock
+++ b/incubator/solr/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: zookeeper
   repository: https://charts.helm.sh/incubator
   version: 2.1.3
-digest: sha256:80784c74a6d7a456de5336bed153ee8506f0d4ad776a1cdd29fc31dcb6eeb3c8
-generated: "2020-11-04T00:31:54.262083+02:00"
+digest: sha256:47223e8f647bea375a69f09d578a5a48e3cdd08c9a12dd34f434aeed4041589d
+generated: "2020-11-04T06:56:57.3382664Z"

--- a/incubator/solr/requirements.lock
+++ b/incubator/solr/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: zookeeper
   repository: https://charts.helm.sh/incubator
   version: 2.1.3
-digest: sha256:6f0f8fc26381329ccae43bae46e93f1a1b81b64b042017c76a70c402bc1f8770
-generated: "2020-10-30T00:43:04.044163-04:00"
+digest: sha256:80784c74a6d7a456de5336bed153ee8506f0d4ad776a1cdd29fc31dcb6eeb3c8
+generated: "2020-11-03T20:14:02.238541+02:00"

--- a/incubator/solr/requirements.lock
+++ b/incubator/solr/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.helm.sh/incubator
   version: 2.1.3
 digest: sha256:80784c74a6d7a456de5336bed153ee8506f0d4ad776a1cdd29fc31dcb6eeb3c8
-generated: "2020-11-03T20:14:02.238541+02:00"
+generated: "2020-11-04T00:31:54.262083+02:00"

--- a/incubator/solr/requirements.yaml
+++ b/incubator/solr/requirements.yaml
@@ -4,3 +4,4 @@ dependencies:
   - name: zookeeper
     version: 2.1.3
     repository: https://charts.helm.sh/incubator
+    condition: zookeeper.enabled

--- a/incubator/solr/templates/_helpers.tpl
+++ b/incubator/solr/templates/_helpers.tpl
@@ -56,7 +56,11 @@ The name of the zookeeper service
 The name of the zookeeper headless service
 */}}
 {{- define "solr.zookeeper-service-name" -}}
+{{- if .Values.zookeeper.enabled -}}
 {{ printf "%s-%s" (include "solr.zookeeper-name" .) "headless" | trunc 63 | trimSuffix "-"  }}
+{{- else -}}
+{{- printf "%s" .Values.zookeeper.url }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
               done
               rm crt-*
 {{ end }}
-              /opt/solr/server/scripts/cloud-scripts/zkcli.sh -zkhost "{{ include "solr.zookeeper-service-name" . }}:2181" -cmd clusterprop -name urlScheme -val https
+              /opt/solr/server/scripts/cloud-scripts/zkcli.sh -zkhost "{{ include "solr.zookeeper-service-name" . }}:{{ .Values.zookeeper.port }}" -cmd clusterprop -name urlScheme -val https
           volumeMounts:
             - name: "keystore-volume"
               mountPath: "/tmp/keystore"
@@ -168,7 +168,7 @@ spec:
             - name: "SOLR_HOST"
               value: "$(POD_HOSTNAME).{{ include "solr.headless-service-name" . }}.{{ .Release.Namespace }}"
             - name: "ZK_HOST"
-              value: "{{ include "solr.zookeeper-service-name" . }}:2181"
+              value: "{{ include "solr.zookeeper-service-name" . }}:{{ .Values.zookeeper.port }}"
             - name: "SOLR_LOG_LEVEL"
               value: "{{ .Values.logLevel }}"
 {{- if .Values.extraEnvVars }}

--- a/incubator/solr/values.yaml
+++ b/incubator/solr/values.yaml
@@ -106,6 +106,18 @@ service:
   type: ClusterIP
   annotations: {}
 
+# ----------------------------------------
+# Zookeepeer:
+# ----------------------------------------
+
+zookeeper:
+  ## If true, install the Zookeeper chart
+  enabled: true
+  ## If the Zookeeper Chart is disabled a URL and port are required to connect
+  url: ""
+  port: 2181
+
+
 # Configuration for the solr prometheus exporter
 exporter:
   image: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
    You can disable zookeeper chart requirements and allow you to configure Solr with an already installed zookeeper cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
