### PR TITLE
[stable/sysdig] Deprecating sysdig chart

### DIFF
--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.7.15
+version: 1.7.16
 appVersion: 10.0.0
 description: Sysdig Monitor and Secure agent
 keywords:
@@ -15,10 +15,4 @@ icon: https://478h5m1yrfsa3bbe262u7muv-wpengine.netdna-ssl.com/wp-content/upload
 sources:
   - https://app.sysdigcloud.com/#/settings/user
   - https://github.com/draios/sysdig
-maintainers:
-  - name: lachie83
-    email: lachlan@deis.com
-  - name: bencer
-    email: jorge.salamero@sysdig.com
-  - name: nestorsalceda
-    email: nestor.salceda@sysdig.com
+deprecated: true

--- a/stable/sysdig/README.md
+++ b/stable/sysdig/README.md
@@ -1,4 +1,10 @@
-# Sysdig
+# DEPRECATED - Sysdig
+
+**This chart is deprecated and moved to its new home:**
+
+**GitHub repo:** https://github.com/sysdiglabs/charts
+
+**Charts repo:** https://charts.sysdig.com
 
 [Sysdig](https://sysdig.com/) is a unified platform for container and microservices monitoring, troubleshooting, security and forensics. Sysdig platform has been built on top of [Sysdig tool](https://sysdig.com/opensource/sysdig/) and [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source technologies.
 


### PR DESCRIPTION
#### Which issue this PR fixes
This deprecates the sysdig chart and references the new home.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
