### PR TITLE
Adding legacy repos to sync

### DIFF
--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -47,6 +47,10 @@ setup_helm_client() {
 
     helm init --client-only
     helm repo add incubator "$INCUBATOR_REPO_URL"
+
+    # Add legacy locations for build
+    helm repo add stable-legacy https://kubernetes-charts.storage.googleapis.com
+    helm repo add incubator-legacy https://kubernetes-charts-incubator.storage.googleapis.com
 }
 
 authenticate() {


### PR DESCRIPTION
When these repos are found in requirements.lock files they will work again.