### PR TITLE
[stable/airflow] Add redis properties configuration for external redis

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 deprecated: true
 description: "DEPRECATED - please use: https://github.com/airflow-helm/charts/tree/main/charts/airflow"
 name: airflow
-version: 7.13.3
+version: 7.14.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -58,7 +58,7 @@ kubectl exec \
 ## Upgrade Steps
 
 Chart version numbers: [Chart.yaml](Chart.yaml) or [Artifact Hub](https://artifacthub.io/packages/helm/helm-stable/airflow)
-
+- [v7.13.X → v7.14.0](UPGRADE.md#v713x--v7140)
 - [v7.12.X → v7.13.0](UPGRADE.md#v712x--v7130)
 - [v7.11.X → v7.12.0](UPGRADE.md#v711x--v7120)
 - [v7.10.X → v7.11.0](UPGRADE.md#v710x--v7110)
@@ -854,7 +854,7 @@ __Airflow Redis (External) Values:__
 | `externalRedis.databaseNumber` | the database number to use within the the external redis | `1` |
 | `externalRedis.passwordSecret` | the name of a pre-created secret containing the external redis password | `""` |
 | `externalRedis.passwordSecretKey` | the key within `externalRedis.passwordSecret` containing the password string | `redis-password` |
-
+| `externalDatabase.properties` | the connection properties eg ?ssl_cert_reqs=CERT_OPTIONAL | `""` |
 __Airflow Prometheus Values:__
 
 | Parameter | Description | Default |

--- a/stable/airflow/UPGRADE.md
+++ b/stable/airflow/UPGRADE.md
@@ -6,6 +6,15 @@
 ---
 
 # Upgrading Steps
+## `v7.13.X` → `v7.14.0`
+
+__The following IMPROVEMENTS have been made:__
+
+* Added an ability to setup external redis connection propertites with the value `externalRedis.properties` for TLS or other advanced parameters
+
+__The following values have been ADDED:__
+
+* `externalRedis.properties`
 
 ## `v7.12.X` → `v7.13.0`
 

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -106,7 +106,7 @@ NOTE:
  - the `REDIS_PASSWORD_CMD` sub-command is set in `configmap-env`
 */}}
 {{- define "REDIS_CONNECTION_CMD" -}}
-echo -n "redis://$(eval $REDIS_PASSWORD_CMD)${REDIS_HOST}:${REDIS_PORT}/${REDIS_DBNUM}"
+echo -n "redis://$(eval $REDIS_PASSWORD_CMD)${REDIS_HOST}:${REDIS_PORT}/${REDIS_DBNUM}${REDIS_PROPERTIES}"
 {{- end -}}
 
 {{/*

--- a/stable/airflow/templates/config/configmap-env.yaml
+++ b/stable/airflow/templates/config/configmap-env.yaml
@@ -58,6 +58,7 @@ data:
   REDIS_CONNECTION_CMD: |-
     {{ include "REDIS_CONNECTION_CMD" . }}
   {{- end }}
+  REDIS_PROPERTIES: "{{.Values.externalRedis.properties}}"
 
   ## ----------------
   ## Airflow

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1528,7 +1528,8 @@ externalRedis:
   ## the key within `externalRedis.passwordSecret` containing the password string
   ##
   passwordSecretKey: "redis-password"
-
+  ## the connection properties for external reids. for eg ?ssl_cert_reqs=CERT_OPTIONAL
+  properties: ""
 ###################################
 # Prometheus - ServiceMonitor
 ###################################


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Add "properties" field for REDIS_CONNECTION_CMD which is generated in _helpers.tpl to support redis connection properties such as TLS/SSL


#### Which issue this PR fixes
  - fixes #22854

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
