### PR TITLE
[stable/traefik] fix: support ACME preferredChain option

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.87.7
-appVersion: 1.7.26
+version: 1.87.8
+appVersion: 1.7.33
 description: DEPRECATED - A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -162,6 +162,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `acme.onHostRule`                      | Whether to generate a certificate for each frontend with Host rule                                                           | `true`                                            |
 | `acme.staging`                         | Whether to get certs from Let's Encrypt's staging environment                                                                | `true`                                            |
 | `acme.caServer`                        | (Advanced) Specify a custom ACME server endpoint. Overrides `acme.staging` behavior if specified.    | `nil` |
+| `acme.preferredChain`                  | Specify the preferred chain to use.                                                                                          | ""                                                |
 | `acme.logging`                         | Display debug log messages from the ACME client library                                                                      | `false`                                           |
 | `acme.domains.enabled`                 | Enable certificate creation by default for specific domain                                                                   | `false`                                           |
 | `acme.domains.domainsList`             | List of domains & (optional) subject names                                                                                   | `[]`                                              |

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -314,6 +314,9 @@ data:
     caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
       {{- end }}
     {{- end -}}
+    {{- if .Values.acme.preferredChain }}
+    preferredChain = {{ .Values.acme.preferredChain | quote }}
+    {{- end }}
     {{- if .Values.acme.logging }}
     acmeLogging = true
     {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -227,6 +227,9 @@ acme:
   ## Specify a custom ACME server endpoint
   ## Optional
   # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
+  ## Specify the preferred chain to use.
+  ## Optional
+  # preferredChain: "ISRG Root X1"
   logging: false
   # Configure a Let's Encrypt certificate to be managed by default.
   # This is the only way to request wildcard certificates (works only with dns challenge).


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR adds the `preferredChain` option to fix the broken ACME TLS certificate generation as there is an expired root certificate in a part of the chain.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
