### PR TITLE
[stable/mssql-linux]: Fix secret changes on upgrade

### DIFF
--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: DEPRECATED - SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.11.4
+version: 0.11.5
 appVersion: 14.0.3023.8
 home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx

--- a/stable/mssql-linux/templates/secret.yaml
+++ b/stable/mssql-linux/templates/secret.yaml
@@ -1,4 +1,9 @@
 {{- if not .Values.existingSecret -}}
+{{- $password := .Values.sapassword | default (randAlphaNum 20) | b64enc }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "mssql.fullname" . ))) }}
+{{- if $secret }}
+{{- $password = index $secret.data "sapassword" }}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,9 +15,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  {{ if .Values.sapassword }}
-  sapassword:  {{ .Values.sapassword | b64enc | quote }}
-  {{ else }}
-  sapassword: {{ randAlphaNum 20 | b64enc | quote }}
-  {{ end }}
+  sapassword:  {{ $password }}
 {{- end -}}


### PR DESCRIPTION
#### Which issue this PR fixes
If `.Values.sapassword` is empty, helm upgrade action cause to change `sapassword` value in Secret
 
#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
