### PR TITLE
Moving prydonius to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 approvers:
   - lachie83
-  - prydonius
   - sameersbn
   - unguiculus
   - scottrigby
@@ -14,6 +13,7 @@ emeritus:
   - foxish
   - linki
   - mgoodness
+  - prydonius
   - seanknox
   - viglesiasce
   


### PR DESCRIPTION
Thanks, @prydonius! Moving you to emeritus per @technosophos.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
