### PR TITLE
Updating to new repo locations

### DIFF
--- a/incubator/azuremonitor-containers/README.md
+++ b/incubator/azuremonitor-containers/README.md
@@ -45,7 +45,7 @@ Monitoring your Kubernetes cluster and containers is critical, especially when r
 ### To Use Azure Log Analytics Workspace in Public Cloud
 
 ```bash
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm repo add incubator https://charts.helm.sh/incubator/
 $ helm install --name azmon-containers-release-1 \
 --set omsagent.secret.wsid=<your_workspace_id>,omsagent.secret.key=<your_workspace_key>,omsagent.env.clusterName=<my_prod_cluster>  incubator/azuremonitor-containers
 ```
@@ -53,7 +53,7 @@ $ helm install --name azmon-containers-release-1 \
 ### To Use Azure Log Analytics Workspace in Azure China Cloud
 
 ```bash
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm repo add incubator https://charts.helm.sh/incubator/
 $ helm install --name azmon-containers-release-1 \
 --set omsagent.domain=opinsights.azure.cn,omsagent.secret.wsid=<your_workspace_id>,omsagent.secret.key=<your_workspace_key>,omsagent.env.clusterName=<your_cluster_name>  incubator/azuremonitor-containers
 ```
@@ -61,7 +61,7 @@ $ helm install --name azmon-containers-release-1 \
 ### To Use Azure Log Analytics Workspace in Azure US Government Cloud
 
 ```bash
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm repo add incubator https://charts.helm.sh/incubator/
 $ helm install --name azmon-containers-release-1 \
 --set omsagent.domain=opinsights.azure.us,omsagent.secret.wsid=<your_workspace_id>,omsagent.secret.key=<your_workspace_key>,omsagent.env.clusterName=<your_cluster_name>  incubator/azuremonitor-containers
 ```

--- a/incubator/distribution/requirements.lock
+++ b/incubator/distribution/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.0.5
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.1.21
 digest: sha256:beb9912728c7d372ddc2ba5b5c4dcee718bd78f65219c1d6831377aad227d471
 generated: 2018-05-11T08:38:33.357628483-07:00

--- a/incubator/distribution/requirements.yaml
+++ b/incubator/distribution/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   version: 2.0.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mongodb.enabled
 - name: redis
   version: 1.1.21
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: redis.enabled

--- a/incubator/elastic-stack/requirements.lock
+++ b/incubator/elastic-stack/requirements.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: elasticsearch
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.13.2
 - name: kibana
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.16.4
 - name: filebeat
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.0.3
 - name: logstash
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.1.0
 - name: fluentd
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.0.0
 - name: fluent-bit
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.15.0
 - name: fluentd-elasticsearch
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.1.0
 - name: nginx-ldapauth-proxy
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.1.2
 - name: elasticsearch-curator
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.0.1
 - name: elasticsearch-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.4.1
 digest: sha256:8107bab1d2e9cff9bb3452bd3f21fa0e3a681a62a79a732466a2dafb7ad2d3d3
 generated: 2018-11-01T13:44:47.784814059-04:00

--- a/incubator/elastic-stack/requirements.yaml
+++ b/incubator/elastic-stack/requirements.yaml
@@ -1,39 +1,39 @@
 dependencies:
 - name: elasticsearch
   version: ^1.10.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name: kibana
   version: ^0.16.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name: filebeat
   version: ^1.0.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: filebeat.enabled
 - name: logstash
   version: ^1.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: logstash.enabled
 - name: fluentd
   version: ^1.0.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: fluentd.enabled
 - name: fluent-bit
   version: ^0.13.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: fluent-bit.enabled
 - name: fluentd-elasticsearch
   version: ^1.0.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: fluentd-elasticsearch.enabled
 - name: nginx-ldapauth-proxy
   version: ^0.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: nginx-ldapauth-proxy.enabled
 - name: elasticsearch-curator
   version: ^1.0.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: elasticsearch-curator.enabled
 - name: elasticsearch-exporter
   version: ^0.4.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: elasticsearch-exporter.enabled

--- a/incubator/istio/README.md
+++ b/incubator/istio/README.md
@@ -7,7 +7,7 @@
 ## TL;DR;
 
 ```console
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+$ helm repo add incubator https://charts.helm.sh/incubator
 $ helm install incubator/istio
 ```
 

--- a/incubator/jaeger/requirements.yaml
+++ b/incubator/jaeger/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: cassandra
     version: ^0.13.1
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    repository: https://charts.helm.sh/incubator/
     condition: provisionDataStore.cassandra
   - name: elasticsearch
     version: ^1.19.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: provisionDataStore.elasticsearch

--- a/incubator/keycloak/requirements.lock
+++ b/incubator/keycloak/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.12.0
 digest: sha256:65c01bdcc4661db1599d2e54feb0c7084434c5ce8a46db842c16b58e41a452cc
 generated: 2018-05-14T09:04:06.443862206+02:00

--- a/incubator/keycloak/requirements.yaml
+++ b/incubator/keycloak/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
     version: 0.12.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: keycloak.persistence.deployPostgres

--- a/incubator/kubeless/README.md
+++ b/incubator/kubeless/README.md
@@ -14,7 +14,7 @@ This chart is deprecated and no longer supported.
 ## TL;DR;
 
 ```bash
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm repo add incubator https://charts.helm.sh/incubator/
 $ helm install --namespace kubeless incubator/kubeless
 ```
 

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -34,7 +34,7 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm repo add incubator https://charts.helm.sh/incubator/
 $ helm dependency update
 $ helm install --name my-release incubator/patroni
 ```

--- a/incubator/spring-cloud-data-flow/requirements.lock
+++ b/incubator/spring-cloud-data-flow/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.3.4
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.1.11
 - name: rabbitmq
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.6.16
 digest: sha256:b16ffdc5da316b3a7e677d3a83670341b13670d7e59f8ce74d023a01df05f135
 generated: 2018-01-31T09:21:26.470351-05:00

--- a/incubator/spring-cloud-data-flow/requirements.yaml
+++ b/incubator/spring-cloud-data-flow/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
 - name:  mysql
   version: 0.3.4
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name:  redis
   version: 1.1.11
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name:  rabbitmq
   version: 0.6.16
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/

--- a/incubator/xray/requirements.lock
+++ b/incubator/xray/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.8.7
 - name: rabbitmq-ha
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.5.2
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.0.5
 digest: sha256:0893dc655e9e80daccdacc2650305aed5a2522cbf7216325f241a0ec3dd62cda
 generated: 2018-05-29T09:44:00.736196764-07:00

--- a/incubator/xray/requirements.yaml
+++ b/incubator/xray/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   version: 0.8.7
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: postgresql.enabled
 - name: rabbitmq-ha
   version: 1.5.2
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name: mongodb
   version: 2.0.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mongodb.enabled

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -22,7 +22,7 @@ helm install stable/airflow \
 
 __(Helm 3) install the Airflow Helm Chart:__
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 
 helm install "airflow" stable/airflow \

--- a/stable/anchore-engine/requirements.lock
+++ b/stable/anchore-engine/requirements.lock
@@ -6,7 +6,7 @@ dependencies:
   repository: ""
   version: 1.0.1
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 10.5.7
 digest: sha256:106bc6a69eed8b6caf211da47687c16c6415662ea2e83813e268010eb121f4e5
 generated: "2020-08-12T16:15:32.051109-07:00"

--- a/stable/artifactory-ha/requirements.lock
+++ b/stable/artifactory-ha/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.8.7
 digest: sha256:02e9e88b9a147c956d857fb8874f16257b90fc980522b329f3257979811af7f7
 generated: 2018-01-17T15:55:26.174758+02:00

--- a/stable/artifactory-ha/requirements.yaml
+++ b/stable/artifactory-ha/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
   version: 0.8.7
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: postgresql.enabled

--- a/stable/artifactory/requirements.lock
+++ b/stable/artifactory/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.8.7
 digest: sha256:02e9e88b9a147c956d857fb8874f16257b90fc980522b329f3257979811af7f7
 generated: 2018-05-18T16:12:27.72899131-07:00

--- a/stable/artifactory/requirements.yaml
+++ b/stable/artifactory/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
     version: 0.8.7
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: postgresql.enabled

--- a/stable/concourse/requirements.lock
+++ b/stable/concourse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 5.3.8
 digest: sha256:8beae180ba7a5ca551f75da9552e59cadbbfcce2d0e2edf6c8a93dcfacd0df10
 generated: "2019-06-20T13:43:23.321244-04:00"

--- a/stable/concourse/requirements.yaml
+++ b/stable/concourse/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
   version: 5.3.8
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: postgresql.enabled

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.8.4
 digest: sha256:80bd2cffd24fe9fc49049fb25d9d11282dfec9dcc647733307fdc64f1337e4e8
 generated: "2020-05-04T14:18:19.42524+02:00"

--- a/stable/datadog/requirements.yaml
+++ b/stable/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
     version: "=2.8.4"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: datadog.kubeStateMetricsEnabled

--- a/stable/distribution/requirements.lock
+++ b/stable/distribution/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.0.5
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.1.21
 digest: sha256:beb9912728c7d372ddc2ba5b5c4dcee718bd78f65219c1d6831377aad227d471
 generated: 2018-05-11T08:38:33.357628483-07:00

--- a/stable/distribution/requirements.yaml
+++ b/stable/distribution/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   version: 2.0.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mongodb.enabled
 - name: redis
   version: 1.1.21
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: redis.enabled

--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-06T11:15:33.456215777Z"

--- a/stable/drupal/requirements.yaml
+++ b/stable/drupal/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/ghost/requirements.lock
+++ b/stable/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:27bef733eb099a7377055cfe2c48e013bd4d55650ff18b50138c80488c812b0b
 generated: "2020-03-03T08:47:07.166043878Z"

--- a/stable/ghost/requirements.yaml
+++ b/stable/ghost/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled
   tags:
     - ghost-database

--- a/stable/gitlab-ce/requirements.lock
+++ b/stable/gitlab-ce/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.9.0
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.8.1
 digest: sha256:94bbb4af5c8b8e6114938d06650c9e82b0a80613e0b60a6cdbb5031fb7771ae2
 generated: 2018-09-08T11:28:35.128492897-04:00

--- a/stable/gitlab-ce/requirements.yaml
+++ b/stable/gitlab-ce/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
   version: 0.9.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name: postgresql
   version: 0.8.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/

--- a/stable/gitlab-ee/requirements.lock
+++ b/stable/gitlab-ee/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.9.0
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.8.1
 digest: sha256:94bbb4af5c8b8e6114938d06650c9e82b0a80613e0b60a6cdbb5031fb7771ae2
 generated: 2018-09-08T11:28:47.951673071-04:00

--- a/stable/gitlab-ee/requirements.yaml
+++ b/stable/gitlab-ee/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
   version: 0.9.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name: postgresql
   version: 0.8.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -61,7 +61,7 @@ Refer the [GoCD website](https://www.gocd.org/kubernetes) for getting started wi
 To install the chart with the release name `gocd-app`:
 
 ```bash
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm repo add stable https://charts.helm.sh/stable
 $ helm install --name gocd-app --namespace gocd stable/gocd
 ```
 

--- a/stable/jasperreports/requirements.lock
+++ b/stable/jasperreports/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-02-28T08:12:22.585924246Z"

--- a/stable/jasperreports/requirements.yaml
+++ b/stable/jasperreports/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.11
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-02-27T09:48:27.480132708Z"

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/keycloak/requirements.lock
+++ b/stable/keycloak/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.15.0
 digest: sha256:428d8302be9a566a3e77538af30c56b63e0bfc97dd01dd434f303f4434cb8100
 generated: 2018-07-06T08:41:15.715456938+02:00

--- a/stable/keycloak/requirements.yaml
+++ b/stable/keycloak/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
     version: 0.15.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: keycloak.persistence.deployPostgres

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 8.1.2
 digest: sha256:c4bf54db60c2c5953ba7b79ce4814f8b8225d04e932868bcfab23b93c05b0f7f
 generated: "2019-12-31T13:58:27.104134475-08:00"

--- a/stable/kong/requirements.yaml
+++ b/stable/kong/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
   version: ~8.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: postgresql.enabled

--- a/stable/logdna-agent/README.md
+++ b/stable/logdna-agent/README.md
@@ -39,7 +39,7 @@ You should see logs in https://app.logdna.com in a few seconds.
 > **Note**: If you're running helm 3.0+ then you might need to run the following first (as described in the [helm/charts readme](https://github.com/helm/charts#how-do-i-enable-the-stable-repository-for-helm-3)):
 >
 > ```bash
-> $ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+> $ helm repo add stable https://charts.helm.sh/stable
 > ```
 
 ### Tags support:

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.0.0
 - name: elasticsearch
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.32.0
 digest: sha256:8463cdb928ac8f1714775c8f3d7d5239754c960a9c4e6419494a370ac6c7fae4
 generated: "2019-11-09T10:14:06.599699784+05:30"

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled
 - name: elasticsearch
   version: 1.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: elasticsearch.enabled

--- a/stable/mattermost-team-edition/requirements.lock
+++ b/stable/mattermost-team-edition/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 0.10.1
 digest: sha256:be368592f2a1722d1b90e6881e2d381b47d674d1f76c50ed85b27cfb00dcda35
 generated: 2018-09-14T14:08:32.750548865+02:00

--- a/stable/mattermost-team-edition/requirements.yaml
+++ b/stable/mattermost-team-edition/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mysql
   version: 0.10.1
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   condition: mysql.enabled

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.10
 digest: sha256:d45d6c79af1488743975c530c9bacc4321ef538392cc1603d08214a02e3cac49
 generated: "2020-02-26T08:44:21.18566319Z"

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled
   tags:
     - mediawiki-database

--- a/stable/mission-control/requirements.lock
+++ b/stable/mission-control/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.0.5
 digest: sha256:600cf841b87376e59e6cac1b4c1bc667edeadfc6392b2e07404c173f756433ed
 generated: 2018-05-11T08:39:14.984480455-07:00

--- a/stable/mission-control/requirements.yaml
+++ b/stable/mission-control/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mongodb
   version: 2.0.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mongodb.enabled

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -30,7 +30,7 @@ using Kubernetes StatefulSets and Init Containers.
 To install the chart with the release name `my-release`:
 
 ``` console
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable/
 helm install --name my-release stable/mongodb-replicaset
 ```
 

--- a/stable/moodle/requirements.lock
+++ b/stable/moodle/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-09T09:25:49.089146511Z"

--- a/stable/moodle/requirements.yaml
+++ b/stable/moodle/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.1.0
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 10.0.1
 digest: sha256:88489b3a1a5bf1cd3f9e264e540f8c3515d40020bb1073f3bb281f0da56efc3f
 generated: "2019-11-28T12:08:10.111637339+01:00"

--- a/stable/nextcloud/requirements.yaml
+++ b/stable/nextcloud/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   version: ~7.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled
 - name: redis
   version: ~10.0.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: redis.enabled

--- a/stable/odoo/requirements.lock
+++ b/stable/odoo/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 8.4.3
 digest: sha256:ab0947bfeb757eaf0dc8fdf51a5a4aeb6f6ca33d55e3a5a91b00cfefd65288e2
 generated: "2020-02-27T09:48:19.36236282Z"

--- a/stable/odoo/requirements.yaml
+++ b/stable/odoo/requirements.yaml
@@ -2,4 +2,4 @@ dependencies:
 - name: postgresql
   condition: postgresql.enabled
   version: 8.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/

--- a/stable/opencart/requirements.lock
+++ b/stable/opencart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.10
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-02-24T07:37:00.741649992Z"

--- a/stable/opencart/requirements.yaml
+++ b/stable/opencart/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.11
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-02-27T09:48:03.36495208Z"

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/osclass/requirements.lock
+++ b/stable/osclass/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-03T08:47:23.668877226Z"

--- a/stable/osclass/requirements.yaml
+++ b/stable/osclass/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-06T11:15:41.326428104Z"

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.8.5
 digest: sha256:380fe3c8514cc2d19b28e5b1a79d83961fa9f9d7f438eba85425dbf8c0b89bbd
 generated: "2020-02-26T08:44:44.63381915Z"

--- a/stable/parse/requirements.yaml
+++ b/stable/parse/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: mongodb
     version: 7.x.x
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/

--- a/stable/phabricator/requirements.lock
+++ b/stable/phabricator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:22662ca4b6b22e2476dbffb98118b0369277a68918a0129d17bf34bd66100653
 generated: "2020-03-06T06:57:16.758673252Z"

--- a/stable/phabricator/requirements.yaml
+++ b/stable/phabricator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/

--- a/stable/phpbb/requirements.lock
+++ b/stable/phpbb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.10
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-02-26T08:44:52.469482899Z"

--- a/stable/phpbb/requirements.yaml
+++ b/stable/phpbb/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/phpmyadmin/requirements.lock
+++ b/stable/phpmyadmin/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 6.13.0
 digest: sha256:a5bab50185c0373da803c6b86abc0e27ed0be1053fe1b560bc8de5a8054e8101
 generated: "2020-02-26T08:45:00.251739043Z"

--- a/stable/phpmyadmin/requirements.yaml
+++ b/stable/phpmyadmin/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   version: 6.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: db.bundleTestDB
   tags:
     - phpmyadmin-database

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-06T06:57:24.619790349Z"

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.8.10
 - name: prometheus-node-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.10.0
 - name: grafana
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 5.3.0
 digest: sha256:4cafebfa80daacbd651defea2a7cad3074e8022114d27d76a3baa1861998981b
 generated: "2020-06-22T12:36:10.4861206Z"

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -2,15 +2,15 @@ dependencies:
 
   - name: kube-state-metrics
     version: "2.8.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
     version: "1.10.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: nodeExporter.enabled
 
   - name: grafana
     version: "5.3.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: grafana.enabled

--- a/stable/prometheus/requirements.yaml
+++ b/stable/prometheus/requirements.yaml
@@ -2,6 +2,6 @@ dependencies:
 
   - name: kube-state-metrics
     version: "2.8.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: kubeStateMetrics.enabled
 

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.10
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 8.4.0
 digest: sha256:35e88b466a4a45bf4e8c4a69a2738788dbc73168a37218e524c7fe3a18650e9e
 generated: "2020-02-24T07:39:39.541140606Z"

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: mariadb
     version: 7.x.x
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: mariadb.enabled
   - name: postgresql
     version: 8.x.x
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: postgresql.enabled

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -110,7 +110,7 @@ You can deploy Reloader by following methods:
 if you have configured helm on your cluster, you can add reloader to helm from public chart repository and deploy it via helm using below mentioned commands
 
  ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable/
 
 helm repo update
 

--- a/stable/sonarqube/requirements.lock
+++ b/stable/sonarqube/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 8.2.0
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.6.0
 digest: sha256:e7f6d50c8a679e5b674212d8ef83781aa29df89d0490670f9f222b3f71e85b30
 generated: "2020-01-29T11:02:00.270992632+01:00"

--- a/stable/sonarqube/requirements.yaml
+++ b/stable/sonarqube/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: postgresql
     version: 8.2.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: postgresql.enabled
   - name: mysql
     version: 0.6.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: mysql.enabled

--- a/stable/spark-history-server/README.md
+++ b/stable/spark-history-server/README.md
@@ -106,7 +106,7 @@ Similarly for HDFS, you can run Spark jobs in any namespace, as long as pods in 
 To install the chart with the sample PVC setup:
 
 ```bash
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm repo add stable https://charts.helm.sh/stable
 $ helm install stable/spark-history-server --namespace spark-history-server
 ```
 

--- a/stable/spring-cloud-data-flow/requirements.lock
+++ b/stable/spring-cloud-data-flow/requirements.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.6.2
 - name: rabbitmq
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 6.16.6
 - name: rabbitmq-ha
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.38.2
 - name: kafka
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  repository: https://charts.helm.sh/incubator/
   version: 0.20.8
 - name: prometheus
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 10.4.0
 - name: grafana
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 4.5.0
 digest: sha256:02cce6791cbddab650f8165cb4865133b497bde53b9103f1c714129efc1e2671
 generated: "2020-01-31T14:36:49.309488742-05:00"

--- a/stable/spring-cloud-data-flow/requirements.yaml
+++ b/stable/spring-cloud-data-flow/requirements.yaml
@@ -1,25 +1,25 @@
 dependencies:
 - name:  mysql
   version: 1.6.2
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mysql.enabled
 - name:  rabbitmq
   version: 6.16.6
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: rabbitmq.enabled
 - name:  rabbitmq-ha
   version: 1.38.2
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: rabbitmq-ha.enabled
 - name:  kafka
   version: 0.20.8
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  repository: https://charts.helm.sh/incubator/
   condition: kafka.enabled
 - name: prometheus
   version: 10.4.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: features.monitoring.enabled
 - name: grafana
   version: 4.5.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: features.monitoring.enabled

--- a/stable/suitecrm/requirements.lock
+++ b/stable/suitecrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-06T06:57:32.8116815Z"

--- a/stable/suitecrm/requirements.yaml
+++ b/stable/suitecrm/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
 generated: "2020-03-03T08:47:31.649870144Z"

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mariadb.enabled

--- a/stable/vsphere-cpi/README.md
+++ b/stable/vsphere-cpi/README.md
@@ -25,7 +25,7 @@ This chart deploys all components required to run the external vSphere CPI as de
 In Helm 3.0+, the stable charts repo isn't enabled by default because there is an effort to move the charts repo into a [distributed model](https://github.com/helm/hub/blob/master/Repositories.md). To enable the [stable charts](https://github.com/helm/charts/tree/master/stable), you can run the following command:
 
 ```bash
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+$ helm repo add stable https://charts.helm.sh/stable/
 $ helm repo update
 ```
 

--- a/stable/wavefront/requirements.lock
+++ b/stable/wavefront/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.3.1
 digest: sha256:6a42b6ed0c45affe9a5f5c88db2fa3223ea2cf1648bf59861308aac709471169
 generated: 2019-08-25T19:41:26.435664-04:00

--- a/stable/wavefront/requirements.yaml
+++ b/stable/wavefront/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
     version: ^2.2.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: kubeStateMetrics.enabled

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 7.3.12
 digest: sha256:0a5be71f27bb4258b63df284f5006ab452666b4c3125a1c15b8753e71ec8c118
 generated: "2020-02-28T13:36:51.88416+01:00"

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: mariadb
     version: 7.x.x
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: mariadb.enabled
     tags:
       - wordpress-database

--- a/stable/xray/requirements.lock
+++ b/stable/xray/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 0.8.7
 - name: rabbitmq-ha
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 1.5.2
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 2.0.5
 digest: sha256:0893dc655e9e80daccdacc2650305aed5a2522cbf7216325f241a0ec3dd62cda
 generated: 2018-05-29T09:44:00.736196764-07:00

--- a/stable/xray/requirements.yaml
+++ b/stable/xray/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   version: 0.8.7
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: postgresql.enabled
 - name: rabbitmq-ha
   version: 1.5.2
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
 - name: mongodb
   version: 2.0.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   condition: mongodb.enabled


### PR DESCRIPTION
The helm build job will not package and make these chart versions
available with the legacy repo locations. Updating in place so
that these chart versions can be made available.