### PR TITLE
[stable/elasticsearch-exporter] Deprecate chart

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
-description: Elasticsearch stats exporter for Prometheus
+deprecated: true
+description: DEPRECATED Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 3.7.0
+version: 3.7.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
@@ -11,10 +12,3 @@ keywords:
   - metrics
   - elasticsearch
   - monitoring
-maintainers:
-  - name: svenmueller
-    email: sven.mueller@commercetools.com
-  - name: caarlos0
-    email: carlos@carlosbecker.com
-  - name: desaintmartin
-    email: cedric@desaintmartin.fr

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -1,5 +1,7 @@
 # Elasticsearch Exporter
 
+DEPRECATED and moved to <https://github.com/prometheus-community/helm-charts>
+
 Prometheus exporter for various metrics about ElasticSearch, written in Go.
 
 Learn more: https://github.com/justwatchcom/elasticsearch_exporter


### PR DESCRIPTION
Moved https://github.com/prometheus-community/helm-charts .

Signed-off-by: Cédric de Saint Martin <cdesaintmartin@wiremind.fr>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
