### PR TITLE
[stable/spark-history-server] servicePort should retrieve from Values

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark-history-server
-version: 1.4.1
+version: 1.4.2
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/templates/ingress.yaml
+++ b/stable/spark-history-server/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
         - path: {{ $.Values.ingress.path }}
           backend:
             serviceName: {{ $fullname }}
-            servicePort: historyport
+            servicePort: {{ .Values.service.port.name }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/stable/spark-history-server/templates/ingress.yaml
+++ b/stable/spark-history-server/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
         - path: {{ $.Values.ingress.path }}
           backend:
             serviceName: {{ $fullname }}
-            servicePort: {{ .Values.service.port.name }}
+            servicePort: {{ .Values.service.port.number }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
servicePort should retrieve from Values. This dis-matching with service.yaml file will cause ingress creation failure.

