### PR TITLE
Adding artifact hub ownership files

### DIFF
--- a/incubator/artifacthub-repo.yml
+++ b/incubator/artifacthub-repo.yml
@@ -1,0 +1,3 @@
+owners:
+  - name: helm
+    email: helm-admin@lists.cncf.io

--- a/stable/artifacthub-repo.yml
+++ b/stable/artifacthub-repo.yml
@@ -1,0 +1,3 @@
+owners:
+  - name: helm
+    email: helm-admin@lists.cncf.io


### PR DESCRIPTION
Others have added the stable and incubator repos to the artifact
hub and continue to have the charts listed. These files will
enable the helm project to claim and maintain ownership

