### PR TITLE
[stable/openvpn] Support new versions of Istio in

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.2.3
+version: 4.2.4
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -132,7 +132,7 @@ data:
 
       /etc/openvpn/setup/setup-certs.sh
 {{ if .Values.openvpn.istio.enabled }}
-      iptables -t nat -A PREROUTING -s {{ .Values.openvpn.OVPN_NETWORK }}/{{ .Values.openvpn.OVPN_SUBNET }} -i tun0 -p tcp -j REDIRECT --to-ports {{ .Values.openvpn.istio.proxy.port }}
+      iptables -t nat -I PREROUTING 1 -s {{ .Values.openvpn.OVPN_NETWORK }}/{{ .Values.openvpn.OVPN_SUBNET }} -i tun0 -p tcp -j REDIRECT --to-ports {{ .Values.openvpn.istio.proxy.port }}
 {{ end }}
 
 {{ range .Values.openvpn.iptablesExtra }}


### PR DESCRIPTION
I'm neither an openvpn, network nor Istio expert, but from my last few hours of deep diving iptables, it looks like it's just an issue of sorting the iptables.
I was experiencing issue https://github.com/helm/charts/issues/22695 which seems to be resolved for me using the applied patch. 
I have no insights of your versioning schema or PR process and I'm honestly too tired right now to read through it.
Let me know if there are any questions or edits needed.
