### PR TITLE
[stable/nfs-client-provisioner] Update location of the maintained chart

### DIFF
--- a/stable/nfs-client-provisioner/README.md
+++ b/stable/nfs-client-provisioner/README.md
@@ -3,6 +3,8 @@
 As of Nov 13, 2020, charts in this repo will no longer be updated.
 For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
 
+This chart continues to be maintained at https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/tree/master/charts/nfs-subdir-external-provisioner.
+
 # nfs-client-provisioner
 
 The [NFS client provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client) is an automatic provisioner for Kubernetes that uses your *already configured* NFS server, automatically creating Persistent Volumes.


### PR DESCRIPTION
#### What this PR does / why we need it:
The `stable/nfs-client-provisioner` chart is now being maintained in new repository. This PR will add note in the deprecated chart README with link to the [new chart location](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/tree/master/charts/nfs-subdir-external-provisioner).

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
