### PR TITLE
[incubator/cassandra] Allows creating a service account for the pods

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.15.2
+version: 0.15.3
 appVersion: 3.11.6
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -147,6 +147,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `rbac.create`                        | Specifies whether RBAC resources should be created                                                  | `true` |
 | `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                | `true` |
 | `serviceAccount.name`                | The name of the ServiceAccount to use           |                                                            |
+| `serviceAccount.rules`               | Permissions you would like granting to the pods | `{}`                                                       |
 | `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |

--- a/incubator/cassandra/templates/cluster-role-binding.yaml
+++ b/incubator/cassandra/templates/cluster-role-binding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.serviceAccount.create .Values.serviceAccount.rules -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cassandra.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cassandra.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cassandra.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/cassandra/templates/cluster-role-binding.yaml
+++ b/incubator/cassandra/templates/cluster-role-binding.yaml
@@ -18,3 +18,4 @@ subjects:
     name: {{ include "cassandra.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
+

--- a/incubator/cassandra/templates/cluster-role.yaml
+++ b/incubator/cassandra/templates/cluster-role.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.serviceAccount.create .Values.serviceAccount.rules -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cassandra.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+{{ toYaml .Values.serviceAccount.rules }}
+{{- end -}}

--- a/incubator/cassandra/templates/serviceaccount.yaml
+++ b/incubator/cassandra/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cassandra.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true
+{{- end -}}

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -30,6 +30,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: {{ include "cassandra.serviceAccountName" . }}
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -150,10 +150,21 @@ rbac:
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
-  create: true
+  create: false
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   # name:
+  # if rules are set, these are the permissions granted to the pods
+  rules: {}
+  # - apiGroups:
+  #   - ""
+  #   resources:
+  #   - pods
+  #   verbs:
+  #   - get
+  #   - list
+  #   - watch
+
 
 # Use host network for Cassandra pods
 # You must pass seed list into config.seeds property if set to true


### PR DESCRIPTION
Signed-off-by: Sergio Rua <sergio.rua@digitalis.io>

#### What this PR does / why we need it:

It allows to create and assign a service account to the cassandra pods

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
