### PR TITLE
[stable/collabora-code] Deprecate collabora-code helm chart

### DIFF
--- a/stable/collabora-code/Chart.yaml
+++ b/stable/collabora-code/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "4.0.3.1"
 description: DEPRECATED A Helm chart for Collabora Office - CODE-Edition
 name: collabora-code
-version: 1.0.8
+version: 1.0.9
 icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
 sources:
 - https://github.com/CollaboraOnline/Docker-CODE

--- a/stable/collabora-code/README.md
+++ b/stable/collabora-code/README.md
@@ -2,8 +2,13 @@
 
 As of Nov 13, 2020, charts in this repo will no longer be updated.
 For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+# DEPRECATED - Collabora CODE
 
-# Collabora CODE
+|**This chart has been deprecated and moved to its new home:**
+This conversation was marked as resolved by billimek
+|
+|- **GitHub repo:** https://github.com/chrisingenhaag/helm/tree/main/charts/collabora-code
+|- **Charts repo:** https://chrisingenhaag.github.io/helm/
 
 [Collabora](https://www.collaboraoffice.com/code/) is a online office suite.
 

--- a/stable/collabora-code/templates/NOTES.txt
+++ b/stable/collabora-code/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the maintained Helm chart is now located at chrisingenhaag/helm (https://github.com/chrisingenhaag/helm/tree/main/charts/collabora).
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}


### PR DESCRIPTION
#### What this PR does / why we need it:

* This deprecates the collabora-code chart and references the new home.
* See https://github.com/chrisingenhaag/helm/pull/1 for preserving old history.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
