### PR TITLE
[incubator/kafka] bump kafka-latest zookeeper dependency to a non-broken version

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: DEPRECATED Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.21.5
+version: 0.21.6
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.helm.sh/incubator
-  version: 2.1.0
-digest: sha256:12f8b256da1b973235586eeacf9d9d0a19d364bf106a054b5700c384e9871e40
-generated: "2020-10-30T00:42:54.380194-04:00"
+  version: 2.1.2
+digest: sha256:d4edd7bfcbdaa53ac64e156bf1ed0a2c0b59f5954f7bb618601622db0bb3c23d
+generated: "2021-01-18T23:13:21.186147-07:00"

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: zookeeper
-  version: 2.1.0
+  version: 2.1.2
   repository: https://charts.helm.sh/incubator
   condition: kafka.zookeeper.enabled,zookeeper.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
There was a fix for [zookeeper 2.1.0](https://github.com/helm/charts/pull/19556), but that fix was not propagated as the required version of the zookeeper chart dependency within `incubator/kafka/dependencies.yaml`; in other words, the latest version of `incubator/kafka` is in a broken state for anyone enabling zookeeper alongside their kafka instance (`zookeeper.enabled: true`)

#### Which issue this PR fixes
Fixes #19555 for those of us deploying zookeeper as a dependency of `incubator/kafka`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
